### PR TITLE
Add automated golden tests for Java and Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Run golden tests
+        run: cargo test --package hotspots-core --test golden_tests
+
+      - name: Build release binary
+        run: cargo build --release
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build hotspots
+        run: cargo build --release
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run comprehensive tests
+        run: python3 test_comprehensive.py
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-repo-comprehensive/
+          retention-days: 7

--- a/fix_golden_paths.py
+++ b/fix_golden_paths.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Convert absolute paths to relative paths in all golden test files"""
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent
+GOLDEN_DIR = PROJECT_ROOT / "tests" / "golden"
+
+def normalize_path_to_relative(path_str, project_root):
+    """Convert an absolute path to a relative path from project root"""
+    path = Path(path_str)
+
+    # If already relative, return as-is
+    if not path.is_absolute():
+        return path_str
+
+    # Try to make it relative to project root
+    try:
+        relative = path.relative_to(project_root)
+        # Use forward slashes for cross-platform compatibility
+        return str(relative).replace('\\', '/')
+    except ValueError:
+        # Path is not under project root - look for common patterns
+        # Find "tests/fixtures/" in the path and extract from there
+        path_str_normalized = str(path).replace('\\', '/')
+        if 'tests/fixtures/' in path_str_normalized:
+            idx = path_str_normalized.index('tests/fixtures/')
+            return path_str_normalized[idx:]
+
+        # If we can't convert it, return as-is (shouldn't happen for our golden files)
+        return path_str
+
+def normalize_paths_in_json(data, project_root):
+    """Recursively normalize paths in JSON structure"""
+    if isinstance(data, list):
+        for item in data:
+            normalize_paths_in_json(item, project_root)
+    elif isinstance(data, dict):
+        if "file" in data and isinstance(data["file"], str):
+            data["file"] = normalize_path_to_relative(data["file"], project_root)
+        for value in data.values():
+            normalize_paths_in_json(value, project_root)
+
+def fix_golden_file(golden_path):
+    """Update a golden file to use relative paths"""
+    print(f"  Fixing {golden_path.name}...")
+
+    # Read the JSON
+    with open(golden_path, 'r') as f:
+        data = json.load(f)
+
+    # Normalize all paths to relative
+    normalize_paths_in_json(data, PROJECT_ROOT)
+
+    # Write back with pretty formatting
+    with open(golden_path, 'w') as f:
+        json.dump(data, f, indent=2)
+        f.write('\n')  # Add trailing newline
+
+def main():
+    print("Converting golden test files to use relative paths...\n")
+
+    # Find all JSON files in the golden directory
+    golden_files = sorted(GOLDEN_DIR.glob("*.json"))
+
+    if not golden_files:
+        print("✗ No golden files found!", file=sys.stderr)
+        return 1
+
+    for golden_file in golden_files:
+        try:
+            fix_golden_file(golden_file)
+        except Exception as e:
+            print(f"✗ Error fixing {golden_file.name}: {e}", file=sys.stderr)
+            return 1
+
+    print(f"\n✓ Successfully fixed {len(golden_files)} golden files!")
+    print("\nAll paths are now relative to the project root.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hotspots-cli/build.rs
+++ b/hotspots-cli/build.rs
@@ -12,10 +12,8 @@ use std::process::Command;
 
 fn main() {
     // Get version from git describe, fallback to CARGO_PKG_VERSION
-    let version = get_git_version().unwrap_or_else(|| {
-        env!("CARGO_PKG_VERSION").to_string()
-    });
-    
+    let version = get_git_version().unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
     println!("cargo:rustc-env=FAULTLINE_VERSION={}", version);
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/heads");
@@ -29,11 +27,11 @@ fn get_git_version() -> Option<String> {
         .args(["describe", "--tags", "--always", "--dirty"])
         .output()
         .ok()?;
-    
+
     if output.status.success() {
         let version = String::from_utf8(output.stdout).ok()?;
         let version = version.trim();
-        
+
         // If it's a clean tag (starts with v and no suffix), use it directly
         if version.starts_with('v') && !version.contains('-') {
             // Clean tag like "v0.1.0"

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -181,11 +181,8 @@ fn main() -> anyhow::Result<()> {
             let resolved_config = config::load_and_resolve(&project_root, config_path.as_deref())
                 .context("failed to load configuration")?;
 
-            if resolved_config.config_path.is_some() {
-                eprintln!(
-                    "Using config: {}",
-                    resolved_config.config_path.as_ref().unwrap().display()
-                );
+            if let Some(config_path) = &resolved_config.config_path {
+                eprintln!("Using config: {}", config_path.display());
             }
 
             // CLI flags override config file values

--- a/hotspots-core/src/analysis.rs
+++ b/hotspots-core/src/analysis.rs
@@ -42,22 +42,20 @@ pub fn analyze_file_with_config(
 
     // Get appropriate parser for this language
     let parser: Box<dyn LanguageParser> = match language {
-        Language::TypeScript | Language::TypeScriptReact |
-        Language::JavaScript | Language::JavaScriptReact => {
+        Language::TypeScript
+        | Language::TypeScriptReact
+        | Language::JavaScript
+        | Language::JavaScriptReact => {
             Box::new(language::ECMAScriptParser::new(source_map.clone()))
         }
-        Language::Go => {
-            Box::new(language::GoParser::new().context("Failed to create Go parser")?)
-        }
+        Language::Go => Box::new(language::GoParser::new().context("Failed to create Go parser")?),
         Language::Java => {
             Box::new(language::JavaParser::new().context("Failed to create Java parser")?)
         }
         Language::Python => {
             Box::new(language::PythonParser::new().context("Failed to create Python parser")?)
         }
-        Language::Rust => {
-            Box::new(language::RustParser)
-        }
+        Language::Rust => Box::new(language::RustParser),
     };
 
     // Parse source file

--- a/hotspots-core/src/cfg/tests.rs
+++ b/hotspots-core/src/cfg/tests.rs
@@ -16,7 +16,10 @@ mod cfg_tests {
     fn test_empty_cfg_validation() {
         let cfg = Cfg::new();
         let result = cfg.validate();
-        assert!(result.is_ok(), "Empty CFG should validate (entry can reach exit via direct edge)");
+        assert!(
+            result.is_ok(),
+            "Empty CFG should validate (entry can reach exit via direct edge)"
+        );
     }
 
     #[test]
@@ -32,7 +35,7 @@ mod cfg_tests {
             .iter()
             .filter(|n| matches!(n.kind, NodeKind::Exit))
             .collect();
-        
+
         assert_eq!(entry_nodes.len(), 1, "Should have exactly one entry node");
         assert_eq!(exit_nodes.len(), 1, "Should have exactly one exit node");
         assert_eq!(cfg.entry, entry_nodes[0].id);
@@ -43,8 +46,12 @@ mod cfg_tests {
     fn test_cfg_add_node() {
         let mut cfg = Cfg::new();
         let node_id = cfg.add_node(NodeKind::Statement);
-        
-        assert_eq!(cfg.nodes.len(), 3, "Should have 3 nodes (entry, exit, statement)");
+
+        assert_eq!(
+            cfg.nodes.len(),
+            3,
+            "Should have 3 nodes (entry, exit, statement)"
+        );
         assert_eq!(node_id, NodeId(2), "Node ID should be 2");
         assert!(matches!(cfg.nodes[2].kind, NodeKind::Statement));
     }
@@ -55,7 +62,7 @@ mod cfg_tests {
         let node_id = cfg.add_node(NodeKind::Statement);
         cfg.add_edge(cfg.entry, node_id);
         cfg.add_edge(node_id, cfg.exit);
-        
+
         assert_eq!(cfg.edge_count(), 2, "Should have 2 edges");
         assert_eq!(cfg.edges[0].from, cfg.entry);
         assert_eq!(cfg.edges[0].to, node_id);
@@ -69,9 +76,12 @@ mod cfg_tests {
         let node_id = cfg.add_node(NodeKind::Statement);
         cfg.add_edge(cfg.entry, node_id);
         cfg.add_edge(node_id, cfg.exit);
-        
+
         let result = cfg.validate();
-        assert!(result.is_ok(), "CFG with path entry -> node -> exit should validate");
+        assert!(
+            result.is_ok(),
+            "CFG with path entry -> node -> exit should validate"
+        );
     }
 
     #[test]
@@ -80,19 +90,25 @@ mod cfg_tests {
         let _unreachable_id = cfg.add_node(NodeKind::Statement);
         // Don't add edge from entry to unreachable_id
         cfg.add_edge(cfg.entry, cfg.exit); // Entry can reach exit
-        
+
         let result = cfg.validate();
-        assert!(result.is_err(), "CFG with unreachable node should fail validation");
+        assert!(
+            result.is_err(),
+            "CFG with unreachable node should fail validation"
+        );
         let err_msg = result.unwrap_err();
-        assert!(err_msg.contains("not reachable") || err_msg.contains("unreachable"), 
-                "Error should mention unreachable nodes, got: {}", err_msg);
+        assert!(
+            err_msg.contains("not reachable") || err_msg.contains("unreachable"),
+            "Error should mention unreachable nodes, got: {}",
+            err_msg
+        );
     }
 
     #[test]
     fn test_cfg_validation_entry_to_exit_direct() {
         let mut cfg = Cfg::new();
         cfg.add_edge(cfg.entry, cfg.exit);
-        
+
         let result = cfg.validate();
         assert!(result.is_ok(), "CFG with entry -> exit should validate");
     }
@@ -105,7 +121,7 @@ mod cfg_tests {
         cfg.add_edge(cfg.entry, node1);
         cfg.add_edge(node1, node2);
         cfg.add_edge(node2, cfg.exit);
-        
+
         let reachable = cfg.reachable_from(cfg.entry);
         assert!(reachable.contains(&cfg.entry));
         assert!(reachable.contains(&node1));
@@ -121,7 +137,7 @@ mod cfg_tests {
         cfg.add_edge(cfg.entry, node1);
         cfg.add_edge(node1, node2);
         cfg.add_edge(node2, cfg.exit);
-        
+
         let can_reach_exit = cfg.reachable_to(cfg.exit);
         assert!(can_reach_exit.contains(&cfg.entry));
         assert!(can_reach_exit.contains(&node1));

--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -172,12 +172,7 @@ impl HotspotsConfig {
 
         // Validate weights are non-negative
         if let Some(ref w) = self.weights {
-            for (name, val) in [
-                ("cc", w.cc),
-                ("nd", w.nd),
-                ("fo", w.fo),
-                ("ns", w.ns),
-            ] {
+            for (name, val) in [("cc", w.cc), ("nd", w.nd), ("fo", w.fo), ("ns", w.ns)] {
                 if let Some(v) = val {
                     if v < 0.0 {
                         anyhow::bail!("weights.{} must be non-negative (got {})", name, v);
@@ -198,19 +193,34 @@ impl HotspotsConfig {
             let rapid_growth = wt.rapid_growth_percent.unwrap_or(50.0);
 
             if watch_min <= 0.0 {
-                anyhow::bail!("warning_thresholds.watch_min must be positive (got {})", watch_min);
+                anyhow::bail!(
+                    "warning_thresholds.watch_min must be positive (got {})",
+                    watch_min
+                );
             }
             if watch_max <= 0.0 {
-                anyhow::bail!("warning_thresholds.watch_max must be positive (got {})", watch_max);
+                anyhow::bail!(
+                    "warning_thresholds.watch_max must be positive (got {})",
+                    watch_max
+                );
             }
             if attention_min <= 0.0 {
-                anyhow::bail!("warning_thresholds.attention_min must be positive (got {})", attention_min);
+                anyhow::bail!(
+                    "warning_thresholds.attention_min must be positive (got {})",
+                    attention_min
+                );
             }
             if attention_max <= 0.0 {
-                anyhow::bail!("warning_thresholds.attention_max must be positive (got {})", attention_max);
+                anyhow::bail!(
+                    "warning_thresholds.attention_max must be positive (got {})",
+                    attention_max
+                );
             }
             if rapid_growth <= 0.0 {
-                anyhow::bail!("warning_thresholds.rapid_growth_percent must be positive (got {})", rapid_growth);
+                anyhow::bail!(
+                    "warning_thresholds.rapid_growth_percent must be positive (got {})",
+                    rapid_growth
+                );
             }
 
             if watch_min >= watch_max {
@@ -238,12 +248,10 @@ impl HotspotsConfig {
 
         // Validate glob patterns compile
         for pattern in &self.include {
-            Glob::new(pattern)
-                .with_context(|| format!("invalid include pattern: {}", pattern))?;
+            Glob::new(pattern).with_context(|| format!("invalid include pattern: {}", pattern))?;
         }
         for pattern in &self.exclude {
-            Glob::new(pattern)
-                .with_context(|| format!("invalid exclude pattern: {}", pattern))?;
+            Glob::new(pattern).with_context(|| format!("invalid exclude pattern: {}", pattern))?;
         }
 
         Ok(())
@@ -399,7 +407,8 @@ pub fn load_config_file(path: &Path) -> Result<HotspotsConfig> {
     let config: HotspotsConfig = serde_json::from_str(&content)
         .with_context(|| format!("failed to parse config file: {}", path.display()))?;
 
-    config.validate()
+    config
+        .validate()
         .with_context(|| format!("invalid config in: {}", path.display()))?;
 
     Ok(config)
@@ -416,10 +425,9 @@ fn load_from_package_json(path: &Path) -> Result<Option<HotspotsConfig>> {
     match pkg.get("hotspots") {
         Some(hotspots_value) => {
             let config: HotspotsConfig = serde_json::from_value(hotspots_value.clone())
-                .with_context(|| {
-                    format!("invalid hotspots config in {}", path.display())
-                })?;
-            config.validate()
+                .with_context(|| format!("invalid hotspots config in {}", path.display()))?;
+            config
+                .validate()
                 .with_context(|| format!("invalid hotspots config in {}", path.display()))?;
             Ok(Some(config))
         }
@@ -560,10 +568,13 @@ mod tests {
 
     #[test]
     fn test_should_include_custom_patterns() {
-        let config: HotspotsConfig = serde_json::from_str(r#"{
+        let config: HotspotsConfig = serde_json::from_str(
+            r#"{
             "include": ["src/**/*.ts"],
             "exclude": ["src/generated/**"]
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
         let resolved = config.resolve().unwrap();
         assert!(resolved.should_include(Path::new("src/api.ts")));
         assert!(!resolved.should_include(Path::new("lib/util.ts")));
@@ -599,14 +610,18 @@ mod tests {
     fn test_discover_package_json() {
         let dir = tempfile::tempdir().unwrap();
         let pkg_path = dir.path().join("package.json");
-        fs::write(&pkg_path, r#"{
+        fs::write(
+            &pkg_path,
+            r#"{
             "name": "my-project",
             "version": "1.0.0",
             "hotspots": {
                 "exclude": ["**/*.test.ts"],
                 "min_lrs": 3.0
             }
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
 
         let result = discover_config(dir.path()).unwrap();
         assert!(result.is_some());
@@ -631,11 +646,19 @@ mod tests {
 
         // Create both config files - .hotspotsrc.json should win
         fs::write(dir.path().join(".hotspotsrc.json"), r#"{"min_lrs": 1.0}"#).unwrap();
-        fs::write(dir.path().join("hotspots.config.json"), r#"{"min_lrs": 2.0}"#).unwrap();
+        fs::write(
+            dir.path().join("hotspots.config.json"),
+            r#"{"min_lrs": 2.0}"#,
+        )
+        .unwrap();
 
         let result = discover_config(dir.path()).unwrap();
         let (config, _) = result.unwrap();
-        assert_eq!(config.min_lrs, Some(1.0), ".hotspotsrc.json should take priority");
+        assert_eq!(
+            config.min_lrs,
+            Some(1.0),
+            ".hotspotsrc.json should take priority"
+        );
     }
 
     #[test]
@@ -681,7 +704,7 @@ mod tests {
         let config: HotspotsConfig = serde_json::from_str(json).unwrap();
         let resolved = config.resolve().unwrap();
         assert_eq!(resolved.moderate_threshold, 3.0); // default
-        assert_eq!(resolved.high_threshold, 6.0);     // default
+        assert_eq!(resolved.high_threshold, 6.0); // default
         assert_eq!(resolved.critical_threshold, 12.0);
     }
 

--- a/hotspots-core/src/discover.rs
+++ b/hotspots-core/src/discover.rs
@@ -54,11 +54,8 @@ pub fn discover_functions(
                 local_index: idx,
             };
             // Extract suppression comment for this function
-            func.suppression_reason = crate::suppression::extract_suppression(
-                source,
-                func.span,
-                source_map,
-            );
+            func.suppression_reason =
+                crate::suppression::extract_suppression(source, func.span, source_map);
             func
         })
         .collect()

--- a/hotspots-core/src/discover/tests.rs
+++ b/hotspots-core/src/discover/tests.rs
@@ -35,7 +35,10 @@ mod discover_tests {
         let src = "const foo = () => { return 42; };";
         let functions = parse_and_discover(src, 0);
         assert_eq!(functions.len(), 1, "Should discover arrow function");
-        assert_eq!(functions[0].name, None, "Arrow function should have no name");
+        assert_eq!(
+            functions[0].name, None,
+            "Arrow function should have no name"
+        );
     }
 
     #[test]
@@ -59,11 +62,14 @@ mod discover_tests {
         "#;
         let functions1 = parse_and_discover(src, 0);
         let functions2 = parse_and_discover(src, 0);
-        
+
         // Functions should be in same order (sorted by span.start)
         assert_eq!(functions1.len(), functions2.len());
         for (f1, f2) in functions1.iter().zip(functions2.iter()) {
-            assert_eq!(f1.span.start, f2.span.start, "Function order should be deterministic");
+            assert_eq!(
+                f1.span.start, f2.span.start,
+                "Function order should be deterministic"
+            );
         }
     }
 
@@ -94,7 +100,11 @@ mod discover_tests {
     fn test_discover_function_with_arrow_expression_body() {
         let src = "const foo = () => 42;";
         let functions = parse_and_discover(src, 0);
-        assert_eq!(functions.len(), 1, "Should discover arrow with expression body");
+        assert_eq!(
+            functions.len(),
+            1,
+            "Should discover arrow with expression body"
+        );
         // Expression body should be converted to return statement
         assert_eq!(
             functions[0].body.as_ecmascript().stmts.len(),

--- a/hotspots-core/src/language/cfg_builder.rs
+++ b/hotspots-core/src/language/cfg_builder.rs
@@ -65,7 +65,10 @@ mod tests {
         let cfg = builder.build(&function);
 
         // Basic CFG should have entry and exit nodes
-        assert!(cfg.node_count() >= 2, "CFG should have at least entry and exit nodes");
+        assert!(
+            cfg.node_count() >= 2,
+            "CFG should have at least entry and exit nodes"
+        );
     }
 
     #[test]

--- a/hotspots-core/src/language/go/cfg_builder.rs
+++ b/hotspots-core/src/language/go/cfg_builder.rs
@@ -17,9 +17,13 @@ impl CfgBuilder for GoCfgBuilder {
         // Re-parse the source to get the tree
         let mut parser = Parser::new();
         let language = tree_sitter_go::LANGUAGE;
-        parser.set_language(&language.into()).expect("Failed to set Go language");
+        parser
+            .set_language(&language.into())
+            .expect("Failed to set Go language");
 
-        let tree = parser.parse(source, None).expect("Failed to re-parse Go source");
+        let tree = parser
+            .parse(source, None)
+            .expect("Failed to re-parse Go source");
         let root = tree.root_node();
 
         // Find the function node in the tree
@@ -78,7 +82,10 @@ impl GoCfgBuilderState {
         // Connect last node to exit
         if let Some(last_node) = self.current_node {
             if last_node != self.cfg.exit {
-                let has_exit_edge = self.cfg.edges.iter()
+                let has_exit_edge = self
+                    .cfg
+                    .edges
+                    .iter()
                     .any(|e| e.from == last_node && e.to == self.cfg.exit);
 
                 if !has_exit_edge {
@@ -403,8 +410,8 @@ fn is_panic_call(node: &Node, source: &str) -> bool {
 mod tests {
     use super::*;
     use crate::ast::{FunctionId, FunctionNode};
-    use crate::language::{FunctionBody, SourceSpan};
     use crate::language::parser::LanguageParser;
+    use crate::language::{FunctionBody, SourceSpan};
 
     fn make_test_go_function(source: &str) -> FunctionNode {
         FunctionNode {
@@ -463,8 +470,16 @@ func test(x int) {
         // Should have at least entry and exit
         // Full CFG would be: entry, condition, then, join, exit (5 nodes)
         // But we verify it's more than just entry->exit (2 nodes)
-        assert!(cfg.node_count() >= 3, "Expected at least 3 nodes for if statement, got {}", cfg.node_count());
-        assert!(cfg.edge_count() >= 2, "Expected at least 2 edges, got {}", cfg.edge_count());
+        assert!(
+            cfg.node_count() >= 3,
+            "Expected at least 3 nodes for if statement, got {}",
+            cfg.node_count()
+        );
+        assert!(
+            cfg.edge_count() >= 2,
+            "Expected at least 2 edges, got {}",
+            cfg.edge_count()
+        );
     }
 
     #[test]
@@ -492,7 +507,15 @@ func test() {
         // Should have at least entry and exit
         // Full CFG would be: entry, loop header, body, join, exit (5 nodes)
         // But we verify it's more than just entry->exit (2 nodes)
-        assert!(cfg.node_count() >= 3, "Expected at least 3 nodes for for loop, got {}", cfg.node_count());
-        assert!(cfg.edge_count() >= 2, "Expected at least 2 edges, got {}", cfg.edge_count());
+        assert!(
+            cfg.node_count() >= 3,
+            "Expected at least 3 nodes for for loop, got {}",
+            cfg.node_count()
+        );
+        assert!(
+            cfg.edge_count() >= 2,
+            "Expected at least 2 edges, got {}",
+            cfg.edge_count()
+        );
     }
 }

--- a/hotspots-core/src/language/go/cfg_builder.rs
+++ b/hotspots-core/src/language/go/cfg_builder.rs
@@ -358,6 +358,7 @@ impl GoCfgBuilderState {
 }
 
 /// Find a child node by kind
+#[allow(clippy::manual_find)]
 fn find_child_by_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {

--- a/hotspots-core/src/language/go/parser.rs
+++ b/hotspots-core/src/language/go/parser.rs
@@ -146,6 +146,7 @@ fn extract_function_name(node: Node, source: &str) -> Option<String> {
 }
 
 /// Find a child node by kind
+#[allow(clippy::manual_find)]
 fn find_child_by_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {

--- a/hotspots-core/src/language/java/cfg_builder.rs
+++ b/hotspots-core/src/language/java/cfg_builder.rs
@@ -17,9 +17,13 @@ impl CfgBuilder for JavaCfgBuilder {
         // Re-parse the source to get the tree
         let mut parser = Parser::new();
         let language = tree_sitter_java::LANGUAGE;
-        parser.set_language(&language.into()).expect("Failed to set Java language");
+        parser
+            .set_language(&language.into())
+            .expect("Failed to set Java language");
 
-        let tree = parser.parse(source, None).expect("Failed to re-parse Java source");
+        let tree = parser
+            .parse(source, None)
+            .expect("Failed to re-parse Java source");
         let root = tree.root_node();
 
         // Find the function/method node in the tree
@@ -80,7 +84,10 @@ impl JavaCfgBuilderState {
         // Connect last node to exit
         if let Some(last_node) = self.current_node {
             if last_node != self.cfg.exit {
-                let has_exit_edge = self.cfg.edges.iter()
+                let has_exit_edge = self
+                    .cfg
+                    .edges
+                    .iter()
                     .any(|e| e.from == last_node && e.to == self.cfg.exit);
 
                 if !has_exit_edge {
@@ -116,7 +123,9 @@ impl JavaCfgBuilderState {
 
     /// Visit if statement
     fn visit_if(&mut self, node: &Node, source: &str) {
-        let Some(current) = self.current_node else { return; };
+        let Some(current) = self.current_node else {
+            return;
+        };
 
         // Create condition node
         let condition = self.cfg.add_node(NodeKind::Condition);
@@ -177,7 +186,9 @@ impl JavaCfgBuilderState {
 
     /// Visit while loop
     fn visit_while(&mut self, node: &Node, source: &str) {
-        let Some(current) = self.current_node else { return; };
+        let Some(current) = self.current_node else {
+            return;
+        };
 
         // Create condition node
         let condition = self.cfg.add_node(NodeKind::Condition);
@@ -214,7 +225,9 @@ impl JavaCfgBuilderState {
 
     /// Visit do-while loop
     fn visit_do_while(&mut self, node: &Node, source: &str) {
-        let Some(current) = self.current_node else { return; };
+        let Some(current) = self.current_node else {
+            return;
+        };
 
         // Create body entry node
         let body_entry = self.cfg.add_node(NodeKind::Statement);
@@ -259,7 +272,9 @@ impl JavaCfgBuilderState {
 
     /// Visit for loop (traditional or enhanced)
     fn visit_for(&mut self, node: &Node, source: &str) {
-        let Some(current) = self.current_node else { return; };
+        let Some(current) = self.current_node else {
+            return;
+        };
 
         // Create condition node (header)
         let condition = self.cfg.add_node(NodeKind::Condition);
@@ -296,7 +311,9 @@ impl JavaCfgBuilderState {
 
     /// Visit switch statement or switch expression
     fn visit_switch(&mut self, node: &Node, source: &str) {
-        let Some(current) = self.current_node else { return; };
+        let Some(current) = self.current_node else {
+            return;
+        };
 
         // Create switch node (decision point)
         let switch_node = self.cfg.add_node(NodeKind::Condition);
@@ -312,7 +329,7 @@ impl JavaCfgBuilderState {
         });
 
         // Find switch body
-        if let Some(switch_body) = find_child_by_kind(*node,"switch_block") {
+        if let Some(switch_body) = find_child_by_kind(*node, "switch_block") {
             let mut cursor = switch_body.walk();
             let mut has_default = false;
 
@@ -359,7 +376,9 @@ impl JavaCfgBuilderState {
 
     /// Visit try statement
     fn visit_try(&mut self, node: &Node, source: &str) {
-        let Some(current) = self.current_node else { return; };
+        let Some(current) = self.current_node else {
+            return;
+        };
 
         // Create try block entry
         let try_entry = self.cfg.add_node(NodeKind::Statement);
@@ -369,7 +388,7 @@ impl JavaCfgBuilderState {
         let mut branch_ends = Vec::new();
 
         // Process try body
-        if let Some(try_body) = find_child_by_kind(*node,"block") {
+        if let Some(try_body) = find_child_by_kind(*node, "block") {
             self.current_node = Some(try_entry);
             self.visit_block(&try_body, source);
 
@@ -408,7 +427,8 @@ impl JavaCfgBuilderState {
         // on all exit paths. For simplicity, we skip modeling finally in the CFG.
 
         // Only create join node if there are branches that don't exit
-        let non_exit_branches: Vec<_> = branch_ends.into_iter()
+        let non_exit_branches: Vec<_> = branch_ends
+            .into_iter()
             .filter(|&end| end != self.cfg.exit)
             .collect();
 
@@ -426,7 +446,9 @@ impl JavaCfgBuilderState {
 
     /// Visit synchronized statement
     fn visit_synchronized(&mut self, node: &Node, source: &str) {
-        let Some(current) = self.current_node else { return; };
+        let Some(current) = self.current_node else {
+            return;
+        };
 
         // Create synchronized node (decision point - acquiring lock)
         let sync_node = self.cfg.add_node(NodeKind::Condition);
@@ -575,7 +597,11 @@ public class Test {
     }
 }
 "#;
-        let function = make_test_function(source, source.find("public void test").unwrap(), source.len());
+        let function = make_test_function(
+            source,
+            source.find("public void test").unwrap(),
+            source.len(),
+        );
         let builder = JavaCfgBuilder;
         let cfg = builder.build(&function);
 
@@ -594,7 +620,11 @@ public class Test {
     }
 }
 "#;
-        let function = make_test_function(source, source.find("public void test").unwrap(), source.len());
+        let function = make_test_function(
+            source,
+            source.find("public void test").unwrap(),
+            source.len(),
+        );
         let builder = JavaCfgBuilder;
         let cfg = builder.build(&function);
 
@@ -614,7 +644,11 @@ public class Test {
     }
 }
 "#;
-        let function = make_test_function(source, source.find("public void test").unwrap(), source.len());
+        let function = make_test_function(
+            source,
+            source.find("public void test").unwrap(),
+            source.len(),
+        );
         let builder = JavaCfgBuilder;
         let cfg = builder.build(&function);
 
@@ -633,7 +667,11 @@ public class Test {
     }
 }
 "#;
-        let function = make_test_function(source, source.find("public void test").unwrap(), source.len());
+        let function = make_test_function(
+            source,
+            source.find("public void test").unwrap(),
+            source.len(),
+        );
         let builder = JavaCfgBuilder;
         let cfg = builder.build(&function);
 
@@ -654,7 +692,11 @@ public class Test {
     }
 }
 "#;
-        let function = make_test_function(source, source.find("public void test").unwrap(), source.len());
+        let function = make_test_function(
+            source,
+            source.find("public void test").unwrap(),
+            source.len(),
+        );
         let builder = JavaCfgBuilder;
         let cfg = builder.build(&function);
 

--- a/hotspots-core/src/language/mod.rs
+++ b/hotspots-core/src/language/mod.rs
@@ -15,7 +15,7 @@ pub mod span;
 
 use std::path::Path;
 
-pub use cfg_builder::{CfgBuilder, get_builder_for_function};
+pub use cfg_builder::{get_builder_for_function, CfgBuilder};
 pub use ecmascript::{ECMAScriptCfgBuilder, ECMAScriptParser};
 pub use function_body::FunctionBody;
 pub use go::{GoCfgBuilder, GoParser};
@@ -278,10 +278,7 @@ mod tests {
 
     #[test]
     fn test_extensions() {
-        assert_eq!(
-            Language::TypeScript.extensions(),
-            &["ts", "mts", "cts"]
-        );
+        assert_eq!(Language::TypeScript.extensions(), &["ts", "mts", "cts"]);
         assert_eq!(
             Language::TypeScriptReact.extensions(),
             &["tsx", "mtsx", "ctsx"]

--- a/hotspots-core/src/language/parser.rs
+++ b/hotspots-core/src/language/parser.rs
@@ -44,8 +44,8 @@ pub trait ParsedModule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::FunctionId;
     use crate::language::{FunctionBody, SourceSpan};
-    use crate::ast::{FunctionId};
 
     // Test implementation of ParsedModule
     struct TestModule {

--- a/hotspots-core/src/language/python/cfg_builder.rs
+++ b/hotspots-core/src/language/python/cfg_builder.rs
@@ -17,9 +17,13 @@ impl CfgBuilder for PythonCfgBuilder {
         // Re-parse the source to get the tree
         let mut parser = Parser::new();
         let language = tree_sitter_python::LANGUAGE;
-        parser.set_language(&language.into()).expect("Failed to set Python language");
+        parser
+            .set_language(&language.into())
+            .expect("Failed to set Python language");
 
-        let tree = parser.parse(source, None).expect("Failed to re-parse Python source");
+        let tree = parser
+            .parse(source, None)
+            .expect("Failed to re-parse Python source");
         let root = tree.root_node();
 
         // Find the function node in the tree
@@ -78,7 +82,10 @@ impl PythonCfgBuilderState {
         // Connect last node to exit
         if let Some(last_node) = self.current_node {
             if last_node != self.cfg.exit {
-                let has_exit_edge = self.cfg.edges.iter()
+                let has_exit_edge = self
+                    .cfg
+                    .edges
+                    .iter()
                     .any(|e| e.from == last_node && e.to == self.cfg.exit);
 
                 if !has_exit_edge {
@@ -333,7 +340,8 @@ impl PythonCfgBuilderState {
         }
 
         // Connect all branch ends to join node (only create if needed)
-        let non_exit_branches: Vec<_> = branch_ends.into_iter()
+        let non_exit_branches: Vec<_> = branch_ends
+            .into_iter()
             .filter(|&end| end != self.cfg.exit)
             .collect();
 
@@ -432,10 +440,16 @@ fn has_control_flow_in_expression(node: &Node, _source: &str) -> bool {
     has_control_flow_recursive(node, &mut cursor)
 }
 
-fn has_control_flow_recursive<'a>(node: &Node<'a>, cursor: &mut tree_sitter::TreeCursor<'a>) -> bool {
+fn has_control_flow_recursive<'a>(
+    node: &Node<'a>,
+    cursor: &mut tree_sitter::TreeCursor<'a>,
+) -> bool {
     match node.kind() {
         // Comprehensions with if clause add to CC
-        "list_comprehension" | "dictionary_comprehension" | "set_comprehension" | "generator_expression" => {
+        "list_comprehension"
+        | "dictionary_comprehension"
+        | "set_comprehension"
+        | "generator_expression" => {
             // Check if it has an if_clause child
             for child in node.children(cursor) {
                 if child.kind() == "if_clause" {
@@ -510,7 +524,8 @@ mod tests {
 
         // Find the function definition node
         let mut cursor = root.walk();
-        let func_node = root.children(&mut cursor)
+        let func_node = root
+            .children(&mut cursor)
             .find(|n| n.kind() == "function_definition" || n.kind() == "async_function_definition")
             .expect("No function found in test source");
 
@@ -522,7 +537,12 @@ mod tests {
                 local_index: 0,
             },
             name: Some("test_func".to_string()),
-            span: SourceSpan::new(start_byte, func_node.end_byte(), func_node.start_position().row as u32 + 1, func_node.start_position().column as u32),
+            span: SourceSpan::new(
+                start_byte,
+                func_node.end_byte(),
+                func_node.start_position().row as u32 + 1,
+                func_node.start_position().column as u32,
+            ),
             body: FunctionBody::Python {
                 body_node: 0,
                 source: source.to_string(),

--- a/hotspots-core/src/language/rust/cfg_builder.rs
+++ b/hotspots-core/src/language/rust/cfg_builder.rs
@@ -14,13 +14,8 @@ impl CfgBuilder for RustCfgBuilder {
         let source = function.body.as_rust();
 
         // Parse the function source
-        match build_cfg_from_source(source) {
-            Ok(cfg) => cfg,
-            Err(_) => {
-                // On error, return a minimal CFG (entry -> exit)
-                Cfg::new()
-            }
-        }
+        // On error, return a minimal CFG (entry -> exit)
+        build_cfg_from_source(source).unwrap_or_default()
     }
 }
 

--- a/hotspots-core/src/language/rust/cfg_builder.rs
+++ b/hotspots-core/src/language/rust/cfg_builder.rs
@@ -4,7 +4,7 @@ use crate::ast::FunctionNode;
 use crate::cfg::{Cfg, NodeId, NodeKind};
 use crate::language::cfg_builder::CfgBuilder;
 use anyhow::{Context, Result};
-use syn::{Expr, ExprBlock, ExprIf, ExprLoop, ExprMatch, ExprWhile, ExprForLoop, Stmt, Block};
+use syn::{Block, Expr, ExprBlock, ExprForLoop, ExprIf, ExprLoop, ExprMatch, ExprWhile, Stmt};
 
 /// CFG builder for Rust functions
 pub struct RustCfgBuilder;
@@ -27,8 +27,8 @@ impl CfgBuilder for RustCfgBuilder {
 /// Build CFG from Rust source
 fn build_cfg_from_source(source: &str) -> Result<Cfg> {
     // Parse the function source
-    let item_fn: syn::ItemFn = syn::parse_str(source)
-        .context("Failed to parse Rust function for CFG building")?;
+    let item_fn: syn::ItemFn =
+        syn::parse_str(source).context("Failed to parse Rust function for CFG building")?;
 
     let mut cfg = Cfg::new();
     let entry = cfg.entry;
@@ -147,7 +147,12 @@ fn build_if_cfg(cfg: &mut Cfg, expr_if: &ExprIf, entry: NodeId, exit: NodeId) ->
 }
 
 /// Build CFG for match expression
-fn build_match_cfg(cfg: &mut Cfg, expr_match: &ExprMatch, entry: NodeId, exit: NodeId) -> Result<NodeId> {
+fn build_match_cfg(
+    cfg: &mut Cfg,
+    expr_match: &ExprMatch,
+    entry: NodeId,
+    exit: NodeId,
+) -> Result<NodeId> {
     let condition = cfg.add_node(NodeKind::Condition);
     cfg.add_edge(entry, condition);
 
@@ -165,7 +170,12 @@ fn build_match_cfg(cfg: &mut Cfg, expr_match: &ExprMatch, entry: NodeId, exit: N
 }
 
 /// Build CFG for loop expression
-fn build_loop_cfg(cfg: &mut Cfg, expr_loop: &ExprLoop, entry: NodeId, _exit: NodeId) -> Result<NodeId> {
+fn build_loop_cfg(
+    cfg: &mut Cfg,
+    expr_loop: &ExprLoop,
+    entry: NodeId,
+    _exit: NodeId,
+) -> Result<NodeId> {
     let header = cfg.add_node(NodeKind::LoopHeader);
     cfg.add_edge(entry, header);
 
@@ -182,7 +192,12 @@ fn build_loop_cfg(cfg: &mut Cfg, expr_loop: &ExprLoop, entry: NodeId, _exit: Nod
 }
 
 /// Build CFG for while loop
-fn build_while_cfg(cfg: &mut Cfg, expr_while: &ExprWhile, entry: NodeId, _exit: NodeId) -> Result<NodeId> {
+fn build_while_cfg(
+    cfg: &mut Cfg,
+    expr_while: &ExprWhile,
+    entry: NodeId,
+    _exit: NodeId,
+) -> Result<NodeId> {
     let condition = cfg.add_node(NodeKind::Condition);
     cfg.add_edge(entry, condition);
 
@@ -202,7 +217,12 @@ fn build_while_cfg(cfg: &mut Cfg, expr_while: &ExprWhile, entry: NodeId, _exit: 
 }
 
 /// Build CFG for for loop
-fn build_for_cfg(cfg: &mut Cfg, expr_for: &ExprForLoop, entry: NodeId, _exit: NodeId) -> Result<NodeId> {
+fn build_for_cfg(
+    cfg: &mut Cfg,
+    expr_for: &ExprForLoop,
+    entry: NodeId,
+    _exit: NodeId,
+) -> Result<NodeId> {
     let condition = cfg.add_node(NodeKind::Condition);
     cfg.add_edge(entry, condition);
 
@@ -222,7 +242,12 @@ fn build_for_cfg(cfg: &mut Cfg, expr_for: &ExprForLoop, entry: NodeId, _exit: No
 }
 
 /// Build CFG for expression block
-fn build_expr_block_cfg(cfg: &mut Cfg, expr_block: &ExprBlock, entry: NodeId, exit: NodeId) -> Result<NodeId> {
+fn build_expr_block_cfg(
+    cfg: &mut Cfg,
+    expr_block: &ExprBlock,
+    entry: NodeId,
+    exit: NodeId,
+) -> Result<NodeId> {
     build_block_cfg(cfg, &expr_block.block, entry, exit)
 }
 

--- a/hotspots-core/src/language/rust/parser.rs
+++ b/hotspots-core/src/language/rust/parser.rs
@@ -1,12 +1,12 @@
 //! Rust parser implementation using syn
 
 use crate::ast::{FunctionId, FunctionNode};
+use crate::language::function_body::FunctionBody;
 use crate::language::parser::{LanguageParser, ParsedModule};
 use crate::language::span::SourceSpan;
-use crate::language::function_body::FunctionBody;
 use anyhow::{Context, Result};
 use syn::spanned::Spanned;
-use syn::{File, Item, ItemFn, ImplItem, ImplItemFn, Signature, Block};
+use syn::{Block, File, ImplItem, ImplItemFn, Item, ItemFn, Signature};
 
 /// Rust parser using syn
 pub struct RustParser;
@@ -28,10 +28,7 @@ struct RustModule {
 
 impl RustModule {
     fn new(file: File, source: String) -> Self {
-        Self {
-            file,
-            source,
-        }
+        Self { file, source }
     }
 
     /// Extract function nodes from the module
@@ -78,7 +75,13 @@ impl RustModule {
                 // Visit methods in impl block
                 for impl_item in &item_impl.items {
                     if let ImplItem::Fn(method) = impl_item {
-                        self.extract_impl_fn(method, type_name.as_deref(), file_index, local_index, functions);
+                        self.extract_impl_fn(
+                            method,
+                            type_name.as_deref(),
+                            file_index,
+                            local_index,
+                            functions,
+                        );
                     }
                 }
             }
@@ -195,10 +198,7 @@ impl RustModule {
             if current_line == line {
                 // We're on the target line - now count columns
                 let line_start = byte_offset;
-                let line_text = self.source[line_start..]
-                    .lines()
-                    .next()
-                    .unwrap_or("");
+                let line_text = self.source[line_start..].lines().next().unwrap_or("");
 
                 // Column is 0-indexed in syn
                 let mut col_count = 0;

--- a/hotspots-core/src/language/rust/parser.rs
+++ b/hotspots-core/src/language/rust/parser.rs
@@ -102,7 +102,7 @@ impl RustModule {
     ) {
         self.extract_function_common(
             &item_fn.sig,
-            &*item_fn.block,
+            &item_fn.block,
             item_fn,
             name_prefix,
             file_index,
@@ -132,6 +132,7 @@ impl RustModule {
     }
 
     /// Common extraction logic for both functions and methods
+    #[allow(clippy::too_many_arguments)]
     fn extract_function_common<S: Spanned>(
         &self,
         sig: &Signature,
@@ -201,12 +202,10 @@ impl RustModule {
                 let line_text = self.source[line_start..].lines().next().unwrap_or("");
 
                 // Column is 0-indexed in syn
-                let mut col_count = 0;
-                for (char_idx, _) in line_text.char_indices() {
+                for (col_count, (char_idx, _)) in line_text.char_indices().enumerate() {
                     if col_count == column {
                         return line_start + char_idx;
                     }
-                    col_count += 1;
                 }
 
                 // Column is past end of line, return line end

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -32,7 +32,7 @@ pub mod trends;
 
 pub use config::ResolvedConfig;
 pub use git::GitContext;
-pub use report::{FunctionRiskReport, render_json, render_text, sort_reports};
+pub use report::{render_json, render_text, sort_reports, FunctionRiskReport};
 
 use anyhow::{Context, Result};
 use swc_common::{sync::Lrc, SourceMap};
@@ -43,7 +43,10 @@ pub struct AnalysisOptions {
 }
 
 /// Analyze files at the given path with default configuration
-pub fn analyze(path: &std::path::Path, options: AnalysisOptions) -> anyhow::Result<Vec<FunctionRiskReport>> {
+pub fn analyze(
+    path: &std::path::Path,
+    options: AnalysisOptions,
+) -> anyhow::Result<Vec<FunctionRiskReport>> {
     analyze_with_config(path, options, None)
 }
 
@@ -83,9 +86,14 @@ pub fn analyze_with_config(
         }
 
         let reports = analysis::analyze_file_with_config(
-            &file_path, &cm, file_index, &options,
-            weights.as_ref(), thresholds.as_ref(),
-        ).with_context(|| format!("Failed to analyze file: {}", file_path.display()))?;
+            &file_path,
+            &cm,
+            file_index,
+            &options,
+            weights.as_ref(),
+            thresholds.as_ref(),
+        )
+        .with_context(|| format!("Failed to analyze file: {}", file_path.display()))?;
         all_reports.extend(reports);
         file_index += 1;
     }
@@ -150,7 +158,10 @@ fn collect_source_files(path: &std::path::Path) -> Result<Vec<std::path::PathBuf
 }
 
 /// Recursively collect supported source files from a directory
-fn collect_source_files_recursive(dir: &std::path::Path, files: &mut Vec<std::path::PathBuf>) -> Result<()> {
+fn collect_source_files_recursive(
+    dir: &std::path::Path,
+    files: &mut Vec<std::path::PathBuf>,
+) -> Result<()> {
     use std::ffi::OsStr;
 
     for entry_result in std::fs::read_dir(dir)
@@ -195,4 +206,3 @@ fn collect_source_files_recursive(dir: &std::path::Path, files: &mut Vec<std::pa
 
     Ok(())
 }
-

--- a/hotspots-core/src/metrics.rs
+++ b/hotspots-core/src/metrics.rs
@@ -470,6 +470,7 @@ fn find_go_function_by_start(
 }
 
 /// Find a child node by kind
+#[allow(clippy::manual_find)]
 fn find_go_child_by_kind<'a>(
     node: tree_sitter::Node<'a>,
     kind: &str,

--- a/hotspots-core/src/metrics.rs
+++ b/hotspots-core/src/metrics.rs
@@ -168,7 +168,10 @@ impl Visit for CatchCounter<'_> {
 /// Walk AST and count maximum depth of control constructs:
 /// - if, loop, switch, try
 fn nesting_depth(body: &BlockStmt) -> usize {
-    let mut visitor = NestingDepthVisitor { max_depth: 0, current_depth: 0 };
+    let mut visitor = NestingDepthVisitor {
+        max_depth: 0,
+        current_depth: 0,
+    };
     body.visit_with(&mut visitor);
     visitor.max_depth
 }
@@ -350,7 +353,9 @@ fn non_structured_exits(body: &BlockStmt) -> usize {
     body.visit_with(&mut visitor);
 
     // Check if last statement is a return (final tail return)
-    let has_final_return = body.stmts.last()
+    let has_final_return = body
+        .stmts
+        .last()
         .map(|s| matches!(s, Stmt::Return(_)))
         .unwrap_or(false);
 
@@ -398,9 +403,13 @@ fn extract_go_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
     use tree_sitter::Parser;
     let mut parser = Parser::new();
     let language = tree_sitter_go::LANGUAGE;
-    parser.set_language(&language.into()).expect("Failed to set Go language");
+    parser
+        .set_language(&language.into())
+        .expect("Failed to set Go language");
 
-    let tree = parser.parse(source, None).expect("Failed to re-parse Go source");
+    let tree = parser
+        .parse(source, None)
+        .expect("Failed to re-parse Go source");
     let root = tree.root_node();
 
     // Find the function node in the tree
@@ -437,7 +446,10 @@ fn extract_go_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
 }
 
 /// Find a Go function node by its start byte position
-fn find_go_function_by_start(root: tree_sitter::Node, start_byte: usize) -> Option<tree_sitter::Node> {
+fn find_go_function_by_start(
+    root: tree_sitter::Node,
+    start_byte: usize,
+) -> Option<tree_sitter::Node> {
     fn search_recursive(node: tree_sitter::Node, start: usize) -> Option<tree_sitter::Node> {
         if (node.kind() == "function_declaration" || node.kind() == "method_declaration")
             && node.start_byte() == start
@@ -458,7 +470,10 @@ fn find_go_function_by_start(root: tree_sitter::Node, start_byte: usize) -> Opti
 }
 
 /// Find a child node by kind
-fn find_go_child_by_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+fn find_go_child_by_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == kind {
@@ -474,8 +489,12 @@ fn go_nesting_depth(body_node: &tree_sitter::Node) -> usize {
         // Increment depth for control structures
         let new_depth = if matches!(
             node.kind(),
-            "if_statement" | "for_statement" | "switch_statement" |
-            "expression_switch_statement" | "type_switch_statement" | "select_statement"
+            "if_statement"
+                | "for_statement"
+                | "switch_statement"
+                | "expression_switch_statement"
+                | "type_switch_statement"
+                | "select_statement"
         ) {
             let depth = current_depth + 1;
             if depth > *max_depth {
@@ -620,9 +639,13 @@ fn extract_java_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
     use tree_sitter::Parser;
     let mut parser = Parser::new();
     let language = tree_sitter_java::LANGUAGE;
-    parser.set_language(&language.into()).expect("Failed to set Java language");
+    parser
+        .set_language(&language.into())
+        .expect("Failed to set Java language");
 
-    let tree = parser.parse(source, None).expect("Failed to re-parse Java source");
+    let tree = parser
+        .parse(source, None)
+        .expect("Failed to re-parse Java source");
     let root = tree.root_node();
 
     // Find the function/method node in the tree
@@ -661,7 +684,10 @@ fn extract_java_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
 }
 
 /// Find a Java function/method node by its start byte position
-fn find_java_function_by_start(root: tree_sitter::Node, start_byte: usize) -> Option<tree_sitter::Node> {
+fn find_java_function_by_start(
+    root: tree_sitter::Node,
+    start_byte: usize,
+) -> Option<tree_sitter::Node> {
     fn search_recursive(node: tree_sitter::Node, start: usize) -> Option<tree_sitter::Node> {
         if (node.kind() == "method_declaration" || node.kind() == "constructor_declaration")
             && node.start_byte() == start
@@ -683,7 +709,10 @@ fn find_java_function_by_start(root: tree_sitter::Node, start_byte: usize) -> Op
 
 /// Find a child node by kind
 #[allow(clippy::manual_find)]
-fn find_java_child_by_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+fn find_java_child_by_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == kind {
@@ -699,10 +728,15 @@ fn java_nesting_depth(body_node: &tree_sitter::Node) -> usize {
         // Increment depth for control structures
         let new_depth = if matches!(
             node.kind(),
-            "if_statement" | "while_statement" | "do_statement" |
-            "for_statement" | "enhanced_for_statement" |
-            "switch_statement" | "switch_expression" |
-            "try_statement" | "synchronized_statement"
+            "if_statement"
+                | "while_statement"
+                | "do_statement"
+                | "for_statement"
+                | "enhanced_for_statement"
+                | "switch_statement"
+                | "switch_expression"
+                | "try_statement"
+                | "synchronized_statement"
         ) {
             let depth = current_depth + 1;
             if depth > *max_depth {
@@ -727,7 +761,11 @@ fn java_nesting_depth(body_node: &tree_sitter::Node) -> usize {
 
 /// Count method calls (fan-out) in Java
 fn java_fan_out(body_node: &tree_sitter::Node, source: &str) -> usize {
-    fn count_calls(node: tree_sitter::Node, source: &str, calls: &mut std::collections::HashSet<String>) {
+    fn count_calls(
+        node: tree_sitter::Node,
+        source: &str,
+        calls: &mut std::collections::HashSet<String>,
+    ) {
         // Java uses "method_invocation" node for method calls
         if node.kind() == "method_invocation" {
             // Extract the method name
@@ -813,9 +851,13 @@ fn extract_python_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
     use tree_sitter::Parser;
     let mut parser = Parser::new();
     let language = tree_sitter_python::LANGUAGE;
-    parser.set_language(&language.into()).expect("Failed to set Python language");
+    parser
+        .set_language(&language.into())
+        .expect("Failed to set Python language");
 
-    let tree = parser.parse(source, None).expect("Failed to re-parse Python source");
+    let tree = parser
+        .parse(source, None)
+        .expect("Failed to re-parse Python source");
     let root = tree.root_node();
 
     // Find the function node in the tree
@@ -852,7 +894,10 @@ fn extract_python_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
 }
 
 /// Find a Python function node by its start byte position
-fn find_python_function_by_start(root: tree_sitter::Node, start_byte: usize) -> Option<tree_sitter::Node> {
+fn find_python_function_by_start(
+    root: tree_sitter::Node,
+    start_byte: usize,
+) -> Option<tree_sitter::Node> {
     fn search_recursive(node: tree_sitter::Node, start: usize) -> Option<tree_sitter::Node> {
         if (node.kind() == "function_definition" || node.kind() == "async_function_definition")
             && node.start_byte() == start
@@ -874,7 +919,10 @@ fn find_python_function_by_start(root: tree_sitter::Node, start_byte: usize) -> 
 
 /// Find a child node by kind
 #[allow(clippy::manual_find)]
-fn find_python_child_by_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+fn find_python_child_by_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == kind {
@@ -890,8 +938,12 @@ fn python_nesting_depth(body_node: &tree_sitter::Node) -> usize {
         // Increment depth for control structures
         let new_depth = if matches!(
             node.kind(),
-            "if_statement" | "while_statement" | "for_statement" |
-            "try_statement" | "with_statement" | "match_statement"
+            "if_statement"
+                | "while_statement"
+                | "for_statement"
+                | "try_statement"
+                | "with_statement"
+                | "match_statement"
         ) {
             let depth = current_depth + 1;
             if depth > *max_depth {
@@ -916,7 +968,11 @@ fn python_nesting_depth(body_node: &tree_sitter::Node) -> usize {
 
 /// Count function calls (fan-out) in Python
 fn python_fan_out(body_node: &tree_sitter::Node, source: &str) -> usize {
-    fn count_calls(node: tree_sitter::Node, source: &str, calls: &mut std::collections::HashSet<String>) {
+    fn count_calls(
+        node: tree_sitter::Node,
+        source: &str,
+        calls: &mut std::collections::HashSet<String>,
+    ) {
         // Python uses "call" node for function calls
         if node.kind() == "call" {
             // Try to extract the function name
@@ -975,8 +1031,10 @@ fn python_count_cc_extras(body_node: &tree_sitter::Node, _source: &str) -> usize
                 *count += 1;
             }
             // Comprehensions with if-filters add to CC
-            "list_comprehension" | "dictionary_comprehension" |
-            "set_comprehension" | "generator_expression" => {
+            "list_comprehension"
+            | "dictionary_comprehension"
+            | "set_comprehension"
+            | "generator_expression" => {
                 // Check if it has an if_clause child
                 let mut cursor = node.walk();
                 for child in node.children(&mut cursor) {

--- a/hotspots-core/src/parser.rs
+++ b/hotspots-core/src/parser.rs
@@ -5,7 +5,7 @@
 //! - Formatting, comments, and whitespace must not affect results
 
 use anyhow::Result;
-use swc_common::{sync::Lrc, FileName, SourceMap, SourceFile};
+use swc_common::{sync::Lrc, FileName, SourceFile, SourceMap};
 use swc_ecma_ast::{EsVersion, Module};
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
 
@@ -15,31 +15,35 @@ fn syntax_for_file(filename: &str) -> Syntax {
     if filename.ends_with(".tsx") || filename.ends_with(".mtsx") || filename.ends_with(".ctsx") {
         // TypeScript with JSX (TSX)
         Syntax::Typescript(swc_ecma_parser::TsSyntax {
-            tsx: true, // Enable JSX in TypeScript
+            tsx: true,         // Enable JSX in TypeScript
             decorators: false, // No experimental decorators
-            dts: false, // TSX files are not declaration files
+            dts: false,        // TSX files are not declaration files
             ..Default::default()
         })
-    } else if filename.ends_with(".ts") || filename.ends_with(".mts") || filename.ends_with(".cts") {
+    } else if filename.ends_with(".ts") || filename.ends_with(".mts") || filename.ends_with(".cts")
+    {
         // TypeScript without JSX
         let is_dts = filename.ends_with(".d.ts");
         Syntax::Typescript(swc_ecma_parser::TsSyntax {
-            tsx: false, // No JSX in plain TS
+            tsx: false,        // No JSX in plain TS
             decorators: false, // No experimental decorators
-            dts: is_dts, // Enable dts mode only for .d.ts files
+            dts: is_dts,       // Enable dts mode only for .d.ts files
             ..Default::default()
         })
-    } else if filename.ends_with(".jsx") || filename.ends_with(".mjsx") || filename.ends_with(".cjsx") {
+    } else if filename.ends_with(".jsx")
+        || filename.ends_with(".mjsx")
+        || filename.ends_with(".cjsx")
+    {
         // JavaScript with JSX
         Syntax::Es(swc_ecma_parser::EsSyntax {
-            jsx: true, // Enable JSX in JavaScript
+            jsx: true,         // Enable JSX in JavaScript
             decorators: false, // No experimental decorators
             ..Default::default()
         })
     } else {
         // Plain JavaScript (for .js, .mjs, .cjs)
         Syntax::Es(swc_ecma_parser::EsSyntax {
-            jsx: false, // No JSX in plain JS
+            jsx: false,        // No JSX in plain JS
             decorators: false, // No experimental decorators
             ..Default::default()
         })
@@ -62,33 +66,24 @@ pub fn parse_source(src: &str, source_map: &Lrc<SourceMap>, filename: &str) -> R
     let syntax = syntax_for_file(filename);
 
     // Create SourceFile for the source code
-    let source_file: Lrc<SourceFile> = source_map.new_source_file(
-        FileName::Custom(filename.into()).into(),
-        src.to_string(),
-    );
+    let source_file: Lrc<SourceFile> =
+        source_map.new_source_file(FileName::Custom(filename.into()).into(), src.to_string());
 
     // Create StringInput from SourceFile
     let input = StringInput::from(&*source_file);
 
     // Create lexer with detected syntax
-    let lexer = Lexer::new(
-        syntax,
-        EsVersion::Es2022,
-        input,
-        None,
-    );
+    let lexer = Lexer::new(syntax, EsVersion::Es2022, input, None);
 
     // Create parser
     let mut parser = Parser::new_from(lexer);
 
     // Parse module
-    parser
-        .parse_module()
-        .map_err(|e| {
-            let error_msg = e.kind().msg();
-            anyhow::anyhow!("Parse error: {}", error_msg)
-                .context(format!("Failed to parse source file: {}", filename))
-        })
+    parser.parse_module().map_err(|e| {
+        let error_msg = e.kind().msg();
+        anyhow::anyhow!("Parse error: {}", error_msg)
+            .context(format!("Failed to parse source file: {}", filename))
+    })
 }
 
 /// Legacy alias for backwards compatibility

--- a/hotspots-core/src/parser/tests.rs
+++ b/hotspots-core/src/parser/tests.rs
@@ -80,7 +80,10 @@ mod parser_tests {
         // Interfaces should parse but won't be analyzed
         let src = "interface Foo { bar: string; }";
         let result = parse_test(src, "test.ts");
-        assert!(result.is_ok(), "Should parse interface (but ignore in analysis)");
+        assert!(
+            result.is_ok(),
+            "Should parse interface (but ignore in analysis)"
+        );
     }
 
     #[test]

--- a/hotspots-core/src/policy.rs
+++ b/hotspots-core/src/policy.rs
@@ -249,10 +249,7 @@ fn evaluate_critical_introduction(deltas: &[FunctionDeltaEntry], results: &mut P
 
         // Trigger if becomes Critical and wasn't Critical before
         if !was_critical_before {
-            let message = format!(
-                "Function {} introduced as Critical",
-                entry.function_id
-            );
+            let message = format!("Function {} introduced as Critical", entry.function_id);
 
             results.failed.push(PolicyResult {
                 id: PolicyId::CriticalIntroduction,
@@ -288,8 +285,7 @@ fn evaluate_excessive_risk_regression(deltas: &[FunctionDeltaEntry], results: &m
             if delta.lrs >= REGRESSION_THRESHOLD {
                 let message = format!(
                     "Function {} regressed by {:.2} LRS",
-                    entry.function_id,
-                    delta.lrs
+                    entry.function_id, delta.lrs
                 );
 
                 results.failed.push(PolicyResult {
@@ -352,8 +348,7 @@ fn evaluate_watch_threshold(
         if entering_watch {
             let message = format!(
                 "Function {} approaching moderate threshold (LRS: {:.2})",
-                entry.function_id,
-                after_lrs
+                entry.function_id, after_lrs
             );
 
             results.warnings.push(PolicyResult {
@@ -416,8 +411,7 @@ fn evaluate_attention_threshold(
         if entering_attention {
             let message = format!(
                 "Function {} approaching high threshold (LRS: {:.2})",
-                entry.function_id,
-                after_lrs
+                entry.function_id, after_lrs
             );
 
             results.warnings.push(PolicyResult {
@@ -474,10 +468,7 @@ fn evaluate_rapid_growth(
         if growth_percent >= config.rapid_growth_percent {
             let message = format!(
                 "Function {} LRS increased by {:.1}% ({:.2} -> {:.2})",
-                entry.function_id,
-                growth_percent,
-                before_lrs,
-                after_lrs
+                entry.function_id, growth_percent, before_lrs, after_lrs
             );
 
             results.warnings.push(PolicyResult {
@@ -504,10 +495,7 @@ fn evaluate_suppression_missing_reason(deltas: &[FunctionDeltaEntry], results: &
         // Check if function has suppression without reason
         if let Some(reason) = &entry.suppression_reason {
             if reason.is_empty() {
-                let message = format!(
-                    "Function {} suppressed without reason",
-                    entry.function_id
-                );
+                let message = format!("Function {} suppressed without reason", entry.function_id);
 
                 results.warnings.push(PolicyResult {
                     id: PolicyId::SuppressionMissingReason,
@@ -553,10 +541,7 @@ fn evaluate_net_repo_regression(
 
     // Trigger if repo total increased
     if total_delta > 0.0 {
-        let message = format!(
-            "Repository total LRS increased by {:.2}",
-            total_delta
-        );
+        let message = format!("Repository total LRS increased by {:.2}", total_delta);
 
         results.warnings.push(PolicyResult {
             id: PolicyId::NetRepoRegression,
@@ -578,8 +563,8 @@ fn evaluate_net_repo_regression(
 mod tests {
     use super::*;
     use crate::delta::{Delta, DeltaCommitInfo, FunctionDelta, FunctionDeltaEntry, FunctionState};
-    use crate::report::MetricsReport;
     use crate::git::GitContext;
+    use crate::report::MetricsReport;
     use tempfile::TempDir;
 
     fn create_test_delta_entry(
@@ -590,13 +575,23 @@ mod tests {
         delta_lrs: Option<f64>,
     ) -> FunctionDeltaEntry {
         let before = before_band.map(|band| FunctionState {
-            metrics: MetricsReport { cc: 4, nd: 2, fo: 2, ns: 1 },
+            metrics: MetricsReport {
+                cc: 4,
+                nd: 2,
+                fo: 2,
+                ns: 1,
+            },
             lrs: 3.9,
             band: band.to_string(),
         });
 
         let after = after_band.map(|band| FunctionState {
-            metrics: MetricsReport { cc: 6, nd: 3, fo: 3, ns: 1 },
+            metrics: MetricsReport {
+                cc: 6,
+                nd: 3,
+                fo: 3,
+                ns: 1,
+            },
             lrs: if band == "critical" { 10.5 } else { 6.2 },
             band: band.to_string(),
         });
@@ -620,7 +615,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn test_critical_introduction_new_function() {
         let mut results = PolicyResults::new();
@@ -637,7 +631,10 @@ mod tests {
         assert_eq!(results.failed.len(), 1);
         assert_eq!(results.failed[0].id, PolicyId::CriticalIntroduction);
         assert_eq!(results.failed[0].severity, PolicySeverity::Blocking);
-        assert_eq!(results.failed[0].function_id, Some("src/foo.ts::handler".to_string()));
+        assert_eq!(
+            results.failed[0].function_id,
+            Some("src/foo.ts::handler".to_string())
+        );
     }
 
     #[test]
@@ -700,7 +697,12 @@ mod tests {
         assert_eq!(results.failed.len(), 1);
         assert_eq!(results.failed[0].id, PolicyId::ExcessiveRiskRegression);
         assert_eq!(results.failed[0].severity, PolicySeverity::Blocking);
-        assert!(results.failed[0].metadata.as_ref().unwrap().delta_lrs.is_some());
+        assert!(results.failed[0]
+            .metadata
+            .as_ref()
+            .unwrap()
+            .delta_lrs
+            .is_some());
     }
 
     #[test]
@@ -770,9 +772,15 @@ mod tests {
         // Should be sorted by id first (CriticalIntroduction < ExcessiveRiskRegression)
         // Then by function_id ASCII
         assert_eq!(results.failed[0].id, PolicyId::CriticalIntroduction);
-        assert_eq!(results.failed[0].function_id, Some("src/a.ts::func".to_string()));
+        assert_eq!(
+            results.failed[0].function_id,
+            Some("src/a.ts::func".to_string())
+        );
         assert_eq!(results.failed[1].id, PolicyId::CriticalIntroduction);
-        assert_eq!(results.failed[1].function_id, Some("src/b.ts::func".to_string()));
+        assert_eq!(
+            results.failed[1].function_id,
+            Some("src/b.ts::func".to_string())
+        );
         assert_eq!(results.failed[2].id, PolicyId::ExcessiveRiskRegression);
     }
 
@@ -816,7 +824,12 @@ mod tests {
         after_lrs: Option<f64>,
     ) -> FunctionDeltaEntry {
         let before = before_lrs.map(|lrs| FunctionState {
-            metrics: MetricsReport { cc: 4, nd: 2, fo: 2, ns: 1 },
+            metrics: MetricsReport {
+                cc: 4,
+                nd: 2,
+                fo: 2,
+                ns: 1,
+            },
             lrs,
             band: if lrs >= 9.0 {
                 "critical".to_string()
@@ -830,7 +843,12 @@ mod tests {
         });
 
         let after = after_lrs.map(|lrs| FunctionState {
-            metrics: MetricsReport { cc: 6, nd: 3, fo: 3, ns: 1 },
+            metrics: MetricsReport {
+                cc: 6,
+                nd: 3,
+                fo: 3,
+                ns: 1,
+            },
             lrs,
             band: if lrs >= 9.0 {
                 "critical".to_string()
@@ -999,8 +1017,18 @@ mod tests {
         assert_eq!(results.warnings.len(), 1);
         assert_eq!(results.warnings[0].id, PolicyId::RapidGrowth);
         assert_eq!(results.warnings[0].severity, PolicySeverity::Warning);
-        assert!(results.warnings[0].metadata.as_ref().unwrap().growth_percent.is_some());
-        let growth = results.warnings[0].metadata.as_ref().unwrap().growth_percent.unwrap();
+        assert!(results.warnings[0]
+            .metadata
+            .as_ref()
+            .unwrap()
+            .growth_percent
+            .is_some());
+        let growth = results.warnings[0]
+            .metadata
+            .as_ref()
+            .unwrap()
+            .growth_percent
+            .unwrap();
         assert!((growth - 100.0).abs() < 0.1); // ~100%
     }
 

--- a/hotspots-core/src/report.rs
+++ b/hotspots-core/src/report.rs
@@ -59,8 +59,14 @@ impl FunctionRiskReport {
         band: RiskBand,
         source_map: &swc_common::SourceMap,
     ) -> Self {
-        let function_name = function.name.as_deref()
-            .unwrap_or(&format!("<anonymous>@{}:{}", file, function.start_line(source_map)))
+        let function_name = function
+            .name
+            .as_deref()
+            .unwrap_or(&format!(
+                "<anonymous>@{}:{}",
+                file,
+                function.start_line(source_map)
+            ))
             .to_string();
 
         FunctionRiskReport {
@@ -91,7 +97,8 @@ impl FunctionRiskReport {
 pub fn sort_reports(mut reports: Vec<FunctionRiskReport>) -> Vec<FunctionRiskReport> {
     reports.sort_by(|a, b| {
         // 1. LRS descending
-        b.lrs.partial_cmp(&a.lrs)
+        b.lrs
+            .partial_cmp(&a.lrs)
             .unwrap_or(std::cmp::Ordering::Equal)
             // 2. File path ascending
             .then_with(|| a.file.cmp(&b.file))
@@ -106,10 +113,13 @@ pub fn sort_reports(mut reports: Vec<FunctionRiskReport>) -> Vec<FunctionRiskRep
 /// Render reports as text output
 pub fn render_text(reports: &[FunctionRiskReport]) -> String {
     let mut output = String::new();
-    
+
     // Header
-    output.push_str(&format!("{:<8} {:<20} {:<6} {}\n", "LRS", "File", "Line", "Function"));
-    
+    output.push_str(&format!(
+        "{:<8} {:<20} {:<6} {}\n",
+        "LRS", "File", "Line", "Function"
+    ));
+
     // Reports
     for report in reports {
         let lrs_str = format!("{:.2}", report.lrs);
@@ -121,7 +131,7 @@ pub fn render_text(reports: &[FunctionRiskReport]) -> String {
             report.function
         ));
     }
-    
+
     output
 }
 
@@ -139,4 +149,3 @@ fn truncate_or_pad(s: &str, width: usize) -> String {
         format!("{:<width$}", s, width = width)
     }
 }
-

--- a/hotspots-core/src/report.rs
+++ b/hotspots-core/src/report.rs
@@ -49,6 +49,7 @@ pub struct RiskReport {
 
 impl FunctionRiskReport {
     /// Create a new function risk report
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         function: &FunctionNode,
         file: String,

--- a/hotspots-core/src/risk.rs
+++ b/hotspots-core/src/risk.rs
@@ -62,7 +62,12 @@ pub struct LrsWeights {
 
 impl Default for LrsWeights {
     fn default() -> Self {
-        LrsWeights { cc: 1.0, nd: 0.8, fo: 0.6, ns: 0.7 }
+        LrsWeights {
+            cc: 1.0,
+            nd: 0.8,
+            fo: 0.6,
+            ns: 0.7,
+        }
     }
 }
 
@@ -76,7 +81,11 @@ pub struct RiskThresholds {
 
 impl Default for RiskThresholds {
     fn default() -> Self {
-        RiskThresholds { moderate: 3.0, high: 6.0, critical: 9.0 }
+        RiskThresholds {
+            moderate: 3.0,
+            high: 6.0,
+            critical: 9.0,
+        }
     }
 }
 
@@ -90,7 +99,10 @@ pub fn calculate_lrs(risk: &RiskComponents) -> f64 {
 
 /// Calculate LRS with custom weights
 pub fn calculate_lrs_with_weights(risk: &RiskComponents, weights: &LrsWeights) -> f64 {
-    weights.cc * risk.r_cc + weights.nd * risk.r_nd + weights.fo * risk.r_fo + weights.ns * risk.r_ns
+    weights.cc * risk.r_cc
+        + weights.nd * risk.r_nd
+        + weights.fo * risk.r_fo
+        + weights.ns * risk.r_ns
 }
 
 /// Assign risk band based on LRS with default thresholds

--- a/hotspots-core/src/suppression.rs
+++ b/hotspots-core/src/suppression.rs
@@ -32,7 +32,11 @@ use swc_common::SourceMap;
 /// ```
 ///
 /// Blank lines between the comment and function will cause the comment to be ignored.
-pub fn extract_suppression(source: &str, span: SourceSpan, _source_map: &SourceMap) -> Option<String> {
+pub fn extract_suppression(
+    source: &str,
+    span: SourceSpan,
+    _source_map: &SourceMap,
+) -> Option<String> {
     // Get the line number of the function start (1-indexed)
     let func_line = span.start_line;
 

--- a/hotspots-core/tests/ci_invariant_tests.rs
+++ b/hotspots-core/tests/ci_invariant_tests.rs
@@ -3,8 +3,8 @@
 //! These tests explicitly validate critical invariants that must always hold.
 //! Run in CI to prevent regressions.
 
-use hotspots_core::{delta, snapshot, git};
 use hotspots_core::report::{FunctionRiskReport, MetricsReport, RiskReport};
+use hotspots_core::{delta, git, snapshot};
 use tempfile::TempDir;
 
 /// Create a test snapshot with given SHA
@@ -16,13 +16,18 @@ fn create_test_snapshot(sha: &str, parent_sha: &str) -> snapshot::Snapshot {
         branch: Some("main".to_string()),
         is_detached: false,
     };
-    
+
     let report = FunctionRiskReport {
         file: "src/foo.ts".to_string(),
         function: "handler".to_string(),
         line: 42,
         language: "TypeScript".to_string(),
-        metrics: MetricsReport { cc: 5, nd: 2, fo: 3, ns: 1 },
+        metrics: MetricsReport {
+            cc: 5,
+            nd: 2,
+            fo: 3,
+            ns: 1,
+        },
         risk: RiskReport {
             r_cc: 2.0,
             r_nd: 1.0,
@@ -33,7 +38,7 @@ fn create_test_snapshot(sha: &str, parent_sha: &str) -> snapshot::Snapshot {
         band: "moderate".to_string(),
         suppression_reason: None,
     };
-    
+
     snapshot::Snapshot::new(git_context, vec![report])
 }
 
@@ -41,32 +46,31 @@ fn create_test_snapshot(sha: &str, parent_sha: &str) -> snapshot::Snapshot {
 fn test_snapshot_immutability() {
     let temp_repo = TempDir::new().expect("failed to create temp directory");
     let repo_path = temp_repo.path();
-    
+
     // Initialize git repo
     std::process::Command::new("git")
         .current_dir(repo_path)
         .args(["init"])
         .output()
         .expect("failed to run git init");
-    
+
     let snapshot = create_test_snapshot("abc123", "def456");
     let snapshot_path = snapshot::snapshot_path(repo_path, snapshot.commit_sha());
-    
+
     // First persist should succeed
-    snapshot::persist_snapshot(repo_path, &snapshot)
-        .expect("first persist should succeed");
-    
+    snapshot::persist_snapshot(repo_path, &snapshot).expect("first persist should succeed");
+
     // Read file content after first persist
-    let first_content = std::fs::read_to_string(&snapshot_path)
-        .expect("failed to read snapshot file");
-    
+    let first_content =
+        std::fs::read_to_string(&snapshot_path).expect("failed to read snapshot file");
+
     // Second persist with identical snapshot should succeed (idempotency)
     snapshot::persist_snapshot(repo_path, &snapshot)
         .expect("second persist with identical snapshot should succeed (idempotent)");
-    
+
     // File content should be unchanged (immutability)
-    let second_content = std::fs::read_to_string(&snapshot_path)
-        .expect("failed to read snapshot file");
+    let second_content =
+        std::fs::read_to_string(&snapshot_path).expect("failed to read snapshot file");
     assert_eq!(
         first_content, second_content,
         "snapshot file must not change when persisting identical snapshot (immutability)"
@@ -77,17 +81,17 @@ fn test_snapshot_immutability() {
 fn test_snapshot_byte_for_byte_determinism() {
     let snapshot1 = create_test_snapshot("abc123", "def456");
     let snapshot2 = create_test_snapshot("abc123", "def456");
-    
+
     // Serialize both snapshots
     let json1 = snapshot1.to_json().expect("should serialize");
     let json2 = snapshot2.to_json().expect("should serialize");
-    
+
     // Should be byte-for-byte identical
     assert_eq!(
         json1, json2,
         "identical snapshots must serialize to identical JSON (deterministic)"
     );
-    
+
     // Verify deterministic ordering (run multiple times)
     let json3 = snapshot1.to_json().expect("should serialize");
     assert_eq!(
@@ -100,33 +104,31 @@ fn test_snapshot_byte_for_byte_determinism() {
 fn test_snapshot_filename_equals_commit_sha() {
     let temp_repo = TempDir::new().expect("failed to create temp directory");
     let repo_path = temp_repo.path();
-    
+
     // Initialize git repo
     std::process::Command::new("git")
         .current_dir(repo_path)
         .args(["init"])
         .output()
         .expect("failed to run git init");
-    
+
     let commit_sha = "abc123def456";
     let snapshot = create_test_snapshot(commit_sha, "def456");
-    
-    snapshot::persist_snapshot(repo_path, &snapshot)
-        .expect("failed to persist snapshot");
-    
+
+    snapshot::persist_snapshot(repo_path, &snapshot).expect("failed to persist snapshot");
+
     // Verify filename equals commit SHA
     let snapshot_path = snapshot::snapshot_path(repo_path, commit_sha);
     assert!(
         snapshot_path.exists(),
         "snapshot file should exist at path derived from commit SHA"
     );
-    
+
     // Verify filename matches commit SHA exactly
     let expected_filename = format!("{}.json", commit_sha);
     let actual_filename = snapshot_path.file_name().unwrap().to_str().unwrap();
     assert_eq!(
-        actual_filename,
-        expected_filename,
+        actual_filename, expected_filename,
         "snapshot filename must equal commit SHA (filename is authoritative identity)"
     );
 }
@@ -141,13 +143,18 @@ fn test_delta_single_parent_only() {
         branch: Some("main".to_string()),
         is_detached: false,
     };
-    
+
     let report = FunctionRiskReport {
         file: "src/foo.ts".to_string(),
         function: "handler".to_string(),
         line: 42,
         language: "TypeScript".to_string(),
-        metrics: MetricsReport { cc: 5, nd: 2, fo: 3, ns: 1 },
+        metrics: MetricsReport {
+            cc: 5,
+            nd: 2,
+            fo: 3,
+            ns: 1,
+        },
         risk: RiskReport {
             r_cc: 2.0,
             r_nd: 1.0,
@@ -158,20 +165,19 @@ fn test_delta_single_parent_only() {
         band: "moderate".to_string(),
         suppression_reason: None,
     };
-    
+
     let merge_snapshot = snapshot::Snapshot::new(git_context, vec![report]);
-    
+
     // Create parent snapshot for parent[0]
     let parent_snapshot = create_test_snapshot("parent1", "grandparent");
-    
+
     // Compute delta - should use parent[0] only
-    let delta = delta::Delta::new(&merge_snapshot, Some(&parent_snapshot))
-        .expect("should compute delta");
-    
+    let delta =
+        delta::Delta::new(&merge_snapshot, Some(&parent_snapshot)).expect("should compute delta");
+
     // Verify delta uses parent[0] only (not parent[1])
     assert_eq!(
-        delta.commit.parent,
-        "parent1",
+        delta.commit.parent, "parent1",
         "delta must use parent[0] only, even for merge commits with multiple parents"
     );
 }
@@ -179,21 +185,19 @@ fn test_delta_single_parent_only() {
 #[test]
 fn test_delta_baseline_handling_correct() {
     let snapshot = create_test_snapshot("abc123", "def456");
-    
+
     // No parent - should be baseline
-    let delta = delta::Delta::new(&snapshot, None)
-        .expect("should create baseline delta");
-    
+    let delta = delta::Delta::new(&snapshot, None).expect("should create baseline delta");
+
     assert!(
         delta.baseline,
         "delta with no parent must have baseline=true"
     );
-    
+
     // With parent - should not be baseline
     let parent = create_test_snapshot("def456", "grandparent");
-    let delta = delta::Delta::new(&snapshot, Some(&parent))
-        .expect("should create delta");
-    
+    let delta = delta::Delta::new(&snapshot, Some(&parent)).expect("should create delta");
+
     assert!(
         !delta.baseline,
         "delta with parent must have baseline=false"
@@ -203,7 +207,7 @@ fn test_delta_baseline_handling_correct() {
 #[test]
 fn test_delta_negative_deltas_allowed() {
     let parent = create_test_snapshot("parent123", "grandparent");
-    
+
     // Create current with lower metrics (should produce negative deltas)
     let git_context = git::GitContext {
         head_sha: "current123".to_string(),
@@ -212,13 +216,18 @@ fn test_delta_negative_deltas_allowed() {
         branch: Some("main".to_string()),
         is_detached: false,
     };
-    
+
     let report = FunctionRiskReport {
         file: "src/foo.ts".to_string(),
         function: "handler".to_string(),
         line: 42,
         language: "TypeScript".to_string(),
-        metrics: MetricsReport { cc: 3, nd: 1, fo: 1, ns: 0 }, // Lower than parent
+        metrics: MetricsReport {
+            cc: 3,
+            nd: 1,
+            fo: 1,
+            ns: 0,
+        }, // Lower than parent
         risk: RiskReport {
             r_cc: 2.0,
             r_nd: 1.0,
@@ -229,12 +238,11 @@ fn test_delta_negative_deltas_allowed() {
         band: "low".to_string(),
         suppression_reason: None,
     };
-    
+
     let current = snapshot::Snapshot::new(git_context, vec![report]);
-    
-    let delta = delta::Delta::new(&current, Some(&parent))
-        .expect("should create delta");
-    
+
+    let delta = delta::Delta::new(&current, Some(&parent)).expect("should create delta");
+
     let delta_values = delta.deltas[0].delta.as_ref().unwrap();
     assert!(
         delta_values.cc < 0,
@@ -249,7 +257,7 @@ fn test_delta_negative_deltas_allowed() {
 #[test]
 fn test_delta_deleted_functions_explicit() {
     let parent = create_test_snapshot("parent123", "grandparent");
-    
+
     // Current has no functions (all deleted)
     let git_context = git::GitContext {
         head_sha: "current123".to_string(),
@@ -259,12 +267,12 @@ fn test_delta_deleted_functions_explicit() {
         is_detached: false,
     };
     let current = snapshot::Snapshot::new(git_context, vec![]);
-    
-    let delta = delta::Delta::new(&current, Some(&parent))
-        .expect("should create delta");
-    
+
+    let delta = delta::Delta::new(&current, Some(&parent)).expect("should create delta");
+
     assert_eq!(
-        delta.deltas.len(), 1,
+        delta.deltas.len(),
+        1,
         "deleted function must appear in delta"
     );
     assert_eq!(

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -338,7 +338,9 @@ fn test_java_golden(fixture_name: &str) {
         .join("fixtures")
         .join("java")
         .join(format!("{}.java", fixture_name));
-    let golden = golden_path(&format!("java-{}.json", fixture_name));
+    // Golden files use lowercase/snake_case names
+    let golden_name = fixture_name.to_lowercase();
+    let golden = golden_path(&format!("java-{}.json", golden_name));
     let project_root = project_root();
 
     let options = AnalysisOptions {
@@ -350,7 +352,7 @@ fn test_java_golden(fixture_name: &str) {
         .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
 
     let output = render_json(&reports);
-    let expected = read_golden(&format!("java-{}.json", fixture_name));
+    let expected = read_golden(&format!("java-{}.json", golden_name));
 
     // Parse both as JSON for comparison (handles formatting differences)
     let mut output_json: serde_json::Value =

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -23,7 +23,10 @@ fn golden_path(name: &str) -> PathBuf {
 }
 
 fn project_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).parent().unwrap().to_path_buf()
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
 }
 
 fn read_golden(name: &str) -> String {
@@ -71,28 +74,28 @@ fn test_golden(fixture_name: &str) {
     let fixture = fixture_path(&format!("{}.ts", fixture_name));
     let golden = golden_path(&format!("{}.json", fixture_name));
     let project_root = project_root();
-    
+
     let options = AnalysisOptions {
         min_lrs: None,
         top_n: None,
     };
-    
+
     let reports = analyze(&fixture, options)
         .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
-    
+
     let output = render_json(&reports);
     let expected = read_golden(&format!("{}.json", fixture_name));
-    
+
     // Parse both as JSON for comparison (handles formatting differences)
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
-    
+
     // Normalize paths in both JSON values before comparison
     normalize_paths(&mut output_json, &project_root);
     normalize_paths(&mut expected_json, &project_root);
-    
+
     assert_eq!(
         output_json, expected_json,
         "Output does not match golden file for {}",
@@ -144,7 +147,10 @@ fn test_golden_determinism() {
     let json1 = render_json(&reports1);
     let json2 = render_json(&reports2);
 
-    assert_eq!(json1, json2, "Output must be byte-for-byte identical across runs");
+    assert_eq!(
+        json1, json2,
+        "Output must be byte-for-byte identical across runs"
+    );
 }
 
 // Go language golden tests
@@ -172,8 +178,8 @@ fn test_go_golden(fixture_name: &str) {
     let expected = read_golden(&format!("go-{}.json", fixture_name));
 
     // Parse both as JSON for comparison (handles formatting differences)
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
 
@@ -233,7 +239,10 @@ fn test_go_golden_determinism() {
     let json1 = render_json(&reports1);
     let json2 = render_json(&reports2);
 
-    assert_eq!(json1, json2, "Go output must be byte-for-byte identical across runs");
+    assert_eq!(
+        json1, json2,
+        "Go output must be byte-for-byte identical across runs"
+    );
 }
 
 // Rust language golden tests
@@ -261,8 +270,8 @@ fn test_rust_golden(fixture_name: &str) {
     let expected = read_golden(&format!("rust-{}.json", fixture_name));
 
     // Parse both as JSON for comparison (handles formatting differences)
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
 
@@ -322,7 +331,10 @@ fn test_rust_golden_determinism() {
     let json1 = render_json(&reports1);
     let json2 = render_json(&reports2);
 
-    assert_eq!(json1, json2, "Rust output must be byte-for-byte identical across runs");
+    assert_eq!(
+        json1, json2,
+        "Rust output must be byte-for-byte identical across runs"
+    );
 }
 
 // Java language golden tests
@@ -350,8 +362,8 @@ fn test_java_golden(fixture_name: &str) {
     let expected = read_golden(&format!("java-{}.json", fixture_name));
 
     // Parse both as JSON for comparison (handles formatting differences)
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
 
@@ -410,8 +422,8 @@ fn test_java_golden_anonymous_class() {
     let output = render_json(&reports);
     let expected = read_golden("java-anonymous_class.json");
 
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
 
@@ -448,8 +460,8 @@ fn test_java_golden_java_specific() {
     let output = render_json(&reports);
     let expected = read_golden("java-java_specific.json");
 
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
 
@@ -486,8 +498,8 @@ fn test_java_golden_switch_and_ternary() {
     let output = render_json(&reports);
     let expected = read_golden("java-switch_and_ternary.json");
 
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
 
@@ -525,7 +537,10 @@ fn test_java_golden_determinism() {
     let json1 = render_json(&reports1);
     let json2 = render_json(&reports2);
 
-    assert_eq!(json1, json2, "Java output must be byte-for-byte identical across runs");
+    assert_eq!(
+        json1, json2,
+        "Java output must be byte-for-byte identical across runs"
+    );
 }
 
 // Python language golden tests
@@ -553,8 +568,8 @@ fn test_python_golden(fixture_name: &str) {
     let expected = read_golden(&format!("python-{}.json", fixture_name));
 
     // Parse both as JSON for comparison (handles formatting differences)
-    let mut output_json: serde_json::Value = serde_json::from_str(&output)
-        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
     let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
         .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
 
@@ -629,5 +644,8 @@ fn test_python_golden_determinism() {
     let json1 = render_json(&reports1);
     let json2 = render_json(&reports2);
 
-    assert_eq!(json1, json2, "Python output must be byte-for-byte identical across runs");
+    assert_eq!(
+        json1, json2,
+        "Python output must be byte-for-byte identical across runs"
+    );
 }

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -35,8 +35,8 @@ fn read_golden(name: &str) -> String {
         .unwrap_or_else(|e| panic!("Failed to read golden file {}: {}", path.display(), e))
 }
 
-/// Normalize paths in JSON to use the actual project root for portability
-/// Strips the project root prefix and reconstructs using the current project root
+/// Normalize paths in JSON to use relative paths for cross-platform portability
+/// Strips the project root prefix to get a relative path that works everywhere
 fn normalize_paths(json: &mut serde_json::Value, project_root: &PathBuf) {
     match json {
         serde_json::Value::Array(arr) => {
@@ -49,8 +49,8 @@ fn normalize_paths(json: &mut serde_json::Value, project_root: &PathBuf) {
                 let path_buf = PathBuf::from(path.as_str());
                 // Strip the project root prefix to get the relative path
                 if let Ok(relative) = path_buf.strip_prefix(project_root) {
-                    // Reconstruct using the current project root
-                    *path = project_root.join(relative).to_string_lossy().to_string();
+                    // Use relative path with forward slashes for cross-platform compatibility
+                    *path = relative.to_string_lossy().replace('\\', "/");
                 }
             }
             for (_, value) in obj {

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -36,7 +36,7 @@ fn read_golden(name: &str) -> String {
 }
 
 /// Normalize paths in JSON to use the actual project root for portability
-/// Extracts the path segment after "hotspots/" and normalizes to use the current project root
+/// Strips the project root prefix and reconstructs using the current project root
 fn normalize_paths(json: &mut serde_json::Value, project_root: &PathBuf) {
     match json {
         serde_json::Value::Array(arr) => {
@@ -46,20 +46,11 @@ fn normalize_paths(json: &mut serde_json::Value, project_root: &PathBuf) {
         }
         serde_json::Value::Object(obj) => {
             if let Some(serde_json::Value::String(path)) = obj.get_mut("file") {
-                // Extract path segment after "hotspots/" - this is the relative path within the project
-                let path_str = path.as_str();
-                if let Some(idx) = path_str.find("hotspots/") {
-                    let suffix = &path_str[idx + "hotspots/".len()..];
-                    // Normalize to use the actual project root (no hardcoded paths)
-                    *path = project_root.join(suffix).to_string_lossy().to_string();
-                } else if let Some(idx) = path_str.find("hotspots") {
-                    // Handle case where "hotspots" is not followed by "/"
-                    if let Some(next_char) = path_str.chars().nth(idx + "hotspots".len()) {
-                        if next_char == '/' || next_char == '\\' {
-                            let suffix = &path_str[idx + "hotspots".len() + 1..];
-                            *path = project_root.join(suffix).to_string_lossy().to_string();
-                        }
-                    }
+                let path_buf = PathBuf::from(path.as_str());
+                // Strip the project root prefix to get the relative path
+                if let Ok(relative) = path_buf.strip_prefix(project_root) {
+                    // Reconstruct using the current project root
+                    *path = project_root.join(relative).to_string_lossy().to_string();
                 }
             }
             for (_, value) in obj {

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -324,3 +324,310 @@ fn test_rust_golden_determinism() {
 
     assert_eq!(json1, json2, "Rust output must be byte-for-byte identical across runs");
 }
+
+// Java language golden tests
+
+fn test_java_golden(fixture_name: &str) {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("java")
+        .join(format!("{}.java", fixture_name));
+    let golden = golden_path(&format!("java-{}.json", fixture_name));
+    let project_root = project_root();
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&fixture, options)
+        .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
+
+    let output = render_json(&reports);
+    let expected = read_golden(&format!("java-{}.json", fixture_name));
+
+    // Parse both as JSON for comparison (handles formatting differences)
+    let mut output_json: serde_json::Value = serde_json::from_str(&output)
+        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
+
+    // Normalize paths in both JSON values before comparison
+    normalize_paths(&mut output_json, &project_root);
+    normalize_paths(&mut expected_json, &project_root);
+
+    assert_eq!(
+        output_json, expected_json,
+        "Output does not match golden file for {}",
+        fixture_name
+    );
+}
+
+#[test]
+fn test_java_golden_simple() {
+    test_java_golden("Simple");
+}
+
+#[test]
+fn test_java_golden_loops() {
+    test_java_golden("Loops");
+}
+
+#[test]
+fn test_java_golden_exceptions() {
+    test_java_golden("Exceptions");
+}
+
+#[test]
+fn test_java_golden_classes() {
+    test_java_golden("Classes");
+}
+
+#[test]
+fn test_java_golden_anonymous_class() {
+    // Fixture: AnonymousClass.java, Golden: java-anonymous_class.json
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("java")
+        .join("AnonymousClass.java");
+    let golden = golden_path("java-anonymous_class.json");
+    let project_root = project_root();
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&fixture, options)
+        .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
+
+    let output = render_json(&reports);
+    let expected = read_golden("java-anonymous_class.json");
+
+    let mut output_json: serde_json::Value = serde_json::from_str(&output)
+        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
+
+    normalize_paths(&mut output_json, &project_root);
+    normalize_paths(&mut expected_json, &project_root);
+
+    assert_eq!(
+        output_json, expected_json,
+        "Output does not match golden file for anonymous_class"
+    );
+}
+
+#[test]
+fn test_java_golden_java_specific() {
+    // Fixture: JavaSpecific.java, Golden: java-java_specific.json
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("java")
+        .join("JavaSpecific.java");
+    let golden = golden_path("java-java_specific.json");
+    let project_root = project_root();
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&fixture, options)
+        .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
+
+    let output = render_json(&reports);
+    let expected = read_golden("java-java_specific.json");
+
+    let mut output_json: serde_json::Value = serde_json::from_str(&output)
+        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
+
+    normalize_paths(&mut output_json, &project_root);
+    normalize_paths(&mut expected_json, &project_root);
+
+    assert_eq!(
+        output_json, expected_json,
+        "Output does not match golden file for java_specific"
+    );
+}
+
+#[test]
+fn test_java_golden_switch_and_ternary() {
+    // Fixture: SwitchAndTernary.java, Golden: java-switch_and_ternary.json
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("java")
+        .join("SwitchAndTernary.java");
+    let golden = golden_path("java-switch_and_ternary.json");
+    let project_root = project_root();
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&fixture, options)
+        .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
+
+    let output = render_json(&reports);
+    let expected = read_golden("java-switch_and_ternary.json");
+
+    let mut output_json: serde_json::Value = serde_json::from_str(&output)
+        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
+
+    normalize_paths(&mut output_json, &project_root);
+    normalize_paths(&mut expected_json, &project_root);
+
+    assert_eq!(
+        output_json, expected_json,
+        "Output does not match golden file for switch_and_ternary"
+    );
+}
+
+#[test]
+fn test_java_golden_determinism() {
+    // Test that running Java analysis twice produces identical output
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("java")
+        .join("Simple.java");
+    let options1 = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    let options2 = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports1 = analyze(&fixture, options1).unwrap();
+    let reports2 = analyze(&fixture, options2).unwrap();
+
+    let json1 = render_json(&reports1);
+    let json2 = render_json(&reports2);
+
+    assert_eq!(json1, json2, "Java output must be byte-for-byte identical across runs");
+}
+
+// Python language golden tests
+
+fn test_python_golden(fixture_name: &str) {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("python")
+        .join(format!("{}.py", fixture_name));
+    let golden = golden_path(&format!("python-{}.json", fixture_name));
+    let project_root = project_root();
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&fixture, options)
+        .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
+
+    let output = render_json(&reports);
+    let expected = read_golden(&format!("python-{}.json", fixture_name));
+
+    // Parse both as JSON for comparison (handles formatting differences)
+    let mut output_json: serde_json::Value = serde_json::from_str(&output)
+        .unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
+
+    // Normalize paths in both JSON values before comparison
+    normalize_paths(&mut output_json, &project_root);
+    normalize_paths(&mut expected_json, &project_root);
+
+    assert_eq!(
+        output_json, expected_json,
+        "Output does not match golden file for {}",
+        fixture_name
+    );
+}
+
+#[test]
+fn test_python_golden_simple() {
+    test_python_golden("simple");
+}
+
+#[test]
+fn test_python_golden_loops() {
+    test_python_golden("loops");
+}
+
+#[test]
+fn test_python_golden_exceptions() {
+    test_python_golden("exceptions");
+}
+
+#[test]
+fn test_python_golden_classes() {
+    test_python_golden("classes");
+}
+
+#[test]
+fn test_python_golden_boolean_ops() {
+    test_python_golden("boolean_ops");
+}
+
+#[test]
+fn test_python_golden_comprehensions() {
+    test_python_golden("comprehensions");
+}
+
+#[test]
+fn test_python_golden_python_specific() {
+    test_python_golden("python_specific");
+}
+
+#[test]
+fn test_python_golden_determinism() {
+    // Test that running Python analysis twice produces identical output
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("python")
+        .join("simple.py");
+    let options1 = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    let options2 = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports1 = analyze(&fixture, options1).unwrap();
+    let reports2 = analyze(&fixture, options2).unwrap();
+
+    let json1 = render_json(&reports1);
+    let json2 = render_json(&reports2);
+
+    assert_eq!(json1, json2, "Python output must be byte-for-byte identical across runs");
+}

--- a/hotspots-core/tests/integration_tests.rs
+++ b/hotspots-core/tests/integration_tests.rs
@@ -19,7 +19,7 @@ fn test_simple_function() {
         min_lrs: None,
         top_n: None,
     };
-    
+
     let reports = analyze(&path, options).unwrap();
     assert_eq!(reports.len(), 1);
     assert_eq!(reports[0].function, "simple");
@@ -32,11 +32,17 @@ fn test_nested_branching() {
         min_lrs: None,
         top_n: None,
     };
-    
+
     let reports = analyze(&path, options).unwrap();
     assert_eq!(reports.len(), 1);
-    assert!(reports[0].metrics.cc > 1, "Nested branching should increase CC");
-    assert!(reports[0].metrics.nd >= 2, "Should have nesting depth of at least 2");
+    assert!(
+        reports[0].metrics.cc > 1,
+        "Nested branching should increase CC"
+    );
+    assert!(
+        reports[0].metrics.nd >= 2,
+        "Should have nesting depth of at least 2"
+    );
 }
 
 #[test]
@@ -46,10 +52,13 @@ fn test_loop_with_breaks() {
         min_lrs: None,
         top_n: None,
     };
-    
+
     let reports = analyze(&path, options).unwrap();
     assert_eq!(reports.len(), 1);
-    assert!(reports[0].metrics.ns > 0, "Breaks and continues should be counted");
+    assert!(
+        reports[0].metrics.ns > 0,
+        "Breaks and continues should be counted"
+    );
 }
 
 #[test]
@@ -59,11 +68,17 @@ fn test_try_catch_finally() {
         min_lrs: None,
         top_n: None,
     };
-    
+
     let reports = analyze(&path, options).unwrap();
     assert_eq!(reports.len(), 1);
-    assert!(reports[0].metrics.cc >= 2, "Try/catch should contribute to CC");
-    assert!(reports[0].metrics.nd >= 1, "Try should increase nesting depth");
+    assert!(
+        reports[0].metrics.cc >= 2,
+        "Try/catch should contribute to CC"
+    );
+    assert!(
+        reports[0].metrics.nd >= 1,
+        "Try should increase nesting depth"
+    );
 }
 
 #[test]
@@ -73,12 +88,18 @@ fn test_pathological_complexity() {
         min_lrs: None,
         top_n: None,
     };
-    
+
     let reports = analyze(&path, options).unwrap();
     assert_eq!(reports.len(), 1);
     // Pathological function should have high complexity
-    assert!(reports[0].metrics.cc > 5, "Pathological function should have high CC");
-    assert!(reports[0].lrs > 5.0, "Pathological function should have high LRS");
+    assert!(
+        reports[0].metrics.cc > 5,
+        "Pathological function should have high CC"
+    );
+    assert!(
+        reports[0].lrs > 5.0,
+        "Pathological function should have high LRS"
+    );
 }
 
 #[test]
@@ -92,15 +113,15 @@ fn test_deterministic_output() {
         min_lrs: None,
         top_n: None,
     };
-    
+
     // Run analysis twice
     let reports1 = analyze(&path, options1).unwrap();
     let reports2 = analyze(&path, options2).unwrap();
-    
+
     // Output should be identical
     let json1 = render_json(&reports1);
     let json2 = render_json(&reports2);
-    
+
     assert_eq!(json1, json2, "Output should be byte-for-byte identical");
 }
 
@@ -116,16 +137,16 @@ fn test_whitespace_invariance() {
         min_lrs: None,
         top_n: None,
     };
-    
+
     let reports = analyze(&path, options1).unwrap();
     let lrs1 = reports[0].lrs;
     let cc1 = reports[0].metrics.cc;
-    
+
     // Re-run should produce same results
     let reports2 = analyze(&path, options2).unwrap();
     let lrs2 = reports2[0].lrs;
     let cc2 = reports2[0].metrics.cc;
-    
+
     assert_eq!(lrs1, lrs2);
     assert_eq!(cc1, cc2);
 }

--- a/hotspots-core/tests/jsx_parity_tests.rs
+++ b/hotspots-core/tests/jsx_parity_tests.rs
@@ -119,8 +119,7 @@ fn test_jsx_elements_dont_inflate_complexity() {
         top_n: None,
     };
 
-    let reports = analyze(&tsx_path, options)
-        .expect("Should analyze simple TSX component");
+    let reports = analyze(&tsx_path, options).expect("Should analyze simple TSX component");
 
     assert_eq!(reports.len(), 1, "Should find exactly one function");
 
@@ -132,7 +131,10 @@ fn test_jsx_elements_dont_inflate_complexity() {
     assert_eq!(report.metrics.nd, 0, "JSX elements should not increase ND");
     assert_eq!(report.metrics.fo, 0, "JSX elements should not increase FO");
     assert_eq!(report.metrics.ns, 0, "JSX elements should not increase NS");
-    assert_eq!(report.lrs, 1.0, "Simple JSX component should have LRS of 1.0");
+    assert_eq!(
+        report.lrs, 1.0,
+        "Simple JSX component should have LRS of 1.0"
+    );
 }
 
 /// Test that control flow in JSX expressions IS counted
@@ -145,8 +147,8 @@ fn test_jsx_control_flow_is_counted() {
         top_n: None,
     };
 
-    let reports = analyze(&tsx_path, options)
-        .expect("Should analyze conditional rendering component");
+    let reports =
+        analyze(&tsx_path, options).expect("Should analyze conditional rendering component");
 
     assert_eq!(reports.len(), 1, "Should find exactly one function");
 
@@ -178,8 +180,7 @@ fn test_multiple_functions_in_jsx_file() {
         top_n: None,
     };
 
-    let reports = analyze(&tsx_path, options)
-        .expect("Should analyze complex component");
+    let reports = analyze(&tsx_path, options).expect("Should analyze complex component");
 
     // Should find: ComplexComponent, handleClick, map callback, onClick handlers
     assert!(
@@ -189,7 +190,8 @@ fn test_multiple_functions_in_jsx_file() {
     );
 
     // Verify ComplexComponent exists
-    let main_component = reports.iter()
+    let main_component = reports
+        .iter()
         .find(|r| r.function == "ComplexComponent")
         .expect("Should find ComplexComponent function");
 

--- a/hotspots-core/tests/language_parity_tests.rs
+++ b/hotspots-core/tests/language_parity_tests.rs
@@ -28,16 +28,16 @@ fn test_typescript_javascript_parity() {
         };
 
         // Analyze TypeScript version
-        let ts_reports = analyze(&ts_path, options)
-            .unwrap_or_else(|_| panic!("Failed to analyze {}", ts_file));
+        let ts_reports =
+            analyze(&ts_path, options).unwrap_or_else(|_| panic!("Failed to analyze {}", ts_file));
 
         // Analyze JavaScript version
         let options = AnalysisOptions {
             min_lrs: None,
             top_n: None,
         };
-        let js_reports = analyze(&js_path, options)
-            .unwrap_or_else(|_| panic!("Failed to analyze {}", js_file));
+        let js_reports =
+            analyze(&js_path, options).unwrap_or_else(|_| panic!("Failed to analyze {}", js_file));
 
         // Both should have same number of functions
         assert_eq!(
@@ -156,10 +156,8 @@ fn test_javascript_module_extensions() {
     };
 
     // Both should parse and analyze successfully
-    let mjs_reports = analyze(&mjs_file, options1)
-        .expect("Should analyze .mjs files");
-    let cjs_reports = analyze(&cjs_file, options2)
-        .expect("Should analyze .cjs files");
+    let mjs_reports = analyze(&mjs_file, options1).expect("Should analyze .mjs files");
+    let cjs_reports = analyze(&cjs_file, options2).expect("Should analyze .cjs files");
 
     assert_eq!(mjs_reports.len(), 1, "Should find function in .mjs file");
     assert_eq!(cjs_reports.len(), 1, "Should find function in .cjs file");
@@ -193,10 +191,8 @@ fn test_typescript_module_extensions() {
     };
 
     // Both should parse and analyze successfully
-    let mts_reports = analyze(&mts_file, options1)
-        .expect("Should analyze .mts files");
-    let cts_reports = analyze(&cts_file, options2)
-        .expect("Should analyze .cts files");
+    let mts_reports = analyze(&mts_file, options1).expect("Should analyze .mts files");
+    let cts_reports = analyze(&cts_file, options2).expect("Should analyze .cts files");
 
     assert_eq!(mts_reports.len(), 1, "Should find function in .mts file");
     assert_eq!(cts_reports.len(), 1, "Should find function in .cts file");

--- a/hotspots-core/tests/suppression_tests.rs
+++ b/hotspots-core/tests/suppression_tests.rs
@@ -130,8 +130,7 @@ fn test_suppression_missing_reason_policy() {
     assert_eq!(results.warnings.len(), 1);
     assert_eq!(results.warnings[0].id, PolicyId::SuppressionMissingReason);
     assert_eq!(results.warnings[0].severity, PolicySeverity::Warning);
-    assert!(results
-        .warnings[0]
+    assert!(results.warnings[0]
         .message
         .contains("suppressed without reason"));
 }

--- a/tests/golden/go-go_specific.json
+++ b/tests/golden/go-go_specific.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "ComplexGoFunction",
     "line": 113,
     "language": "Go",
@@ -20,7 +20,7 @@
     "band": "critical"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "SelectInLoop",
     "line": 99,
     "language": "Go",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "MultipleDefers",
     "line": 16,
     "language": "Go",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "SelectWithDefault",
     "line": 84,
     "language": "Go",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "ConditionalDefer",
     "line": 24,
     "language": "Go",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "WithPanic",
     "line": 52,
     "language": "Go",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "WithRecover",
     "line": 60,
     "language": "Go",
@@ -140,7 +140,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "SimpleSelect",
     "line": 70,
     "language": "Go",
@@ -160,7 +160,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "GoroutineAndDefer",
     "line": 45,
     "language": "Go",
@@ -180,7 +180,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "MultipleGoroutines",
     "line": 38,
     "language": "Go",
@@ -200,7 +200,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "WithDefer",
     "line": 10,
     "language": "Go",
@@ -220,7 +220,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "WithGoroutine",
     "line": 32,
     "language": "Go",
@@ -240,7 +240,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "cleanup",
     "line": 154,
     "language": "Go",
@@ -260,7 +260,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "doWork",
     "line": 155,
     "language": "Go",
@@ -280,7 +280,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/go_specific.go",
+    "file": "tests/fixtures/go/go_specific.go",
     "function": "doOtherWork",
     "line": 156,
     "language": "Go",

--- a/tests/golden/go-loops.json
+++ b/tests/golden/go-loops.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "LoopWithCondition",
     "line": 13,
     "language": "Go",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "NestedLoops",
     "line": 23,
     "language": "Go",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "LoopWithBreak",
     "line": 33,
     "language": "Go",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "LoopWithContinue",
     "line": 43,
     "language": "Go",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "InfiniteLoop",
     "line": 72,
     "language": "Go",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "SimpleLoop",
     "line": 5,
     "language": "Go",
@@ -120,7 +120,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "RangeLoop",
     "line": 54,
     "language": "Go",
@@ -140,7 +140,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/loops.go",
+    "file": "tests/fixtures/go/loops.go",
     "function": "WhileStyleLoop",
     "line": 63,
     "language": "Go",

--- a/tests/golden/go-simple.json
+++ b/tests/golden/go-simple.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/simple.go",
+    "file": "tests/fixtures/go/simple.go",
     "function": "MultipleReturns",
     "line": 39,
     "language": "Go",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/simple.go",
+    "file": "tests/fixtures/go/simple.go",
     "function": "IfElse",
     "line": 20,
     "language": "Go",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/simple.go",
+    "file": "tests/fixtures/go/simple.go",
     "function": "EarlyReturn",
     "line": 30,
     "language": "Go",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/simple.go",
+    "file": "tests/fixtures/go/simple.go",
     "function": "SingleBranch",
     "line": 12,
     "language": "Go",
@@ -80,7 +80,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/simple.go",
+    "file": "tests/fixtures/go/simple.go",
     "function": "Simple",
     "line": 5,
     "language": "Go",

--- a/tests/golden/go-switch.json
+++ b/tests/golden/go-switch.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/switch.go",
+    "file": "tests/fixtures/go/switch.go",
     "function": "SimpleSwitch",
     "line": 5,
     "language": "Go",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/switch.go",
+    "file": "tests/fixtures/go/switch.go",
     "function": "NestedSwitch",
     "line": 45,
     "language": "Go",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/switch.go",
+    "file": "tests/fixtures/go/switch.go",
     "function": "SwitchWithFallthrough",
     "line": 29,
     "language": "Go",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/switch.go",
+    "file": "tests/fixtures/go/switch.go",
     "function": "TypeSwitch",
     "line": 72,
     "language": "Go",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/switch.go",
+    "file": "tests/fixtures/go/switch.go",
     "function": "SwitchNoDefault",
     "line": 18,
     "language": "Go",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/switch.go",
+    "file": "tests/fixtures/go/switch.go",
     "function": "ExpressionSwitch",
     "line": 61,
     "language": "Go",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/go/switch.go",
+    "file": "tests/fixtures/go/switch.go",
     "function": "SwitchMultipleValues",
     "line": 85,
     "language": "Go",

--- a/tests/golden/java-anonymous_class.json
+++ b/tests/golden/java-anonymous_class.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/AnonymousClass.java",
+    "file": "tests/fixtures/java/AnonymousClass.java",
     "function": "run",
     "line": 4,
     "language": "Java",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/AnonymousClass.java",
+    "file": "tests/fixtures/java/AnonymousClass.java",
     "function": "useAnonymousClass",
     "line": 2,
     "language": "Java",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/AnonymousClass.java",
+    "file": "tests/fixtures/java/AnonymousClass.java",
     "function": "doSomething",
     "line": 17,
     "language": "Java",
@@ -60,7 +60,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/AnonymousClass.java",
+    "file": "tests/fixtures/java/AnonymousClass.java",
     "function": "someCondition",
     "line": 13,
     "language": "Java",

--- a/tests/golden/java-classes.json
+++ b/tests/golden/java-classes.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Classes.java",
+    "file": "tests/fixtures/java/Classes.java",
     "function": "Classes",
     "line": 4,
     "language": "Java",
@@ -20,7 +20,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Classes.java",
+    "file": "tests/fixtures/java/Classes.java",
     "function": "instanceMethod",
     "line": 8,
     "language": "Java",
@@ -40,7 +40,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Classes.java",
+    "file": "tests/fixtures/java/Classes.java",
     "function": "staticMethod",
     "line": 12,
     "language": "Java",
@@ -60,7 +60,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Classes.java",
+    "file": "tests/fixtures/java/Classes.java",
     "function": "innerMethod",
     "line": 17,
     "language": "Java",

--- a/tests/golden/java-exceptions.json
+++ b/tests/golden/java-exceptions.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Exceptions.java",
+    "file": "tests/fixtures/java/Exceptions.java",
     "function": "multipleCatchClauses",
     "line": 6,
     "language": "Java",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Exceptions.java",
+    "file": "tests/fixtures/java/Exceptions.java",
     "function": "tryWithResources",
     "line": 19,
     "language": "Java",

--- a/tests/golden/java-java_specific.json
+++ b/tests/golden/java-java_specific.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/JavaSpecific.java",
+    "file": "tests/fixtures/java/JavaSpecific.java",
     "function": "lambdaExpression",
     "line": 5,
     "language": "Java",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/JavaSpecific.java",
+    "file": "tests/fixtures/java/JavaSpecific.java",
     "function": "streamOperations",
     "line": 13,
     "language": "Java",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/JavaSpecific.java",
+    "file": "tests/fixtures/java/JavaSpecific.java",
     "function": "switchExpression",
     "line": 20,
     "language": "Java",
@@ -60,7 +60,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/JavaSpecific.java",
+    "file": "tests/fixtures/java/JavaSpecific.java",
     "function": "synchronizedMethod",
     "line": 28,
     "language": "Java",

--- a/tests/golden/java-loops.json
+++ b/tests/golden/java-loops.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Loops.java",
+    "file": "tests/fixtures/java/Loops.java",
     "function": "nestedLoops",
     "line": 27,
     "language": "Java",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Loops.java",
+    "file": "tests/fixtures/java/Loops.java",
     "function": "forLoopWithBreak",
     "line": 18,
     "language": "Java",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Loops.java",
+    "file": "tests/fixtures/java/Loops.java",
     "function": "whileLoop",
     "line": 2,
     "language": "Java",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Loops.java",
+    "file": "tests/fixtures/java/Loops.java",
     "function": "doWhileLoop",
     "line": 10,
     "language": "Java",

--- a/tests/golden/java-simple.json
+++ b/tests/golden/java-simple.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Simple.java",
+    "file": "tests/fixtures/java/Simple.java",
     "function": "withEarlyReturn",
     "line": 6,
     "language": "Java",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/Simple.java",
+    "file": "tests/fixtures/java/Simple.java",
     "function": "simpleMethod",
     "line": 2,
     "language": "Java",

--- a/tests/golden/java-switch_and_ternary.json
+++ b/tests/golden/java-switch_and_ternary.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/SwitchAndTernary.java",
+    "file": "tests/fixtures/java/SwitchAndTernary.java",
     "function": "traditionalSwitch",
     "line": 2,
     "language": "Java",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/SwitchAndTernary.java",
+    "file": "tests/fixtures/java/SwitchAndTernary.java",
     "function": "booleanOperators",
     "line": 19,
     "language": "Java",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/java/SwitchAndTernary.java",
+    "file": "tests/fixtures/java/SwitchAndTernary.java",
     "function": "ternaryExpression",
     "line": 15,
     "language": "Java",

--- a/tests/golden/loop-breaks.json
+++ b/tests/golden/loop-breaks.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/loop-breaks.ts",
+    "file": "tests/fixtures/loop-breaks.ts",
     "function": "loopWithBreaks",
     "line": 2,
     "language": "TypeScript",

--- a/tests/golden/nested-branching.json
+++ b/tests/golden/nested-branching.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/nested-branching.ts",
+    "file": "tests/fixtures/nested-branching.ts",
     "function": "nested",
     "line": 2,
     "language": "TypeScript",

--- a/tests/golden/pathological.json
+++ b/tests/golden/pathological.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/pathological.ts",
+    "file": "tests/fixtures/pathological.ts",
     "function": "pathological",
     "line": 2,
     "language": "TypeScript",

--- a/tests/golden/python-boolean_ops.json
+++ b/tests/golden/python-boolean_ops.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "complex_boolean",
     "line": 22,
     "language": "Python",
@@ -20,7 +20,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "walrus_operator",
     "line": 52,
     "language": "Python",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "boolean_and_or",
     "line": 15,
     "language": "Python",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "boolean_and",
     "line": 1,
     "language": "Python",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "boolean_or",
     "line": 8,
     "language": "Python",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "nested_ternary",
     "line": 36,
     "language": "Python",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "boolean_in_return",
     "line": 47,
     "language": "Python",
@@ -140,7 +140,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "ternary_expression",
     "line": 31,
     "language": "Python",
@@ -160,7 +160,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/boolean_ops.py",
+    "file": "tests/fixtures/python/boolean_ops.py",
     "function": "ternary_in_assignment",
     "line": 41,
     "language": "Python",

--- a/tests/golden/python-classes.json
+++ b/tests/golden/python-classes.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/classes.py",
+    "file": "tests/fixtures/python/classes.py",
     "function": "async_method",
     "line": 39,
     "language": "Python",
@@ -20,7 +20,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/classes.py",
+    "file": "tests/fixtures/python/classes.py",
     "function": "method_with_exception_handling",
     "line": 30,
     "language": "Python",
@@ -40,7 +40,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/classes.py",
+    "file": "tests/fixtures/python/classes.py",
     "function": "static_method",
     "line": 22,
     "language": "Python",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/classes.py",
+    "file": "tests/fixtures/python/classes.py",
     "function": "class_method",
     "line": 15,
     "language": "Python",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/classes.py",
+    "file": "tests/fixtures/python/classes.py",
     "function": "instance_method",
     "line": 8,
     "language": "Python",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/classes.py",
+    "file": "tests/fixtures/python/classes.py",
     "function": "__init__",
     "line": 4,
     "language": "Python",

--- a/tests/golden/python-comprehensions.json
+++ b/tests/golden/python-comprehensions.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "complex_comprehension",
     "line": 31,
     "language": "Python",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "filtered_list_comp",
     "line": 6,
     "language": "Python",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "dict_comprehension_filtered",
     "line": 11,
     "language": "Python",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "set_comprehension_filtered",
     "line": 16,
     "language": "Python",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "nested_comp_with_filter",
     "line": 26,
     "language": "Python",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "generator_expression",
     "line": 42,
     "language": "Python",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "simple_list_comp",
     "line": 1,
     "language": "Python",
@@ -140,7 +140,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/comprehensions.py",
+    "file": "tests/fixtures/python/comprehensions.py",
     "function": "nested_comp",
     "line": 21,
     "language": "Python",

--- a/tests/golden/python-exceptions.json
+++ b/tests/golden/python-exceptions.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/exceptions.py",
+    "file": "tests/fixtures/python/exceptions.py",
     "function": "except_with_finally",
     "line": 24,
     "language": "Python",
@@ -20,7 +20,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/exceptions.py",
+    "file": "tests/fixtures/python/exceptions.py",
     "function": "multiple_except_clauses",
     "line": 10,
     "language": "Python",
@@ -40,7 +40,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/exceptions.py",
+    "file": "tests/fixtures/python/exceptions.py",
     "function": "nested_try_blocks",
     "line": 40,
     "language": "Python",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/exceptions.py",
+    "file": "tests/fixtures/python/exceptions.py",
     "function": "single_except_clause",
     "line": 1,
     "language": "Python",

--- a/tests/golden/python-loops.json
+++ b/tests/golden/python-loops.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/loops.py",
+    "file": "tests/fixtures/python/loops.py",
     "function": "nested_loops",
     "line": 29,
     "language": "Python",
@@ -20,7 +20,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/loops.py",
+    "file": "tests/fixtures/python/loops.py",
     "function": "async_for_loop",
     "line": 42,
     "language": "Python",
@@ -40,7 +40,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/loops.py",
+    "file": "tests/fixtures/python/loops.py",
     "function": "for_loop_with_break",
     "line": 9,
     "language": "Python",
@@ -60,7 +60,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/loops.py",
+    "file": "tests/fixtures/python/loops.py",
     "function": "for_loop_with_continue",
     "line": 19,
     "language": "Python",
@@ -80,7 +80,7 @@
     "band": "high"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/loops.py",
+    "file": "tests/fixtures/python/loops.py",
     "function": "while_loop",
     "line": 1,
     "language": "Python",

--- a/tests/golden/python-python_specific.json
+++ b/tests/golden/python-python_specific.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "async_for_with_filter",
     "line": 30,
     "language": "Python",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "match_statement",
     "line": 39,
     "language": "Python",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "match_with_guard",
     "line": 52,
     "language": "Python",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "nested_context_managers",
     "line": 7,
     "language": "Python",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "with_context_manager",
     "line": 1,
     "language": "Python",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "async_function",
     "line": 24,
     "language": "Python",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "list_comprehension_filtered",
     "line": 14,
     "language": "Python",
@@ -140,7 +140,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/python_specific.py",
+    "file": "tests/fixtures/python/python_specific.py",
     "function": "list_comprehension_no_filter",
     "line": 19,
     "language": "Python",

--- a/tests/golden/python-simple.json
+++ b/tests/golden/python-simple.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/simple.py",
+    "file": "tests/fixtures/python/simple.py",
     "function": "multiple_returns",
     "line": 13,
     "language": "Python",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/simple.py",
+    "file": "tests/fixtures/python/simple.py",
     "function": "with_early_return",
     "line": 6,
     "language": "Python",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/python/simple.py",
+    "file": "tests/fixtures/python/simple.py",
     "function": "simple_function",
     "line": 1,
     "language": "Python",

--- a/tests/golden/rust-loops.json
+++ b/tests/golden/rust-loops.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "loop_with_break",
     "line": 42,
     "language": "Rust",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "nested_loops",
     "line": 65,
     "language": "Rust",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "simple_loop",
     "line": 3,
     "language": "Rust",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "loop_with_continue",
     "line": 54,
     "language": "Rust",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "while_with_break",
     "line": 77,
     "language": "Rust",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "while_loop",
     "line": 16,
     "language": "Rust",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "for_loop",
     "line": 26,
     "language": "Rust",
@@ -140,7 +140,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/loops.rs",
+    "file": "tests/fixtures/rust/loops.rs",
     "function": "for_range",
     "line": 34,
     "language": "Rust",

--- a/tests/golden/rust-match.json
+++ b/tests/golden/rust-match.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/match.rs",
+    "file": "tests/fixtures/rust/match.rs",
     "function": "nested_match",
     "line": 43,
     "language": "Rust",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/match.rs",
+    "file": "tests/fixtures/rust/match.rs",
     "function": "match_with_guards",
     "line": 11,
     "language": "Rust",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/match.rs",
+    "file": "tests/fixtures/rust/match.rs",
     "function": "match_with_ranges",
     "line": 20,
     "language": "Rust",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/match.rs",
+    "file": "tests/fixtures/rust/match.rs",
     "function": "simple_match",
     "line": 3,
     "language": "Rust",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/match.rs",
+    "file": "tests/fixtures/rust/match.rs",
     "function": "match_enum",
     "line": 35,
     "language": "Rust",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/match.rs",
+    "file": "tests/fixtures/rust/match.rs",
     "function": "match_option",
     "line": 56,
     "language": "Rust",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/match.rs",
+    "file": "tests/fixtures/rust/match.rs",
     "function": "match_result",
     "line": 64,
     "language": "Rust",

--- a/tests/golden/rust-rust_specific.json
+++ b/tests/golden/rust-rust_specific.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "mixed_error_handling",
     "line": 49,
     "language": "Rust",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "multiple_question_operators",
     "line": 8,
     "language": "Rust",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "chained_question",
     "line": 63,
     "language": "Rust",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "multiple_panics",
     "line": 40,
     "language": "Rust",
@@ -80,7 +80,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "conditional_panic",
     "line": 34,
     "language": "Rust",
@@ -100,7 +100,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "with_question_operator",
     "line": 3,
     "language": "Rust",
@@ -120,7 +120,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "with_unwrap",
     "line": 18,
     "language": "Rust",
@@ -140,7 +140,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "with_expect",
     "line": 22,
     "language": "Rust",
@@ -160,7 +160,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "result_with_question",
     "line": 58,
     "language": "Rust",
@@ -180,7 +180,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "question_in_expression",
     "line": 14,
     "language": "Rust",
@@ -200,7 +200,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "with_panic",
     "line": 30,
     "language": "Rust",
@@ -220,7 +220,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/rust_specific.rs",
+    "file": "tests/fixtures/rust/rust_specific.rs",
     "function": "multiple_unwraps",
     "line": 26,
     "language": "Rust",

--- a/tests/golden/rust-simple.json
+++ b/tests/golden/rust-simple.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/simple.rs",
+    "file": "tests/fixtures/rust/simple.rs",
     "function": "nested_if",
     "line": 35,
     "language": "Rust",
@@ -20,7 +20,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/simple.rs",
+    "file": "tests/fixtures/rust/simple.rs",
     "function": "with_early_return",
     "line": 12,
     "language": "Rust",
@@ -40,7 +40,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/simple.rs",
+    "file": "tests/fixtures/rust/simple.rs",
     "function": "with_if_else",
     "line": 27,
     "language": "Rust",
@@ -60,7 +60,7 @@
     "band": "moderate"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/simple.rs",
+    "file": "tests/fixtures/rust/simple.rs",
     "function": "multiple_statements",
     "line": 19,
     "language": "Rust",
@@ -80,7 +80,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/simple.rs",
+    "file": "tests/fixtures/rust/simple.rs",
     "function": "async_function",
     "line": 47,
     "language": "Rust",
@@ -100,7 +100,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/simple.rs",
+    "file": "tests/fixtures/rust/simple.rs",
     "function": "simple_calculation",
     "line": 7,
     "language": "Rust",
@@ -120,7 +120,7 @@
     "band": "low"
   },
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/rust/simple.rs",
+    "file": "tests/fixtures/rust/simple.rs",
     "function": "empty_function",
     "line": 3,
     "language": "Rust",

--- a/tests/golden/simple.json
+++ b/tests/golden/simple.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/simple.ts",
+    "file": "tests/fixtures/simple.ts",
     "function": "simple",
     "line": 2,
     "language": "TypeScript",

--- a/tests/golden/try-catch-finally.json
+++ b/tests/golden/try-catch-finally.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/try-catch-finally.ts",
+    "file": "tests/fixtures/try-catch-finally.ts",
     "function": "tryCatchFinally",
     "line": 2,
     "language": "TypeScript",


### PR DESCRIPTION
## Summary

Adds automated golden file regression tests for Java and Python language support, completing the test coverage for all 6 supported languages.

## Changes

- **Added 16 new golden tests** (8 Java + 8 Python)
- Total golden tests: 16 → 32
- All tests passing ✅

### Java Golden Tests (8 tests)
- `test_java_golden_simple()`
- `test_java_golden_loops()`
- `test_java_golden_exceptions()`
- `test_java_golden_classes()`
- `test_java_golden_anonymous_class()`
- `test_java_golden_java_specific()`
- `test_java_golden_switch_and_ternary()`
- `test_java_golden_determinism()`

### Python Golden Tests (8 tests)
- `test_python_golden_simple()`
- `test_python_golden_loops()`
- `test_python_golden_exceptions()`
- `test_python_golden_classes()`
- `test_python_golden_boolean_ops()`
- `test_python_golden_comprehensions()`
- `test_python_golden_python_specific()`
- `test_python_golden_determinism()`

## Why This Matters

Previously, Java and Python had:
- ✅ Golden **files** (expected output)
- ✅ Working implementations
- ❌ No automated **tests** to verify output matches golden files

Now:
- ✅ Automated regression tests for all 6 languages
- ✅ Determinism verified (byte-for-byte identical output)
- ✅ Protection against accidental changes to output format

## Test Results

```
running 32 tests
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

**Total test suite: 252 tests, all passing**

## Language Coverage

| Language | Golden Tests | Status |
|----------|-------------|---------|
| TypeScript/JS | 6 tests | ✅ Complete |
| Go | 5 tests | ✅ Complete |
| Rust | 5 tests | ✅ Complete |
| **Java** | **8 tests** | ✅ **Now Complete** |
| **Python** | **8 tests** | ✅ **Now Complete** |

🚀 Generated with [Claude Code](https://claude.com/claude-code)