### PR TITLE
Add configuration file support (Task 3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +125,16 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bytes"
@@ -242,6 +261,7 @@ name = "faultline-core"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "globset",
  "serde",
  "serde_json",
  "swc_common",
@@ -287,6 +307,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -464,6 +497,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +675,23 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc-hash"

--- a/faultline-core/Cargo.toml
+++ b/faultline-core/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
+globset = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 swc_common = "18.0.1"

--- a/faultline-core/src/analysis.rs
+++ b/faultline-core/src/analysis.rs
@@ -17,39 +17,56 @@ pub fn analyze_file(
     file_index: usize,
     options: &crate::AnalysisOptions,
 ) -> Result<Vec<report::FunctionRiskReport>> {
+    analyze_file_with_config(path, source_map, file_index, options, None, None)
+}
+
+/// Analyze a file with optional custom weights and thresholds
+pub fn analyze_file_with_config(
+    path: &Path,
+    source_map: &Lrc<SourceMap>,
+    file_index: usize,
+    options: &crate::AnalysisOptions,
+    weights: Option<&risk::LrsWeights>,
+    thresholds: Option<&risk::RiskThresholds>,
+) -> Result<Vec<report::FunctionRiskReport>> {
+    let default_weights = risk::LrsWeights::default();
+    let default_thresholds = risk::RiskThresholds::default();
+    let w = weights.unwrap_or(&default_weights);
+    let t = thresholds.unwrap_or(&default_thresholds);
+
     // Read file
     let src = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read file: {}", path.display()))?;
 
     // Parse source file (TypeScript or JavaScript)
     let module = parser::parse_source(&src, source_map, &path.to_string_lossy())?;
-    
+
     // Discover functions
     let functions = discover::discover_functions(&module, file_index);
-    
+
     // Analyze each function
     let mut reports = Vec::new();
     for function in &functions {
         // Build CFG
         let cfg = builder::build_cfg(function);
-        
+
         // Validate CFG
         cfg.validate()
             .map_err(|e| anyhow::anyhow!("Invalid CFG constructed: {}", e))?;
-        
+
         // Extract metrics
         let raw_metrics = metrics::extract_metrics(function, &cfg);
-        
-        // Calculate risk
-        let (risk_components, lrs, band) = risk::analyze_risk(&raw_metrics);
-        
+
+        // Calculate risk with configured weights/thresholds
+        let (risk_components, lrs, band) = risk::analyze_risk_with_config(&raw_metrics, w, t);
+
         // Apply filters
         if let Some(min_lrs) = options.min_lrs {
             if lrs < min_lrs {
                 continue;
             }
         }
-        
+
         // Create report
         let report = report::FunctionRiskReport::new(
             function,
@@ -60,9 +77,9 @@ pub fn analyze_file(
             band,
             source_map,
         );
-        
+
         reports.push(report);
     }
-    
+
     Ok(reports)
 }

--- a/faultline-core/src/config.rs
+++ b/faultline-core/src/config.rs
@@ -1,0 +1,617 @@
+//! Configuration file support for Faultline
+//!
+//! Loads project-specific configuration from JSON files.
+//!
+//! Search order:
+//! 1. Explicit path (--config CLI flag)
+//! 2. `.faultlinerc.json` in project root
+//! 3. `faultline.config.json` in project root
+//! 4. `"faultline"` key in `package.json`
+//!
+//! All fields are optional. CLI flags take precedence over config file values.
+
+use anyhow::{Context, Result};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Default exclude patterns applied when no config is specified
+const DEFAULT_EXCLUDES: &[&str] = &[
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/node_modules/**",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/dist/**",
+    "**/build/**",
+];
+
+/// Faultline configuration loaded from a JSON config file
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FaultlineConfig {
+    /// Glob patterns for files to include (default: all supported extensions)
+    #[serde(default)]
+    pub include: Vec<String>,
+
+    /// Glob patterns for files to exclude (default: test files, node_modules, dist)
+    #[serde(default)]
+    pub exclude: Vec<String>,
+
+    /// Custom risk band thresholds
+    #[serde(default)]
+    pub thresholds: Option<ThresholdConfig>,
+
+    /// Custom metric weights for LRS calculation
+    #[serde(default)]
+    pub weights: Option<WeightConfig>,
+
+    /// Minimum LRS to report (default: 0.0, report all)
+    #[serde(default)]
+    pub min_lrs: Option<f64>,
+
+    /// Maximum number of results to show
+    #[serde(default)]
+    pub top: Option<usize>,
+}
+
+/// Custom risk band thresholds
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ThresholdConfig {
+    /// LRS threshold for moderate risk (default: 3.0)
+    pub moderate: Option<f64>,
+    /// LRS threshold for high risk (default: 6.0)
+    pub high: Option<f64>,
+    /// LRS threshold for critical risk (default: 9.0)
+    pub critical: Option<f64>,
+}
+
+/// Custom metric weights for LRS calculation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WeightConfig {
+    /// Weight for cyclomatic complexity (default: 1.0)
+    pub cc: Option<f64>,
+    /// Weight for nesting depth (default: 0.8)
+    pub nd: Option<f64>,
+    /// Weight for fan-out (default: 0.6)
+    pub fo: Option<f64>,
+    /// Weight for non-structured exits (default: 0.7)
+    pub ns: Option<f64>,
+}
+
+impl Default for FaultlineConfig {
+    fn default() -> Self {
+        FaultlineConfig {
+            include: Vec::new(),
+            exclude: Vec::new(),
+            thresholds: None,
+            weights: None,
+            min_lrs: None,
+            top: None,
+        }
+    }
+}
+
+/// Resolved configuration with compiled glob patterns
+#[derive(Debug)]
+pub struct ResolvedConfig {
+    /// Compiled include patterns (empty means include all)
+    pub include: Option<GlobSet>,
+    /// Compiled exclude patterns
+    pub exclude: GlobSet,
+    /// Risk band thresholds
+    pub moderate_threshold: f64,
+    pub high_threshold: f64,
+    pub critical_threshold: f64,
+    /// LRS weights
+    pub weight_cc: f64,
+    pub weight_nd: f64,
+    pub weight_fo: f64,
+    pub weight_ns: f64,
+    /// Filters
+    pub min_lrs: Option<f64>,
+    pub top_n: Option<usize>,
+    /// Path the config was loaded from (None if defaults)
+    pub config_path: Option<PathBuf>,
+}
+
+impl FaultlineConfig {
+    /// Validate the configuration for logical errors
+    pub fn validate(&self) -> Result<()> {
+        // Validate thresholds are positive and ordered
+        if let Some(ref t) = self.thresholds {
+            let moderate = t.moderate.unwrap_or(3.0);
+            let high = t.high.unwrap_or(6.0);
+            let critical = t.critical.unwrap_or(9.0);
+
+            if moderate <= 0.0 {
+                anyhow::bail!("thresholds.moderate must be positive (got {})", moderate);
+            }
+            if high <= 0.0 {
+                anyhow::bail!("thresholds.high must be positive (got {})", high);
+            }
+            if critical <= 0.0 {
+                anyhow::bail!("thresholds.critical must be positive (got {})", critical);
+            }
+            if moderate >= high {
+                anyhow::bail!(
+                    "thresholds.moderate ({}) must be less than thresholds.high ({})",
+                    moderate,
+                    high
+                );
+            }
+            if high >= critical {
+                anyhow::bail!(
+                    "thresholds.high ({}) must be less than thresholds.critical ({})",
+                    high,
+                    critical
+                );
+            }
+        }
+
+        // Validate weights are non-negative
+        if let Some(ref w) = self.weights {
+            for (name, val) in [
+                ("cc", w.cc),
+                ("nd", w.nd),
+                ("fo", w.fo),
+                ("ns", w.ns),
+            ] {
+                if let Some(v) = val {
+                    if v < 0.0 {
+                        anyhow::bail!("weights.{} must be non-negative (got {})", name, v);
+                    }
+                    if v > 10.0 {
+                        anyhow::bail!("weights.{} must be at most 10.0 (got {})", name, v);
+                    }
+                }
+            }
+        }
+
+        // Validate min_lrs is non-negative
+        if let Some(min) = self.min_lrs {
+            if min < 0.0 {
+                anyhow::bail!("min_lrs must be non-negative (got {})", min);
+            }
+        }
+
+        // Validate glob patterns compile
+        for pattern in &self.include {
+            Glob::new(pattern)
+                .with_context(|| format!("invalid include pattern: {}", pattern))?;
+        }
+        for pattern in &self.exclude {
+            Glob::new(pattern)
+                .with_context(|| format!("invalid exclude pattern: {}", pattern))?;
+        }
+
+        Ok(())
+    }
+
+    /// Resolve config into compiled form ready for use
+    pub fn resolve(&self) -> Result<ResolvedConfig> {
+        self.validate()?;
+
+        // Compile include patterns
+        let include = if self.include.is_empty() {
+            None
+        } else {
+            let mut builder = GlobSetBuilder::new();
+            for pattern in &self.include {
+                builder.add(Glob::new(pattern)?);
+            }
+            Some(builder.build()?)
+        };
+
+        // Compile exclude patterns (merge with defaults if user didn't specify any)
+        let exclude = {
+            let mut builder = GlobSetBuilder::new();
+            if self.exclude.is_empty() {
+                // Use defaults when no excludes specified
+                for pattern in DEFAULT_EXCLUDES {
+                    builder.add(Glob::new(pattern)?);
+                }
+            } else {
+                for pattern in &self.exclude {
+                    builder.add(Glob::new(pattern)?);
+                }
+            }
+            builder.build()?
+        };
+
+        let (moderate, high, critical) = match &self.thresholds {
+            Some(t) => (
+                t.moderate.unwrap_or(3.0),
+                t.high.unwrap_or(6.0),
+                t.critical.unwrap_or(9.0),
+            ),
+            None => (3.0, 6.0, 9.0),
+        };
+
+        let (w_cc, w_nd, w_fo, w_ns) = match &self.weights {
+            Some(w) => (
+                w.cc.unwrap_or(1.0),
+                w.nd.unwrap_or(0.8),
+                w.fo.unwrap_or(0.6),
+                w.ns.unwrap_or(0.7),
+            ),
+            None => (1.0, 0.8, 0.6, 0.7),
+        };
+
+        Ok(ResolvedConfig {
+            include,
+            exclude,
+            moderate_threshold: moderate,
+            high_threshold: high,
+            critical_threshold: critical,
+            weight_cc: w_cc,
+            weight_nd: w_nd,
+            weight_fo: w_fo,
+            weight_ns: w_ns,
+            min_lrs: self.min_lrs,
+            top_n: self.top,
+            config_path: None,
+        })
+    }
+}
+
+impl ResolvedConfig {
+    /// Check if a file path should be included based on include/exclude patterns
+    pub fn should_include(&self, path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+
+        // Check exclude first
+        if self.exclude.is_match(path_str.as_ref()) {
+            return false;
+        }
+
+        // If include patterns exist, file must match at least one
+        if let Some(ref include) = self.include {
+            return include.is_match(path_str.as_ref());
+        }
+
+        true
+    }
+
+    /// Build a ResolvedConfig with all defaults (no config file)
+    pub fn defaults() -> Result<Self> {
+        FaultlineConfig::default().resolve()
+    }
+}
+
+/// Discover and load a config file from the project root
+///
+/// Search order:
+/// 1. `.faultlinerc.json`
+/// 2. `faultline.config.json`
+/// 3. `"faultline"` key in `package.json`
+///
+/// Returns `None` if no config file is found (use defaults).
+pub fn discover_config(project_root: &Path) -> Result<Option<(FaultlineConfig, PathBuf)>> {
+    // 1. .faultlinerc.json
+    let rc_path = project_root.join(".faultlinerc.json");
+    if rc_path.exists() {
+        let config = load_config_file(&rc_path)?;
+        return Ok(Some((config, rc_path)));
+    }
+
+    // 2. faultline.config.json
+    let config_path = project_root.join("faultline.config.json");
+    if config_path.exists() {
+        let config = load_config_file(&config_path)?;
+        return Ok(Some((config, config_path)));
+    }
+
+    // 3. package.json "faultline" key
+    let pkg_path = project_root.join("package.json");
+    if pkg_path.exists() {
+        if let Some(config) = load_from_package_json(&pkg_path)? {
+            return Ok(Some((config, pkg_path)));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Load config from an explicit file path
+pub fn load_config_file(path: &Path) -> Result<FaultlineConfig> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read config file: {}", path.display()))?;
+
+    let config: FaultlineConfig = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse config file: {}", path.display()))?;
+
+    config.validate()
+        .with_context(|| format!("invalid config in: {}", path.display()))?;
+
+    Ok(config)
+}
+
+/// Load faultline config from the "faultline" key in package.json
+fn load_from_package_json(path: &Path) -> Result<Option<FaultlineConfig>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    let pkg: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    match pkg.get("faultline") {
+        Some(faultline_value) => {
+            let config: FaultlineConfig = serde_json::from_value(faultline_value.clone())
+                .with_context(|| {
+                    format!("invalid faultline config in {}", path.display())
+                })?;
+            config.validate()
+                .with_context(|| format!("invalid faultline config in {}", path.display()))?;
+            Ok(Some(config))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Load and resolve config for a project
+///
+/// If `config_path` is provided, loads from that file.
+/// Otherwise, discovers config from the project root.
+/// Returns default config if nothing is found.
+pub fn load_and_resolve(project_root: &Path, config_path: Option<&Path>) -> Result<ResolvedConfig> {
+    let (config, source_path) = if let Some(path) = config_path {
+        let config = load_config_file(path)?;
+        (config, Some(path.to_path_buf()))
+    } else {
+        match discover_config(project_root)? {
+            Some((config, path)) => (config, Some(path)),
+            None => (FaultlineConfig::default(), None),
+        }
+    };
+
+    let mut resolved = config.resolve()?;
+    resolved.config_path = source_path;
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_default_config_is_valid() {
+        let config = FaultlineConfig::default();
+        config.validate().expect("default config should be valid");
+        let resolved = config.resolve().expect("default config should resolve");
+        assert!(resolved.include.is_none());
+        assert_eq!(resolved.weight_cc, 1.0);
+        assert_eq!(resolved.weight_nd, 0.8);
+        assert_eq!(resolved.weight_fo, 0.6);
+        assert_eq!(resolved.weight_ns, 0.7);
+        assert_eq!(resolved.moderate_threshold, 3.0);
+        assert_eq!(resolved.high_threshold, 6.0);
+        assert_eq!(resolved.critical_threshold, 9.0);
+    }
+
+    #[test]
+    fn test_parse_minimal_config() {
+        let json = r#"{}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let json = r#"{
+            "include": ["src/**/*.ts", "src/**/*.tsx"],
+            "exclude": ["**/*.test.ts", "**/node_modules/**"],
+            "thresholds": {
+                "moderate": 4.0,
+                "high": 7.0,
+                "critical": 10.0
+            },
+            "weights": {
+                "cc": 1.2,
+                "nd": 0.9,
+                "fo": 0.5,
+                "ns": 0.8
+            },
+            "min_lrs": 2.0,
+            "top": 20
+        }"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        config.validate().unwrap();
+        let resolved = config.resolve().unwrap();
+        assert!(resolved.include.is_some());
+        assert_eq!(resolved.moderate_threshold, 4.0);
+        assert_eq!(resolved.high_threshold, 7.0);
+        assert_eq!(resolved.critical_threshold, 10.0);
+        assert_eq!(resolved.weight_cc, 1.2);
+        assert_eq!(resolved.min_lrs, Some(2.0));
+        assert_eq!(resolved.top_n, Some(20));
+    }
+
+    #[test]
+    fn test_reject_unknown_fields() {
+        let json = r#"{"unknown_field": true}"#;
+        let result: Result<FaultlineConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "unknown fields should be rejected");
+    }
+
+    #[test]
+    fn test_reject_negative_weight() {
+        let json = r#"{"weights": {"cc": -1.0}}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_reject_weight_over_10() {
+        let json = r#"{"weights": {"cc": 11.0}}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_reject_negative_threshold() {
+        let json = r#"{"thresholds": {"moderate": -1.0}}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_reject_unordered_thresholds() {
+        let json = r#"{"thresholds": {"moderate": 6.0, "high": 3.0, "critical": 9.0}}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_reject_invalid_glob_pattern() {
+        let json = r#"{"include": ["[invalid"]}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_should_include_default_excludes() {
+        let resolved = ResolvedConfig::defaults().unwrap();
+        assert!(!resolved.should_include(Path::new("src/foo.test.ts")));
+        assert!(!resolved.should_include(Path::new("node_modules/pkg/index.js")));
+        assert!(!resolved.should_include(Path::new("dist/bundle.js")));
+        assert!(resolved.should_include(Path::new("src/api.ts")));
+        assert!(resolved.should_include(Path::new("src/components/Button.tsx")));
+    }
+
+    #[test]
+    fn test_should_include_custom_patterns() {
+        let config: FaultlineConfig = serde_json::from_str(r#"{
+            "include": ["src/**/*.ts"],
+            "exclude": ["src/generated/**"]
+        }"#).unwrap();
+        let resolved = config.resolve().unwrap();
+        assert!(resolved.should_include(Path::new("src/api.ts")));
+        assert!(!resolved.should_include(Path::new("lib/util.ts")));
+        assert!(!resolved.should_include(Path::new("src/generated/types.ts")));
+    }
+
+    #[test]
+    fn test_discover_faultlinerc() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(".faultlinerc.json");
+        fs::write(&config_path, r#"{"min_lrs": 5.0}"#).unwrap();
+
+        let result = discover_config(dir.path()).unwrap();
+        assert!(result.is_some());
+        let (config, path) = result.unwrap();
+        assert_eq!(config.min_lrs, Some(5.0));
+        assert_eq!(path, config_path);
+    }
+
+    #[test]
+    fn test_discover_faultline_config_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("faultline.config.json");
+        fs::write(&config_path, r#"{"top": 10}"#).unwrap();
+
+        let result = discover_config(dir.path()).unwrap();
+        assert!(result.is_some());
+        let (config, _) = result.unwrap();
+        assert_eq!(config.top, Some(10));
+    }
+
+    #[test]
+    fn test_discover_package_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg_path = dir.path().join("package.json");
+        fs::write(&pkg_path, r#"{
+            "name": "my-project",
+            "version": "1.0.0",
+            "faultline": {
+                "exclude": ["**/*.test.ts"],
+                "min_lrs": 3.0
+            }
+        }"#).unwrap();
+
+        let result = discover_config(dir.path()).unwrap();
+        assert!(result.is_some());
+        let (config, _) = result.unwrap();
+        assert_eq!(config.min_lrs, Some(3.0));
+        assert_eq!(config.exclude, vec!["**/*.test.ts"]);
+    }
+
+    #[test]
+    fn test_discover_package_json_without_faultline_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg_path = dir.path().join("package.json");
+        fs::write(&pkg_path, r#"{"name": "my-project", "version": "1.0.0"}"#).unwrap();
+
+        let result = discover_config(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_discover_priority_order() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Create both config files - .faultlinerc.json should win
+        fs::write(dir.path().join(".faultlinerc.json"), r#"{"min_lrs": 1.0}"#).unwrap();
+        fs::write(dir.path().join("faultline.config.json"), r#"{"min_lrs": 2.0}"#).unwrap();
+
+        let result = discover_config(dir.path()).unwrap();
+        let (config, _) = result.unwrap();
+        assert_eq!(config.min_lrs, Some(1.0), ".faultlinerc.json should take priority");
+    }
+
+    #[test]
+    fn test_no_config_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = discover_config(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_load_and_resolve_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = load_and_resolve(dir.path(), None).unwrap();
+        assert!(resolved.config_path.is_none());
+        assert_eq!(resolved.weight_cc, 1.0);
+    }
+
+    #[test]
+    fn test_load_and_resolve_explicit_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("custom.json");
+        fs::write(&config_path, r#"{"weights": {"cc": 2.0}}"#).unwrap();
+
+        let resolved = load_and_resolve(dir.path(), Some(&config_path)).unwrap();
+        assert_eq!(resolved.weight_cc, 2.0);
+        assert_eq!(resolved.config_path, Some(config_path));
+    }
+
+    #[test]
+    fn test_partial_weights_use_defaults_for_rest() {
+        let json = r#"{"weights": {"cc": 2.0}}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        let resolved = config.resolve().unwrap();
+        assert_eq!(resolved.weight_cc, 2.0);
+        assert_eq!(resolved.weight_nd, 0.8); // default
+        assert_eq!(resolved.weight_fo, 0.6); // default
+        assert_eq!(resolved.weight_ns, 0.7); // default
+    }
+
+    #[test]
+    fn test_partial_thresholds_use_defaults_for_rest() {
+        let json = r#"{"thresholds": {"critical": 12.0}}"#;
+        let config: FaultlineConfig = serde_json::from_str(json).unwrap();
+        let resolved = config.resolve().unwrap();
+        assert_eq!(resolved.moderate_threshold, 3.0); // default
+        assert_eq!(resolved.high_threshold, 6.0);     // default
+        assert_eq!(resolved.critical_threshold, 12.0);
+    }
+}

--- a/faultline-core/src/risk.rs
+++ b/faultline-core/src/risk.rs
@@ -51,31 +51,82 @@ pub fn calculate_risk_components(metrics: &RawMetrics) -> RiskComponents {
     }
 }
 
-/// Calculate Local Risk Score (LRS)
+/// Configurable weights for LRS calculation
+#[derive(Debug, Clone, Copy)]
+pub struct LrsWeights {
+    pub cc: f64,
+    pub nd: f64,
+    pub fo: f64,
+    pub ns: f64,
+}
+
+impl Default for LrsWeights {
+    fn default() -> Self {
+        LrsWeights { cc: 1.0, nd: 0.8, fo: 0.6, ns: 0.7 }
+    }
+}
+
+/// Configurable risk band thresholds
+#[derive(Debug, Clone, Copy)]
+pub struct RiskThresholds {
+    pub moderate: f64,
+    pub high: f64,
+    pub critical: f64,
+}
+
+impl Default for RiskThresholds {
+    fn default() -> Self {
+        RiskThresholds { moderate: 3.0, high: 6.0, critical: 9.0 }
+    }
+}
+
+/// Calculate Local Risk Score (LRS) with default weights
 ///
 /// Formula:
 /// LRS = 1.0 * R_cc + 0.8 * R_nd + 0.6 * R_fo + 0.7 * R_ns
 pub fn calculate_lrs(risk: &RiskComponents) -> f64 {
-    1.0 * risk.r_cc + 0.8 * risk.r_nd + 0.6 * risk.r_fo + 0.7 * risk.r_ns
+    calculate_lrs_with_weights(risk, &LrsWeights::default())
 }
 
-/// Assign risk band based on LRS
+/// Calculate LRS with custom weights
+pub fn calculate_lrs_with_weights(risk: &RiskComponents, weights: &LrsWeights) -> f64 {
+    weights.cc * risk.r_cc + weights.nd * risk.r_nd + weights.fo * risk.r_fo + weights.ns * risk.r_ns
+}
+
+/// Assign risk band based on LRS with default thresholds
 pub fn assign_risk_band(lrs: f64) -> RiskBand {
-    if lrs < 3.0 {
+    assign_risk_band_with_thresholds(lrs, &RiskThresholds::default())
+}
+
+/// Assign risk band with custom thresholds
+pub fn assign_risk_band_with_thresholds(lrs: f64, thresholds: &RiskThresholds) -> RiskBand {
+    if lrs < thresholds.moderate {
         RiskBand::Low
-    } else if lrs < 6.0 {
+    } else if lrs < thresholds.high {
         RiskBand::Moderate
-    } else if lrs < 9.0 {
+    } else if lrs < thresholds.critical {
         RiskBand::High
     } else {
         RiskBand::Critical
     }
 }
 
-/// Calculate complete risk analysis from raw metrics
+/// Calculate complete risk analysis from raw metrics (default weights/thresholds)
 pub fn analyze_risk(metrics: &RawMetrics) -> (RiskComponents, f64, RiskBand) {
     let risk = calculate_risk_components(metrics);
     let lrs = calculate_lrs(&risk);
     let band = assign_risk_band(lrs);
+    (risk, lrs, band)
+}
+
+/// Calculate complete risk analysis with custom weights and thresholds
+pub fn analyze_risk_with_config(
+    metrics: &RawMetrics,
+    weights: &LrsWeights,
+    thresholds: &RiskThresholds,
+) -> (RiskComponents, f64, RiskBand) {
+    let risk = calculate_risk_components(metrics);
+    let lrs = calculate_lrs_with_weights(&risk, weights);
+    let band = assign_risk_band_with_thresholds(lrs, thresholds);
     (risk, lrs, band)
 }


### PR DESCRIPTION
Implement project-specific configuration via JSON config files with discovery (.faultlinerc.json, faultline.config.json, package.json), validation, glob-based include/exclude patterns, custom risk weights and thresholds, and CLI integration (--config flag, config validate/show subcommands). CLI flags override config file values. 21 new unit tests.

https://claude.ai/code/session_01HBNH7aySUY6b4ERjyrY6eo