### PR TITLE
feat: pattern detection — 13 code smell labels with HTML dashboard and --explain-patterns

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,477 @@
+# Pattern Detection — Implementation Tasks
+
+Branch: `feature/pattern-detection`
+
+This file tracks the implementation of pattern detection as specified in `docs/patterns.md`. Work through tasks in order — each task depends on the ones before it.
+
+---
+
+## Context
+
+Patterns are informational labels derived from existing metrics. They do not affect LRS or risk bands. The authoritative spec is `docs/patterns.md`.
+
+**Files that will be modified:**
+
+| File | Change |
+|---|---|
+| `hotspots-core/src/patterns.rs` | NEW — pattern engine |
+| `hotspots-core/src/lib.rs` | expose `pub mod patterns` |
+| `hotspots-core/src/callgraph.rs` | make `is_entry_point` pub |
+| `hotspots-core/src/config.rs` | add `PatternThresholdsConfig` to `HotspotsConfig`; add `pattern_thresholds` to `ResolvedConfig` |
+| `hotspots-core/src/report.rs` | add `patterns` and `pattern_details` to `FunctionRiskReport` |
+| `hotspots-core/src/analysis.rs` | compute Tier 1 patterns, pass to report |
+| `hotspots-core/src/snapshot.rs` | add `neighbor_churn` to `CallGraphMetrics`; add `patterns` and `pattern_details` to `FunctionSnapshot`; compute neighbor_churn and Tier 2 patterns in enrichment |
+| `hotspots-cli/src/main.rs` | add `PATTERNS` column to tabular output; add `--explain-patterns` flag |
+| `hotspots-core/src/html.rs` | add `Patterns` column to HTML report |
+| `hotspots-core/tests/golden_tests.rs` | add golden assertions for pattern output |
+| `hotspots-core/tests/fixtures/` | add synthetic fixture for pattern golden tests |
+| `hotspots-core/tests/golden/` | add expected output file for pattern golden tests |
+
+---
+
+## Task 1 — Create `patterns.rs`: pure pattern engine
+
+**File:** `hotspots-core/src/patterns.rs` (new file)
+
+Implement the entire pattern classification engine as a pure, stateless module. No I/O, no global state.
+
+### String types, not `&'static str`
+
+All string fields in `PatternDetail` and `TriggeredBy` must be `String`, not `&'static str`. `&'static str` cannot be used in a `#[derive(Serialize)]` struct without a custom impl. The allocation cost is negligible — patterns are computed once per function per analysis run.
+
+### Types to define
+
+```rust
+// Input for Tier 1 classification
+pub struct Tier1Input {
+    pub cc: usize,
+    pub nd: usize,
+    pub fo: usize,
+    pub ns: usize,
+    pub loc: usize,
+}
+
+// Input for Tier 2 classification (all Option — absent outside snapshot mode)
+pub struct Tier2Input {
+    pub fan_in: Option<u32>,
+    pub scc_size: Option<u32>,
+    pub churn_lines: Option<u64>,
+    pub days_since_last_change: Option<u32>,
+    pub neighbor_churn: Option<u64>,
+    pub is_entrypoint: bool,  // suppresses middle_man and neighbor_risk when true
+}
+
+// All thresholds in one struct — defaults match docs/patterns.md.
+// Passed by reference into classify(); callers use Thresholds::default() unless
+// overridden by config. This keeps all threshold logic in one place and makes
+// per-project overrides (Task 9) a thin config-loading layer.
+#[derive(Debug, Clone)]
+pub struct Thresholds {
+    pub complex_branching_cc: usize,
+    pub complex_branching_nd: usize,
+    pub deeply_nested_nd: usize,
+    pub exit_heavy_ns: usize,
+    pub god_function_loc: usize,
+    pub god_function_fo: usize,
+    pub long_function_loc: usize,
+    pub churn_magnet_churn: u64,
+    pub churn_magnet_cc: usize,
+    pub cyclic_hub_scc: u32,
+    pub cyclic_hub_fan_in: u32,
+    pub hub_function_fan_in: u32,
+    pub hub_function_cc: usize,
+    pub middle_man_fan_in: u32,
+    pub middle_man_fo: usize,
+    pub middle_man_cc_max: usize,
+    pub neighbor_risk_churn: u64,
+    pub neighbor_risk_fo: usize,
+    pub shotgun_target_fan_in: u32,
+    pub shotgun_target_churn: u64,
+    pub stale_complex_cc: usize,
+    pub stale_complex_loc: usize,
+    pub stale_complex_days: u32,
+}
+
+impl Default for Thresholds { ... }  // all values from docs/patterns.md
+
+// A single triggered condition — used by --explain-patterns.
+// All fields are String (not &'static str) for serde compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggeredBy {
+    pub metric: String,     // e.g. "LOC", "CC"
+    pub op: String,         // ">=" or "<="
+    pub value: u64,         // observed value
+    pub threshold: u64,     // threshold compared against
+}
+
+// Full detail for one fired pattern — used by --explain-patterns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatternDetail {
+    pub id: String,
+    pub tier: u8,               // 1 or 2
+    pub kind: String,           // "primitive" or "derived"
+    pub triggered_by: Vec<TriggeredBy>,
+}
+```
+
+### Functions to implement
+
+```rust
+// Returns sorted pattern IDs only (Tier 1 alphabetical, then Tier 2 alphabetical).
+// Implemented by calling classify_detailed() and extracting ids — single source of
+// threshold logic, no divergence possible.
+pub fn classify(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Vec<String>
+
+// Returns full pattern detail for --explain-patterns.
+// This is the canonical implementation — classify() delegates to this.
+pub fn classify_detailed(
+    t1: &Tier1Input,
+    t2: &Tier2Input,
+    th: &Thresholds,
+) -> Vec<PatternDetail>
+
+// Internal helpers — one per primitive pattern.
+// Return Some(PatternDetail) if fired, None if not.
+// Each helper constructs triggered_by from the metrics that crossed threshold.
+fn check_complex_branching(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_deeply_nested(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_exit_heavy(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_god_function(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_long_function(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_churn_magnet(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_cyclic_hub(t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_hub_function(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_middle_man(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_neighbor_risk(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_shotgun_target(t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail>
+fn check_stale_complex(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail>
+```
+
+**Entrypoint suppression:** `check_middle_man` and `check_neighbor_risk` return `None` immediately when `t2.is_entrypoint` is `true`. This is the complete implementation of entrypoint exclusion.
+
+**`volatile_god` (derived):** computed inside `classify_detailed()` after all primitives are checked. If both `god_function` and `churn_magnet` details are present in the result, append a `volatile_god` entry whose `triggered_by` is the union of both primitives' `triggered_by` lists. Do not re-evaluate raw thresholds. `kind: "derived"`.
+
+**Ordering:** Tier 1 results first (alphabetical), then Tier 2 (alphabetical). `volatile_god` sorts among Tier 2.
+
+### Unit tests (required in the same file, under `#[cfg(test)]`)
+
+For **every primitive pattern**, write four tests using `Thresholds::default()`:
+1. Just below threshold — must not fire
+2. Exactly at threshold — must fire
+3. Well above threshold — must fire
+4. Compound pattern: one condition met, other not — must not fire
+
+For **`volatile_god`** (derived):
+1. Only `god_function` conditions met — `volatile_god` must not appear
+2. Only `churn_magnet` conditions met — `volatile_god` must not appear
+3. Both met — must contain all three: `god_function`, `churn_magnet`, `volatile_god`
+
+For **entrypoint suppression**:
+1. `middle_man` conditions met, `is_entrypoint: false` — must fire
+2. Same conditions, `is_entrypoint: true` — must not fire
+3. Same pair of tests for `neighbor_risk`
+
+**Ordering test:** inputs that trigger all 5 Tier 1 patterns. Output must be exactly:
+`["complex_branching", "deeply_nested", "exit_heavy", "god_function", "long_function"]`
+
+**Detail test:** trigger `god_function`. Call `classify_detailed()`. Assert the returned `PatternDetail` has `tier: 1`, `kind: "primitive"`, and `triggered_by` contains entries for `LOC` and `FO` with correct `value` and `threshold`.
+
+---
+
+## Task 2 — `is_entry_point` pub + `neighbor_churn` on `CallGraphMetrics`
+
+### 2a — Make `is_entry_point` pub in `callgraph.rs`
+
+**File:** `hotspots-core/src/callgraph.rs`
+
+`is_entry_point` is currently `fn is_entry_point` (private). Change to `pub fn is_entry_point`. No other changes to this file.
+
+This method uses name-based heuristics (main, handler patterns, etc.) and is cheap to call. It does not need to be stored per-function — snapshot enrichment (Task 6) calls it directly.
+
+### 2b — Add `neighbor_churn` to `CallGraphMetrics`
+
+**File:** `hotspots-core/src/snapshot.rs`
+
+`CallGraphMetrics` is the struct stored in `FunctionSnapshot.callgraph`. Add:
+
+```rust
+pub neighbor_churn: Option<u64>,
+```
+
+Initialize to `None` in all constructors. The value is computed during enrichment (Task 6) once churn data is available for all functions.
+
+**Grep first:** search for all `CallGraphMetrics { ` construction sites in `snapshot.rs` and add `neighbor_churn: None`.
+
+---
+
+## Task 3 — Add `patterns` and `pattern_details` to `FunctionRiskReport`
+
+**File:** `hotspots-core/src/report.rs`
+
+Add to `FunctionRiskReport`:
+
+```rust
+pub patterns: Vec<String>,
+#[serde(skip_serializing_if = "Option::is_none")]
+pub pattern_details: Option<Vec<patterns::PatternDetail>>,
+```
+
+Initialize `patterns` to `vec![]` and `pattern_details` to `None` in the constructor. Task 5 wires in real values.
+
+`pattern_details` is absent from JSON output by default. It is only populated when `--explain-patterns` is passed (Task 10).
+
+**Grep first:** search for all `FunctionRiskReport` construction sites and add the new fields.
+
+---
+
+## Task 4 — Add `patterns` and `pattern_details` to `FunctionSnapshot`
+
+**File:** `hotspots-core/src/snapshot.rs`
+
+Add to `FunctionSnapshot`:
+
+```rust
+pub patterns: Vec<String>,
+#[serde(skip_serializing_if = "Option::is_none")]
+pub pattern_details: Option<Vec<patterns::PatternDetail>>,
+```
+
+Initialize both to empty. Task 6 wires in real values.
+
+**Grep first:** search for all `FunctionSnapshot` construction sites and add the new fields.
+
+---
+
+## Task 5 — Wire Tier 1 patterns in analysis mode
+
+**File:** `hotspots-core/src/analysis.rs`
+
+After `extract_metrics()` returns `RawMetrics`, compute patterns. Use `config.pattern_thresholds` (added in Task 9; use `Thresholds::default()` until then):
+
+```rust
+let t1 = patterns::Tier1Input {
+    cc: raw.cc, nd: raw.nd, fo: raw.fo, ns: raw.ns, loc: raw.loc,
+};
+let t2 = patterns::Tier2Input {
+    fan_in: None, scc_size: None, churn_lines: None,
+    days_since_last_change: None, neighbor_churn: None,
+    is_entrypoint: false,
+};
+let function_patterns = patterns::classify(&t1, &t2, &config.pattern_thresholds);
+```
+
+Pass `function_patterns` to `FunctionRiskReport`. When `--explain-patterns` is active (Task 10), call `classify_detailed()` instead and populate `pattern_details`.
+
+---
+
+## Task 6 — Compute `neighbor_churn` and Tier 2 patterns in snapshot enrichment
+
+**File:** `hotspots-core/src/snapshot.rs`
+
+Runs after call graph and git churn data are both available for all functions.
+
+### 6a — Compute `neighbor_churn` per function
+
+For each function snapshot, sum `churn_lines` across all direct callees (1-hop outgoing edges). Look up each callee's churn total from the already-built churn map; contribute 0 for callees with no entry. Store in `snap.callgraph.neighbor_churn`.
+
+### 6b — Compute Tier 2 patterns
+
+```rust
+let t1 = patterns::Tier1Input {
+    cc: snap.metrics.cc, nd: snap.metrics.nd,
+    fo: snap.metrics.fo, ns: snap.metrics.ns, loc: snap.metrics.loc,
+};
+let t2 = patterns::Tier2Input {
+    fan_in: snap.callgraph.as_ref().map(|cg| cg.fan_in as u32),
+    scc_size: snap.callgraph.as_ref().map(|cg| cg.scc_size as u32),
+    churn_lines: snap.churn.as_ref().map(|c| c.lines_added + c.lines_deleted),
+    days_since_last_change: snap.days_since_last_change,
+    neighbor_churn: snap.callgraph.as_ref().and_then(|cg| cg.neighbor_churn),
+    is_entrypoint: call_graph.is_entry_point(&snap.function_id),
+};
+snap.patterns = patterns::classify(&t1, &t2, &config.pattern_thresholds);
+// if --explain-patterns (Task 10):
+// snap.pattern_details = Some(patterns::classify_detailed(&t1, &t2, &config.pattern_thresholds));
+```
+
+---
+
+## Task 7 — Tabular output for `patterns`
+
+**File:** `hotspots-cli/src/main.rs`
+
+Add a `PATTERNS` column to tabular output:
+- Value: comma-separated pattern IDs, or `-` if empty
+- Only render the column when at least one function in the result has patterns
+- Column appears after `BAND`
+
+JSON output requires no changes — `patterns: Vec<String>` serialises as a JSON array automatically.
+
+---
+
+## Task 8 — HTML report patterns column
+
+**File:** `hotspots-core/src/html.rs`
+
+Add a `Patterns` column to the HTML function table:
+- Each pattern ID rendered as `<span class="pattern pattern-{id}">` — allows per-pattern CSS
+- Show `-` for empty lists
+- Add minimal CSS: `.pattern { font-family: monospace; font-size: 0.9em; margin-right: 4px; }`
+
+No new data pipeline work — `FunctionSnapshot.patterns` is populated by Task 6.
+
+---
+
+## Task 9 — Per-project threshold overrides via `.hotspotsrc.json`
+
+**Files:** `hotspots-core/src/config.rs`
+
+Follow the exact same pattern as `ScoringWeightsConfig` → `ScoringWeights` → `ResolvedConfig.scoring_weights`.
+
+### 9a — Add `PatternThresholdsConfig` to `HotspotsConfig`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PatternThresholdsConfig {
+    pub complex_branching_cc: Option<usize>,
+    pub complex_branching_nd: Option<usize>,
+    pub deeply_nested_nd: Option<usize>,
+    pub exit_heavy_ns: Option<usize>,
+    pub god_function_loc: Option<usize>,
+    pub god_function_fo: Option<usize>,
+    pub long_function_loc: Option<usize>,
+    pub churn_magnet_churn: Option<u64>,
+    pub churn_magnet_cc: Option<usize>,
+    pub cyclic_hub_scc: Option<u32>,
+    pub cyclic_hub_fan_in: Option<u32>,
+    pub hub_function_fan_in: Option<u32>,
+    pub hub_function_cc: Option<usize>,
+    pub middle_man_fan_in: Option<u32>,
+    pub middle_man_fo: Option<usize>,
+    pub middle_man_cc_max: Option<usize>,
+    pub neighbor_risk_churn: Option<u64>,
+    pub neighbor_risk_fo: Option<usize>,
+    pub shotgun_target_fan_in: Option<u32>,
+    pub shotgun_target_churn: Option<u64>,
+    pub stale_complex_cc: Option<usize>,
+    pub stale_complex_loc: Option<usize>,
+    pub stale_complex_days: Option<u32>,
+}
+```
+
+Add to `HotspotsConfig` (note: `deny_unknown_fields` is on `HotspotsConfig` — the new field must be added here or config parsing will reject the `patterns` key):
+
+```rust
+#[serde(default)]
+pub patterns: Option<PatternThresholdsConfig>,
+```
+
+### 9b — Add `pattern_thresholds` to `ResolvedConfig`
+
+```rust
+pub pattern_thresholds: patterns::Thresholds,
+```
+
+### 9c — Merge in `resolve()`
+
+Follow the `scoring_weights` pattern: start from `patterns::Thresholds::default()`, override field by field for any `Some` value in `PatternThresholdsConfig`. Each field falls back to the default independently — partial configs work.
+
+### 9d — Validation
+
+Add a `validate_pattern_thresholds()` helper called from `HotspotsConfig::validate()`. Rules:
+- All usize/u32/u64 thresholds must be > 0
+- `middle_man_cc_max` must be < `hub_function_cc` (prevents middle_man and hub_function from being simultaneously impossible to distinguish — warn, not error)
+
+### 9e — Wire through call sites
+
+Update Tasks 5 and 6's `classify()` calls to use `&config.pattern_thresholds` instead of `&Thresholds::default()`. This is a one-line change at each call site once `ResolvedConfig` has the field.
+
+---
+
+## Task 10 — `--explain-patterns` flag
+
+**File:** `hotspots-cli/src/main.rs`
+
+Add `--explain-patterns` boolean flag to the `analyze` and `snapshot` subcommands.
+
+When set:
+- Call `patterns::classify_detailed()` instead of `patterns::classify()` in analysis (Task 5) and snapshot enrichment (Task 6)
+- Store result in `pattern_details` on the report/snapshot struct
+- JSON output: `pattern_details` serialises automatically (absent by default via `skip_serializing_if`)
+- Tabular output: after the main row for a function, print one indented line per pattern:
+  ```
+    god_function: LOC=85 (≥60), FO=12 (≥10)
+  ```
+- HTML output: expand each `<span class="pattern">` into a `<span title="LOC=85 (≥60), FO=12 (≥10)">` tooltip
+
+`pattern_details` must remain `None` when `--explain-patterns` is not passed. Do not call `classify_detailed()` in the hot path.
+
+---
+
+## Task 11 — Golden tests for Tier 1 patterns
+
+**Files:**
+- `hotspots-core/tests/fixtures/patterns_tier1.ts` (new)
+- `hotspots-core/tests/golden/patterns_tier1.json` (new)
+- `hotspots-core/tests/golden_tests.rs` (add test case)
+
+### Fixture requirements
+
+Write a TypeScript fixture with five named functions, each engineered to trigger specific Tier 1 patterns:
+
+1. `godAndLong` — triggers `god_function` and `long_function` (LOC ≥ 80, FO ≥ 10)
+2. `complexBranching` — triggers `complex_branching` (CC ≥ 10, ND ≥ 4) but not `deeply_nested`
+3. `deeplyNested` — triggers `deeply_nested` alone (ND ≥ 5, CC < 10)
+4. `exitHeavy` — triggers `exit_heavy` (NS ≥ 5)
+5. `allFiveTier1` — triggers all five Tier 1 patterns simultaneously
+
+After running analysis on the fixture, capture output and commit it as the golden file. The golden file locks the `patterns` array per function.
+
+### Test assertion
+
+```rust
+// In golden_tests.rs:
+// Run analysis, load golden JSON, assert patterns match for each function by name.
+```
+
+---
+
+## Task 12 — Full test suite pass
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
+**Anticipated failure modes:**
+
+- **`deny_unknown_fields`** on `HotspotsConfig` — if Task 9 is not complete, any test that serialises/deserialises a config with the `patterns` key will fail. Complete Task 9 before running tests.
+- **Struct exhaustiveness** — any `..Default::default()` or struct literal missing new fields will fail to compile. Grep for all construction sites before compiling.
+- **Golden file drift** — `patterns: []` will appear in JSON output for all existing golden files. Update them: an empty `patterns` array is valid and expected for existing fixtures that don't trigger any patterns.
+- **Clippy `needless_pass_by_value`** — `classify()` takes `&Thresholds` by reference; ensure no call site passes by value.
+
+---
+
+## Out of scope for this branch
+
+- **Percentile-based thresholds** — requires a two-pass analysis (collect all metric values repo-wide, then classify per-function). The current per-function stateless engine cannot support this without an architectural change to the analysis pipeline. Documented as a planned extension in `docs/patterns.md`.
+
+---
+
+## Definition of done
+
+- [ ] All 13 patterns implemented in `patterns.rs` with full unit test coverage
+- [ ] `Thresholds` struct with `Default` impl; all `classify()` calls accept `&Thresholds`
+- [ ] Entrypoint suppression for `middle_man` and `neighbor_risk`
+- [ ] `FunctionRiskReport.patterns` populated in analyze mode (Tier 1)
+- [ ] `FunctionSnapshot.patterns` populated in snapshot mode (Tier 1 + Tier 2)
+- [ ] `neighbor_churn` computed and stored in snapshot enrichment
+- [ ] Tabular output shows `PATTERNS` column when non-empty
+- [ ] HTML output shows `Patterns` column
+- [ ] JSON output includes `patterns` array; `pattern_details` absent unless `--explain-patterns`
+- [ ] `--explain-patterns` populates `pattern_details` with triggered conditions
+- [ ] `.hotspotsrc.json` `patterns` section overrides thresholds per-field; partial configs work
+- [ ] Golden test fixture and expected output committed
+- [ ] `cargo fmt`, `cargo clippy`, `cargo test` all pass clean

--- a/TASKS.md
+++ b/TASKS.md
@@ -462,16 +462,16 @@ cargo test
 
 ## Definition of done
 
-- [ ] All 13 patterns implemented in `patterns.rs` with full unit test coverage
-- [ ] `Thresholds` struct with `Default` impl; all `classify()` calls accept `&Thresholds`
-- [ ] Entrypoint suppression for `middle_man` and `neighbor_risk`
-- [ ] `FunctionRiskReport.patterns` populated in analyze mode (Tier 1)
-- [ ] `FunctionSnapshot.patterns` populated in snapshot mode (Tier 1 + Tier 2)
-- [ ] `neighbor_churn` computed and stored in snapshot enrichment
-- [ ] Tabular output shows `PATTERNS` column when non-empty
-- [ ] HTML output shows `Patterns` column
-- [ ] JSON output includes `patterns` array; `pattern_details` absent unless `--explain-patterns`
-- [ ] `--explain-patterns` populates `pattern_details` with triggered conditions
-- [ ] `.hotspotsrc.json` `patterns` section overrides thresholds per-field; partial configs work
-- [ ] Golden test fixture and expected output committed
-- [ ] `cargo fmt`, `cargo clippy`, `cargo test` all pass clean
+- [x] All 13 patterns implemented in `patterns.rs` with full unit test coverage
+- [x] `Thresholds` struct with `Default` impl; all `classify()` calls accept `&Thresholds`
+- [x] Entrypoint suppression for `middle_man` and `neighbor_risk`
+- [x] `FunctionRiskReport.patterns` populated in analyze mode (Tier 1)
+- [x] `FunctionSnapshot.patterns` populated in snapshot mode (Tier 1 + Tier 2)
+- [x] `neighbor_churn` computed and stored in snapshot enrichment
+- [x] Tabular output shows `PATTERNS` column when non-empty
+- [x] HTML output shows `Patterns` column with colored pill badges and pattern breakdown panel
+- [x] JSON output includes `patterns` array; `pattern_details` absent unless `--explain-patterns`
+- [x] `--explain-patterns` populates `pattern_details` with triggered conditions
+- [x] `.hotspotsrc.json` `patterns` section overrides thresholds per-field; partial configs work
+- [x] Golden test fixture and expected output committed
+- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass clean

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,419 @@
+# Code Pattern Reference
+
+This document is the single source of truth for the code patterns that Hotspots detects. Each entry defines what the pattern means, which signals trigger it, what the industry calls it, and why it matters for maintenance risk.
+
+Patterns are **informational labels** — they do not affect the LRS score or risk band. A function can carry multiple patterns simultaneously.
+
+---
+
+## How patterns work
+
+Patterns are derived from the same signals Hotspots already measures: cyclomatic complexity (CC), nesting depth (ND), fan-out (FO), non-structured exits (NS), lines of code (LOC), and — in snapshot mode — call graph data (fan-in, SCC membership, dependency depth) and git data (churn, touch frequency, recency).
+
+Two tiers exist based on what data is available:
+
+| Tier | Available in | Requires |
+|---|---|---|
+| **Tier 1 — Structural** | All modes | CC, ND, FO, NS, LOC only |
+| **Tier 2 — Enriched** | Snapshot mode only | Call graph + git history |
+
+Tier 2 patterns are a superset: a function can carry both structural and enriched patterns at once.
+
+Some Tier 2 patterns are **derived** — they are pure conjunctions of other named patterns and reuse those patterns' thresholds directly rather than defining independent thresholds. This is noted in each entry. All other patterns are **primitive**.
+
+---
+
+## Metric definitions
+
+All thresholds reference the following metrics. Definitions are locked here to ensure consistent implementation and testing.
+
+**`LOC`** — physical lines of code for the function body, excluding blank lines and comment-only lines.
+
+**`CC`** — cyclomatic complexity (McCabe 1976): number of linearly independent paths, equivalent to the number of binary decision points + 1.
+
+**`ND`** — maximum nesting depth within the function body: the deepest level of nested control structures (if/else, loops, try/catch, match arms, closures).
+
+**`FO`** — fan-out: number of distinct functions called directly within the function body, excluding calls to the standard library or external dependencies unless they cross a module boundary.
+
+**`NS`** — non-structured exits: count of early returns, thrown exceptions, and multi-level breaks or continues within the function body.
+
+**`fan_in`** — number of distinct functions in the repo that contain a direct call to this function. Computed from the snapshot call graph. External callers (outside the repo) are not counted.
+
+**`scc_size`** — size of the strongly connected component containing this function in the call graph. A value of 1 means the function is not in a cycle. Requires snapshot mode.
+
+**`churn_lines`** — cumulative sum of lines added plus lines deleted touching this function across all commits in the git history, or within a configurable window (default: lifetime). Renames are followed. Merge commits are excluded. Whitespace-only changes are excluded by default.
+
+**`touch_frequency`** — number of distinct commits touching this function. Default window: lifetime. A configurable rolling window (e.g. last 90 days) is a planned extension.
+
+**`days_since_last_change`** — calendar days between today and the most recent commit that modified at least one non-whitespace line in this function body.
+
+**`neighbor_churn`** — sum of `churn_lines` for all direct callees (outgoing call graph edges, 1-hop only). Excludes stdlib and external dependencies. If a callee has no git history entry (e.g. it was added and never changed), it contributes 0.
+
+---
+
+## Default thresholds and configuration
+
+All thresholds listed in this document are **defaults**. They are deliberately conservative: it is better to surface a genuine pattern and have a developer dismiss it than to miss a real structural problem.
+
+Thresholds can be tuned per project via the `patterns` section of `.hotspotsrc.json` (planned — not yet implemented). When implemented, each threshold will support two forms:
+
+- **Absolute**: `LOC >= 80` — fixed value, language- and repo-size-agnostic
+- **Percentile**: `LOC >= p95` — computed within a configurable scope (repo, language, module) — planned extension
+
+The absolute form is used for all defaults today. Percentile-based thresholds are a planned extension and will not require a schema change when added.
+
+---
+
+## Exclusions and guards
+
+The following exclusions apply by default to reduce noise. They can be overridden in `.hotspotsrc.json` (planned):
+
+- **Generated files** — files matching common generated-code patterns (e.g. `*.pb.go`, `*_generated.*`, files containing a `// Code generated` header) are excluded from pattern detection.
+- **Vendored directories** — `vendor/`, `node_modules/`, and similar third-party trees are excluded.
+- **Test files** — files matching language-standard test patterns (e.g. `*_test.go`, `*.spec.ts`, `test_*.py`) are excluded. This avoids false positives on test helpers and fixtures.
+- **Path globs** — arbitrary glob patterns can be added to `.hotspotsrc.json` to exclude generated, legacy, or scaffolding code.
+
+Note: `middle_man` and `neighbor_risk` are particularly sensitive to entrypoint functions (web handlers, CLI commands, dispatchers) that are expected to have high fan-in and fan-out by design. Until explicit entrypoint exclusion is implemented, these patterns may fire on legitimate dispatch code and should be reviewed with that context in mind.
+
+---
+
+## Output contract
+
+Patterns appear in all output modes under a stable schema:
+
+```
+patterns: string[]
+```
+
+An optional extended form is available with `--explain-patterns` (planned):
+
+```
+pattern_details?: {
+  id: string,
+  tier: 1 | 2,
+  kind: "primitive" | "derived",
+  triggered_by: { metric: string, op: string, value: number, threshold: number }[]
+}[]
+```
+
+In tabular output, patterns appear as a comma-separated list in a `patterns` column. Ordering within the list is deterministic: Tier 1 patterns before Tier 2, then alphabetical within each tier.
+
+---
+
+## Tier 1 — Structural Patterns
+
+These fire from static metrics alone and are available in every output mode.
+
+---
+
+### `complex_branching`
+
+**Kind:** Primitive
+**Industry names:** Complex Method, Arrow Anti-Pattern, Spaghetti Logic
+**Source:** McCabe cyclomatic complexity (1976); Fowler *Refactoring* (long conditional chains)
+
+**Signals:** High CC **and** high ND
+
+**Definition:**
+High cyclomatic complexity (many independent paths) compounded by deep nesting (those paths are hard to visually parse). Either dimension alone is tolerable; together they produce functions that are genuinely difficult to reason about because the branching structure must be held in working memory while navigating multiple nesting levels.
+
+**Why it matters:**
+CC directly predicts defect density and test case count. Deep nesting amplifies this by making the logic structure opaque. Functions with both properties consistently show higher bug rates in empirical studies.
+
+**Default thresholds:** CC ≥ 10 **and** ND ≥ 4
+
+---
+
+### `deeply_nested`
+
+**Kind:** Primitive
+**Industry names:** Arrow Anti-Pattern, Pyramid of Doom
+**Source:** Common style guidance across most languages; prominent in JavaScript community as "callback hell"
+
+**Signals:** High ND, regardless of CC
+
+**Definition:**
+Excessive nesting depth even in the absence of high branch count. This typically appears as guard clauses that were never inverted, nested callbacks, or deeply nested loops. Readability degrades non-linearly with depth: at ND ≥ 5, the outermost context is genuinely difficult to hold in mind while reading inner code.
+
+**Why it matters:**
+Beyond readability, deep nesting is a sign that early-exit refactoring opportunities have been missed. It correlates with higher defect rates independently of CC because the number of implicit assumptions grows with depth.
+
+**Default thresholds:** ND ≥ 5
+
+---
+
+### `exit_heavy`
+
+**Kind:** Primitive
+**Industry names:** Multiple Return Points (contested — guard-clause style rehabilitates small counts)
+**Source:** Structured programming tradition
+
+**Signals:** High NS
+
+**Definition:**
+A function with many non-structured exit points: early returns, thrown exceptions, and break or continue statements that exit multiple levels. A small number of guard clauses at the top of a function is good style and will not trigger this pattern. The concern is exits *scattered throughout* the body, which make it hard to reason about the complete set of outcomes and to instrument uniformly (e.g. adding logging on all exit paths).
+
+What NS counts is language-specific. See the NS metric definition above. If your language's NS metric has additional detail (e.g. whether `break` inside a `match` arm counts), that definition takes precedence here.
+
+**Why it matters:**
+Each exit point is a place where a caller's assumption about post-conditions can be violated. Many scattered exits also increase the number of paths that must be independently tested, compounding the effect of high CC.
+
+**Default thresholds:** NS ≥ 5
+
+---
+
+### `god_function`
+
+**Kind:** Primitive
+**Industry names:** God Method, Brain Method, Long Method
+**Source:** Fowler *Refactoring* (Long Method); Tornhill *Software Design X-Rays* (Brain Method)
+
+**Signals:** High LOC **and** high FO
+
+**Definition:**
+A function that does too much *and* orchestrates too many other concerns. The size (LOC) indicates a Single Responsibility violation; the fan-out (FO) shows it is reaching into many other modules to do so. The combination is worse than either alone: a large function that is also deeply entangled is expensive to read, test, and change. This pattern often co-occurs with Feature Envy (Fowler), where a function accesses another module's data more than its own, but the two are not equivalent — `god_function` is defined by size and breadth of coupling, not by data access patterns.
+
+**Why it matters:**
+God functions are the most common root cause of defect clusters. They are hard to unit test (too many paths, too many dependencies), hard to review (too much context), and attract further additions because "it already does everything."
+
+**Default thresholds:** LOC ≥ 60 **and** FO ≥ 10
+
+---
+
+### `long_function`
+
+**Kind:** Primitive
+**Industry names:** Long Method
+**Source:** Fowler *Refactoring* — one of the original code smells
+
+**Signals:** High LOC alone
+
+**Definition:**
+A physically large function, irrespective of branching or coupling. Length alone is a proxy for Single Responsibility violations: functions that are hard to name concisely are usually doing more than one thing. LOC also directly predicts review time and the likelihood that a reviewer misses a subtle bug.
+
+Note: `long_function` will frequently co-occur with `god_function`. `god_function` is the stronger signal when both fire, but `long_function` alone is still meaningful — a large function with low fan-out may be a sequential pipeline that is easy to follow but should still be decomposed.
+
+**Why it matters:**
+Short functions are easier to name, test, review, and reuse. Function length is one of the strongest simple predictors of bug probability per function in empirical research.
+
+**Default thresholds:** LOC ≥ 80
+
+---
+
+## Tier 2 — Enriched Patterns
+
+These require snapshot mode (`--mode snapshot`) because they combine structural metrics with call graph topology and git history.
+
+---
+
+### `churn_magnet`
+
+**Kind:** Primitive
+**Industry names:** Hotspot (Tornhill), Change-Prone Complex Method
+**Source:** Tornhill *Your Code as a Crime Scene* — the core thesis: complexity × churn = maintenance risk
+
+**Signals:** High churn_lines **and** high CC
+
+**Definition:**
+The canonical hotspot: a function that is both structurally complex and frequently changed. Complexity means each change is expensive and error-prone; churn means those expensive changes happen often. This is the primary signal for maintenance debt accumulation.
+
+**Why it matters:**
+Tornhill's empirical research across many large codebases shows that the intersection of high complexity and high churn predicts defect density far better than either dimension alone. A complex function that never changes is legacy, but manageable. A complex function that changes constantly is actively generating defects.
+
+**Default thresholds:** churn_lines ≥ 200 **and** CC ≥ 8
+
+---
+
+### `cyclic_hub`
+
+**Kind:** Primitive
+**Industry names:** Inappropriate Intimacy, Cyclic Dependency, Circular Coupling
+**Source:** Fowler *Refactoring* (Inappropriate Intimacy); Martin — Acyclic Dependencies Principle
+
+**Signals:** scc_size > 1 **and** high fan_in
+
+**Definition:**
+A function caught in a cyclic dependency (its SCC contains more than one node) that is also heavily depended upon from outside the cycle. This is the hardest structural problem to refactor: breaking the cycle requires decoupling functions that mutually depend on each other, and the high fan-in means many external callers are also affected by any interface change.
+
+**Why it matters:**
+Cyclic dependencies prevent independent deployment, make testing harder (circular mocking), and are the primary obstacle to modularisation. When a cyclic function is also a hub, breaking it requires coordinated changes across multiple files. Detecting it early gives teams a chance to break cycles before the fan-in grows further.
+
+**Default thresholds:** scc_size ≥ 2 **and** fan_in ≥ 6
+
+---
+
+### `hub_function`
+
+**Kind:** Primitive
+**Industry names:** Knowledge Concentration, Central Module
+**Source:** Tornhill *Your Code as a Crime Scene* (knowledge concentration); object-oriented coupling literature (hub coupling)
+
+**Signals:** High fan_in **and** high CC
+
+**Definition:**
+A function that many callers depend on and that is itself structurally complex. Fan-in measures how much of the codebase relies on this function; CC measures how hard it is to understand and change. The combination creates a structural bottleneck: any bug here has wide blast radius, and changing it requires understanding complex logic under pressure from many dependent callers.
+
+**Why it matters:**
+Hub functions with high complexity are the highest-leverage refactoring targets in a codebase. Simplifying them reduces risk for all their callers simultaneously. They are also the most likely locus of defensive code that accumulates over time as callers make conflicting demands.
+
+**Default thresholds:** fan_in ≥ 10 **and** CC ≥ 8
+
+---
+
+### `middle_man`
+
+**Kind:** Primitive
+**Industry names:** Middle Man, Dispatcher Anti-Pattern, God Router
+**Source:** Fowler *Refactoring* (Middle Man)
+
+**Signals:** High fan_in **and** high FO **and** low CC
+
+**Definition:**
+A function that many things call, which itself calls many other things, but contains little logic of its own. It is a routing layer that has grown beyond its original purpose. Low CC distinguishes this from `hub_function`: a middle man is structurally simple inside but topologically central. It may be acceptable as a legitimate dispatcher, but at scale it represents unnecessary coupling — all callers are coupled to a routing function they do not actually need.
+
+See the note in [Exclusions and guards](#exclusions-and-guards) about entrypoint functions, which can trigger this pattern legitimately.
+
+**Why it matters:**
+Middle men add indirection without abstraction. They make the call graph harder to navigate, increase coupling, and become a maintenance problem when routing logic starts to grow. Large middle men are a sign that the dependency inversion principle has been bypassed.
+
+**Default thresholds:** fan_in ≥ 8 **and** FO ≥ 8 **and** CC ≤ 4
+
+---
+
+### `neighbor_risk`
+
+**Kind:** Primitive
+**Industry names:** Instability by Proximity, Dependency Contamination
+**Source:** New pattern — not in standard literature. Justified by Hotspots' unique ability to measure churn in the call graph neighbourhood, a signal no traditional static analysis tool provides.
+
+**Signals:** High neighbor_churn **and** high FO
+
+**Definition:**
+A function whose own code is stable, but whose dependencies are churning heavily. Even if this function never changes, it is at risk from the instability of the code it calls. A function with many callees, most of which are actively being changed, is one dependency update away from needing to adapt.
+
+See the note in [Exclusions and guards](#exclusions-and-guards) about entrypoint-style functions that may have high FO by design.
+
+**Why it matters:**
+Standard hotspot analysis focuses on a function's own churn. Hotspots' call graph data allows detection of *indirect* instability — functions that are stable islands in unstable neighbourhoods. These are the functions most likely to appear stable in reviews but break unexpectedly after a sprint of changes in adjacent code. Flagging them allows teams to add integration tests before the instability propagates.
+
+**Default thresholds:** neighbor_churn ≥ 400 **and** FO ≥ 8
+
+---
+
+### `shotgun_target`
+
+**Kind:** Primitive
+**Industry names:** Shotgun Surgery target, High-Impact Churn, Ripple Effect Source
+**Source:** Fowler *Refactoring* — Shotgun Surgery describes code where a single change requires many scattered edits; the *target* is the function receiving those changes under pressure from many callers
+
+**Signals:** High fan_in **and** high churn_lines
+
+**Definition:**
+A function that is both heavily depended upon and frequently changed. Each change here has the potential to break any of its callers, and the frequency of change means risk materialises regularly. This is distinct from `hub_function` (which focuses on complexity as the amplifier) and `churn_magnet` (which focuses on CC × churn): here the risk is breadth of impact × change frequency, regardless of the function's internal complexity.
+
+**Why it matters:**
+High fan-in with high churn is the signature of a function that has been modified without its interface being stabilised. It suggests the abstraction boundary is wrong — callers are depending on implementation details that keep shifting. Stabilising the interface (or breaking the function apart) is the primary remediation.
+
+**Default thresholds:** fan_in ≥ 8 **and** churn_lines ≥ 150
+
+---
+
+### `stale_complex`
+
+**Kind:** Primitive
+**Industry names:** Untouchable Code, Fear Code, Frozen Complexity
+**Source:** Tornhill *Software Design X-Rays* — the "fear" metric: complex code that nobody dares change
+
+**Signals:** High CC **and** high LOC **and** very low touch_frequency (days_since_last_change above threshold)
+
+**Definition:**
+A complex, large function that has not been changed in an extended period — not because it is stable and well-understood, but because it is complex enough to be feared. This is the *inverse* of `churn_magnet`: rather than accumulating churn, it accumulates entropy through avoidance. Teams work around it, adding adapter layers rather than modifying the core logic.
+
+"Not changed" means no commit has modified at least one non-whitespace line in the function body within the threshold window. Renames are followed. Formatting-only commits (whitespace-only diffs) do not reset the clock.
+
+**Why it matters:**
+Stale complex functions are a hidden liability. They appear stable in metrics but represent a significant risk when they *do* need to change — under urgency, with no recent institutional knowledge. Identifying them proactively allows teams to schedule incremental familiarisation and decomposition before a crisis forces a rushed change.
+
+**Default thresholds:** CC ≥ 10 **and** LOC ≥ 60 **and** days_since_last_change ≥ 180
+
+---
+
+### `volatile_god`
+
+**Kind:** Derived from `god_function` && `churn_magnet`
+**Industry names:** Volatile God Method, Churning Monolith
+**Source:** Composite of Fowler (God Method) + Tornhill (hotspot). Not separately named in the literature but represents the intersection of both seminal concerns.
+
+**Signals:** All conditions for `god_function` fire **and** churn_lines meets the `churn_magnet` threshold
+
+**Definition:**
+A god function that is also frequently changed: the worst-case combination of structural debt and maintenance pressure. The size and coupling of a god function make every change expensive; the frequency of change means those costs are incurred repeatedly. Because this pattern is derived, its thresholds are exactly those of the two primitives it combines — there are no independent thresholds to keep in sync.
+
+**Why it matters:**
+A god function that is rarely touched is legacy debt — expensive to pay down but not actively causing new problems. A god function that changes regularly is *active* debt: it is generating defects, slowing every sprint that touches it, and training developers to avoid it. `volatile_god` is the highest-priority pattern for targeted refactoring investment.
+
+**Derived thresholds (inherited):** LOC ≥ 60 **and** FO ≥ 10 **and** churn_lines ≥ 200 **and** CC ≥ 8
+
+---
+
+## Pattern combinations and escalation
+
+Some patterns frequently co-occur and together signal a higher-priority concern than either alone. `volatile_god` is already a named derived pattern covering the most common escalation; the combinations below are observed co-occurrences that are not yet named patterns but are worth noting in triage.
+
+| Combination | Escalated meaning |
+|---|---|
+| `hub_function` + `cyclic_hub` | Architecture-level coupling problem; cannot be safely refactored at the function level alone — cycle must be broken first |
+| `complex_branching` + `exit_heavy` | Control flow is non-linear in two compounding ways; test coverage is likely incomplete — prioritise coverage before any refactor |
+| `middle_man` + `churn_magnet` | A routing layer that keeps absorbing logic — the routing function is growing into the thing it was meant to dispatch away from |
+| `stale_complex` + `hub_function` | Feared bottleneck — high blast radius if it needs to change, and it hasn't been touched in a long time; schedule familiarisation proactively |
+| `shotgun_target` + `churn_magnet` | Interface instability compounded by internal complexity — the function is changing a lot and breaking callers; interface stabilisation is urgent |
+
+---
+
+## Engineering requirements
+
+This section describes what the pattern engine must implement. It is intended to drive the implementation plan directly.
+
+### Pattern engine
+
+- Input: a `FunctionMetrics` record (Tier 1 fields) plus optional `EnrichedMetrics` (Tier 2 fields; absent outside snapshot mode)
+- Output: `Vec<PatternId>` with deterministic ordering (Tier 1 before Tier 2, then alphabetical within each tier)
+- Derived patterns are computed by checking whether component primitive patterns fired, not by re-evaluating raw metric conditions — this prevents threshold drift between a primitive and its derived pattern
+- The engine must be pure and stateless: same inputs always produce same outputs
+
+### Threshold registry
+
+- Central map: `PatternId -> ThresholdSet`
+- All defaults embedded in code; config overrides layered on top
+- Even if `.hotspotsrc.json` config is not yet implemented, the internal type should accommodate a `ThresholdOverride` layer so the config path is a thin addition, not a refactor
+
+### Test matrix
+
+For each primitive pattern:
+- Just below threshold (must not fire)
+- Exactly at threshold (must fire)
+- Above threshold (must fire)
+- Opposite end of any compound condition at threshold, other metric below (must not fire)
+
+For derived patterns:
+- Each component primitive below threshold (must not fire)
+- All component primitives at threshold (must fire)
+
+Golden tests:
+- At least one synthetic function triggering 4–5 patterns simultaneously, with expected output verified
+- Snapshot-only tests using a small synthetic call graph + git history fixture covering all Tier 2 patterns
+
+### Raw vs normalised metrics
+
+All thresholds in this document operate on **raw metrics** — no normalisation, no z-scores, no per-language adjustment. This is intentional for v1. Percentile-based thresholds are a planned extension and are explicitly accommodated in the threshold registry design (see above). Deciding to normalise later will require adding a normalisation layer, not changing the pattern definitions.
+
+---
+
+## Sources and further reading
+
+- Martin Fowler — *Refactoring: Improving the Design of Existing Code* (1999, 2nd ed. 2018)
+- Adam Tornhill — *Your Code as a Crime Scene* (2015)
+- Adam Tornhill — *Software Design X-Rays* (2018)
+- Thomas J. McCabe — "A Complexity Measure" (IEEE Transactions on Software Engineering, 1976)
+- Robert C. Martin — *Clean Code* (2008) and the Acyclic Dependencies Principle
+- Empirical studies on CC and defect density: Gill & Kemerer (1991), Basili et al. (1996)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -190,6 +190,34 @@ the top 10 high/moderate source-file pairs.
 **Note:** In snapshot mode with `--format text`, you must specify either `--explain`
 or `--level <LEVEL>`.
 
+##### `--explain-patterns`
+**Optional.** Populate and emit per-pattern trigger details (`pattern_details`).
+**Valid with:** all modes and formats.
+**Cannot be used with:** `--mode delta` when a mode is specified.
+
+```bash
+# Basic mode: Tier 1 pattern details in text output
+hotspots analyze src/ --explain-patterns
+
+# Snapshot mode: Tier 1 + Tier 2 details, JSON output
+hotspots analyze src/ --mode snapshot --format json --explain-patterns
+
+# Combined with --explain for full per-function breakdown
+hotspots analyze src/ --mode snapshot --format text --explain --explain-patterns
+```
+
+In **text** output, each function row is followed by indented lines showing the metric values that triggered each pattern:
+
+```
+14.10    critical   src/imports.rs    622    resolve_cargo_workspace_edges  complex_branching, god_function
+           complex_branching: cc=15 (>=10), nd=5 (>=4)
+           god_function: loc=120 (>=60), fo=14 (>=10)
+```
+
+In **JSON** output, the `pattern_details` array is populated on each function object (otherwise omitted).
+
+In **snapshot mode**, Tier 2 enriched patterns (those requiring call graph and git history) are also included in the details.
+
 ##### `--level <LEVEL>`
 **Optional.** Switch to a higher-level ranked view instead of per-function output.
 **Only valid with:** `--mode snapshot --format text`
@@ -307,6 +335,15 @@ hotspots analyze . --mode snapshot --format text --explain
 **Snapshot without persisting (read-only inspection):**
 ```bash
 hotspots analyze . --mode snapshot --no-persist --format json
+```
+
+**Pattern trigger details:**
+```bash
+# Show what triggered each pattern (text)
+hotspots analyze src/ --explain-patterns
+
+# Pattern details in JSON for tooling
+hotspots analyze src/ --mode snapshot --format json --explain-patterns
 ```
 
 ---

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -159,6 +159,8 @@ pub struct AgentFunctionView {
     pub days_since_changed: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fan_in: Option<usize>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub patterns: Vec<String>,
 }
 
 /// A triage quadrant with count and top-N functions
@@ -255,6 +257,7 @@ fn to_agent_view(
                 touches_30d: func.touch_count_30d,
                 days_since_changed: func.days_since_last_change,
                 fan_in: func.callgraph.as_ref().map(|cg| cg.fan_in),
+                patterns: func.patterns.clone(),
             }
         })
         .collect()

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -997,6 +997,8 @@ mod tests {
             driver: None,
             driver_detail: None,
             quadrant: None,
+            patterns: vec![],
+            pattern_details: None,
         }
     }
 

--- a/hotspots-core/src/analysis.rs
+++ b/hotspots-core/src/analysis.rs
@@ -1,5 +1,6 @@
 //! Analysis orchestration - ties together parsing, discovery, CFG, metrics, and reporting
 
+use crate::ast::FunctionNode;
 use crate::language::{self, Language, LanguageParser};
 use crate::metrics;
 use crate::report;
@@ -35,15 +36,35 @@ pub fn analyze_file_with_config(
     let t = thresholds.unwrap_or(&default_thresholds);
     let pt = pattern_thresholds.unwrap_or(&default_pattern_thresholds);
 
-    // Read file
     let src = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read file: {}", path.display()))?;
-
-    // Detect language from file extension
     let language = Language::from_path(path)
         .ok_or_else(|| anyhow::anyhow!("Unsupported file type: {}", path.display()))?;
+    let parser = create_parser(language, source_map)?;
+    let module = parser.parse(&src, &path.to_string_lossy())?;
+    let functions = module.discover_functions(file_index, &src);
 
-    // Get appropriate parser for this language
+    let func_cfg = FunctionAnalysisConfig {
+        options,
+        weights: w,
+        thresholds: t,
+        pattern_thresholds: pt,
+        source_map,
+    };
+    let mut reports = Vec::new();
+    for function in &functions {
+        if let Some(report) = analyze_function(function, path, language, &func_cfg) {
+            reports.push(report);
+        }
+    }
+    Ok(reports)
+}
+
+/// Instantiates the correct parser for the given language.
+fn create_parser(
+    language: Language,
+    source_map: &Lrc<SourceMap>,
+) -> Result<Box<dyn LanguageParser>> {
     let parser: Box<dyn LanguageParser> = match language {
         Language::TypeScript
         | Language::TypeScriptReact
@@ -60,79 +81,76 @@ pub fn analyze_file_with_config(
         }
         Language::Rust => Box::new(language::RustParser),
     };
+    Ok(parser)
+}
 
-    // Parse source file
-    let module = parser.parse(&src, &path.to_string_lossy())?;
+struct FunctionAnalysisConfig<'a> {
+    options: &'a crate::AnalysisOptions,
+    weights: &'a risk::LrsWeights,
+    thresholds: &'a risk::RiskThresholds,
+    pattern_thresholds: &'a crate::patterns::Thresholds,
+    source_map: &'a Lrc<SourceMap>,
+}
 
-    // Discover functions (with suppression extraction)
-    let functions = module.discover_functions(file_index, &src);
-
-    // Analyze each function
-    let mut reports = Vec::new();
-    for function in &functions {
-        // Build CFG using language-specific builder
-        let builder = language::get_builder_for_function(function);
-        let cfg = builder.build(function);
-
-        // Validate CFG
-        if let Err(e) = cfg.validate() {
-            eprintln!(
-                "warning: skipping function '{}' in {}: invalid CFG: {}",
-                function.name.as_deref().unwrap_or("<anonymous>"),
-                path.display(),
-                e
-            );
-            continue;
-        }
-
-        // Extract metrics
-        let raw_metrics = metrics::extract_metrics(function, &cfg);
-
-        // Calculate risk with configured weights/thresholds
-        let (risk_components, lrs, band) = risk::analyze_risk_with_config(&raw_metrics, w, t);
-
-        // Apply filters
-        if let Some(min_lrs) = options.min_lrs {
-            if lrs < min_lrs {
-                continue;
-            }
-        }
-
-        // Classify Tier 1 patterns (Tier 2 requires snapshot mode enrichment)
-        let t1 = crate::patterns::Tier1Input {
-            cc: raw_metrics.cc,
-            nd: raw_metrics.nd,
-            fo: raw_metrics.fo,
-            ns: raw_metrics.ns,
-            loc: raw_metrics.loc,
-        };
-        let t2 = crate::patterns::Tier2Input {
-            fan_in: None,
-            scc_size: None,
-            churn_lines: None,
-            days_since_last_change: None,
-            neighbor_churn: None,
-            is_entrypoint: false,
-        };
-        let patterns = crate::patterns::classify(&t1, &t2, pt);
-
-        // Create report
-        let report = report::FunctionRiskReport::new(
-            function,
-            path.to_string_lossy().to_string(),
-            language.name().to_string(),
-            report::FunctionAnalysis {
-                metrics: raw_metrics,
-                risk: risk_components,
-                lrs,
-                band,
-                patterns,
-            },
-            source_map,
+/// Builds CFG, extracts metrics, computes risk and patterns for one function.
+/// Returns None if the CFG is invalid or the function is filtered by min_lrs.
+fn analyze_function(
+    function: &FunctionNode,
+    path: &Path,
+    language: Language,
+    config: &FunctionAnalysisConfig<'_>,
+) -> Option<report::FunctionRiskReport> {
+    let w = config.weights;
+    let t = config.thresholds;
+    let pt = config.pattern_thresholds;
+    let options = config.options;
+    let source_map = config.source_map;
+    let cfg = language::get_builder_for_function(function).build(function);
+    if let Err(e) = cfg.validate() {
+        eprintln!(
+            "warning: skipping function '{}' in {}: invalid CFG: {}",
+            function.name.as_deref().unwrap_or("<anonymous>"),
+            path.display(),
+            e
         );
-
-        reports.push(report);
+        return None;
     }
 
-    Ok(reports)
+    let raw_metrics = metrics::extract_metrics(function, &cfg);
+    let (risk_components, lrs, band) = risk::analyze_risk_with_config(&raw_metrics, w, t);
+
+    if options.min_lrs.is_some_and(|min| lrs < min) {
+        return None;
+    }
+
+    let t1 = crate::patterns::Tier1Input {
+        cc: raw_metrics.cc,
+        nd: raw_metrics.nd,
+        fo: raw_metrics.fo,
+        ns: raw_metrics.ns,
+        loc: raw_metrics.loc,
+    };
+    let t2 = crate::patterns::Tier2Input {
+        fan_in: None,
+        scc_size: None,
+        churn_lines: None,
+        days_since_last_change: None,
+        neighbor_churn: None,
+        is_entrypoint: false,
+    };
+    let patterns = crate::patterns::classify(&t1, &t2, pt);
+
+    Some(report::FunctionRiskReport::new(
+        function,
+        path.to_string_lossy().to_string(),
+        language.name().to_string(),
+        report::FunctionAnalysis {
+            metrics: raw_metrics,
+            risk: risk_components,
+            lrs,
+            band,
+            patterns,
+        },
+        source_map,
+    ))
 }

--- a/hotspots-core/src/callgraph.rs
+++ b/hotspots-core/src/callgraph.rs
@@ -337,7 +337,7 @@ impl CallGraph {
     }
 
     /// Check if a function is likely an entry point
-    fn is_entry_point(&self, function_id: &str) -> bool {
+    pub fn is_entry_point(&self, function_id: &str) -> bool {
         // Extract function name from ID (format: "file::function")
         let function_name = function_id.split("::").last().unwrap_or("").to_lowercase();
 

--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -92,6 +92,10 @@ pub struct HotspotsConfig {
     /// Lower values = more functions get specific labels; higher = only extreme outliers.
     #[serde(default)]
     pub driver_threshold_percentile: Option<u8>,
+
+    /// Pattern detection thresholds. Overrides defaults from `docs/patterns.md`.
+    #[serde(default)]
+    pub patterns: Option<PatternThresholdsConfig>,
 }
 
 /// Custom risk band thresholds
@@ -138,6 +142,35 @@ pub struct ScoringWeightsConfig {
     pub depth: Option<f64>,
     /// Weight for neighbor churn factor (default: 0.2)
     pub neighbor_churn: Option<f64>,
+}
+
+/// Pattern detection thresholds — override defaults from `docs/patterns.md`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PatternThresholdsConfig {
+    pub complex_branching_cc: Option<usize>,
+    pub complex_branching_nd: Option<usize>,
+    pub deeply_nested_nd: Option<usize>,
+    pub exit_heavy_ns: Option<usize>,
+    pub god_function_loc: Option<usize>,
+    pub god_function_fo: Option<usize>,
+    pub long_function_loc: Option<usize>,
+    pub churn_magnet_churn: Option<usize>,
+    pub churn_magnet_cc: Option<usize>,
+    pub cyclic_hub_scc: Option<usize>,
+    pub cyclic_hub_fan_in: Option<usize>,
+    pub hub_function_fan_in: Option<usize>,
+    pub hub_function_cc: Option<usize>,
+    pub middle_man_fan_in: Option<usize>,
+    pub middle_man_fo: Option<usize>,
+    pub middle_man_cc_max: Option<usize>,
+    pub neighbor_risk_churn: Option<usize>,
+    pub neighbor_risk_fo: Option<usize>,
+    pub shotgun_target_fan_in: Option<usize>,
+    pub shotgun_target_churn: Option<usize>,
+    pub stale_complex_cc: Option<usize>,
+    pub stale_complex_loc: Option<usize>,
+    pub stale_complex_days: Option<u32>,
 }
 
 /// Warning thresholds for proactive alerts
@@ -190,6 +223,8 @@ pub struct ResolvedConfig {
     pub driver_threshold_percentile: u8,
     /// Activity risk scoring weights
     pub scoring_weights: crate::scoring::ScoringWeights,
+    /// Pattern detection thresholds
+    pub pattern_thresholds: crate::patterns::Thresholds,
     /// Path the config was loaded from (None if defaults)
     pub config_path: Option<PathBuf>,
 }
@@ -208,6 +243,9 @@ impl HotspotsConfig {
         }
         if let Some(ref s) = self.scoring {
             validate_scoring(s)?;
+        }
+        if let Some(ref p) = self.patterns {
+            validate_pattern_thresholds(p)?;
         }
         if let Some(min) = self.min_lrs {
             if min < 0.0 {
@@ -361,6 +399,47 @@ fn validate_scoring(s: &ScoringWeightsConfig) -> Result<()> {
     Ok(())
 }
 
+fn validate_pattern_thresholds(p: &PatternThresholdsConfig) -> Result<()> {
+    // All thresholds must be at least 1 when specified
+    let usize_fields: &[(&str, Option<usize>)] = &[
+        ("complex_branching_cc", p.complex_branching_cc),
+        ("complex_branching_nd", p.complex_branching_nd),
+        ("deeply_nested_nd", p.deeply_nested_nd),
+        ("exit_heavy_ns", p.exit_heavy_ns),
+        ("god_function_loc", p.god_function_loc),
+        ("god_function_fo", p.god_function_fo),
+        ("long_function_loc", p.long_function_loc),
+        ("churn_magnet_churn", p.churn_magnet_churn),
+        ("churn_magnet_cc", p.churn_magnet_cc),
+        ("cyclic_hub_scc", p.cyclic_hub_scc),
+        ("cyclic_hub_fan_in", p.cyclic_hub_fan_in),
+        ("hub_function_fan_in", p.hub_function_fan_in),
+        ("hub_function_cc", p.hub_function_cc),
+        ("middle_man_fan_in", p.middle_man_fan_in),
+        ("middle_man_fo", p.middle_man_fo),
+        ("middle_man_cc_max", p.middle_man_cc_max),
+        ("neighbor_risk_churn", p.neighbor_risk_churn),
+        ("neighbor_risk_fo", p.neighbor_risk_fo),
+        ("shotgun_target_fan_in", p.shotgun_target_fan_in),
+        ("shotgun_target_churn", p.shotgun_target_churn),
+        ("stale_complex_cc", p.stale_complex_cc),
+        ("stale_complex_loc", p.stale_complex_loc),
+    ];
+    for (name, val) in usize_fields {
+        if let Some(v) = val {
+            if *v == 0 {
+                anyhow::bail!("patterns.{} must be at least 1 (got 0)", name);
+            }
+        }
+    }
+    if let Some(v) = p.stale_complex_days {
+        if v == 0 {
+            anyhow::bail!("patterns.stale_complex_days must be at least 1 (got 0)");
+        }
+    }
+    Ok(())
+}
+
 impl HotspotsConfig {
     /// Resolve config into compiled form ready for use
     pub fn resolve(&self) -> Result<ResolvedConfig> {
@@ -440,6 +519,40 @@ impl HotspotsConfig {
             None => crate::scoring::ScoringWeights::default(),
         };
 
+        let pattern_thresholds = match &self.patterns {
+            Some(p) => {
+                let d = crate::patterns::Thresholds::default();
+                crate::patterns::Thresholds {
+                    complex_branching_cc: p.complex_branching_cc.unwrap_or(d.complex_branching_cc),
+                    complex_branching_nd: p.complex_branching_nd.unwrap_or(d.complex_branching_nd),
+                    deeply_nested_nd: p.deeply_nested_nd.unwrap_or(d.deeply_nested_nd),
+                    exit_heavy_ns: p.exit_heavy_ns.unwrap_or(d.exit_heavy_ns),
+                    god_function_loc: p.god_function_loc.unwrap_or(d.god_function_loc),
+                    god_function_fo: p.god_function_fo.unwrap_or(d.god_function_fo),
+                    long_function_loc: p.long_function_loc.unwrap_or(d.long_function_loc),
+                    churn_magnet_churn: p.churn_magnet_churn.unwrap_or(d.churn_magnet_churn),
+                    churn_magnet_cc: p.churn_magnet_cc.unwrap_or(d.churn_magnet_cc),
+                    cyclic_hub_scc: p.cyclic_hub_scc.unwrap_or(d.cyclic_hub_scc),
+                    cyclic_hub_fan_in: p.cyclic_hub_fan_in.unwrap_or(d.cyclic_hub_fan_in),
+                    hub_function_fan_in: p.hub_function_fan_in.unwrap_or(d.hub_function_fan_in),
+                    hub_function_cc: p.hub_function_cc.unwrap_or(d.hub_function_cc),
+                    middle_man_fan_in: p.middle_man_fan_in.unwrap_or(d.middle_man_fan_in),
+                    middle_man_fo: p.middle_man_fo.unwrap_or(d.middle_man_fo),
+                    middle_man_cc_max: p.middle_man_cc_max.unwrap_or(d.middle_man_cc_max),
+                    neighbor_risk_churn: p.neighbor_risk_churn.unwrap_or(d.neighbor_risk_churn),
+                    neighbor_risk_fo: p.neighbor_risk_fo.unwrap_or(d.neighbor_risk_fo),
+                    shotgun_target_fan_in: p
+                        .shotgun_target_fan_in
+                        .unwrap_or(d.shotgun_target_fan_in),
+                    shotgun_target_churn: p.shotgun_target_churn.unwrap_or(d.shotgun_target_churn),
+                    stale_complex_cc: p.stale_complex_cc.unwrap_or(d.stale_complex_cc),
+                    stale_complex_loc: p.stale_complex_loc.unwrap_or(d.stale_complex_loc),
+                    stale_complex_days: p.stale_complex_days.unwrap_or(d.stale_complex_days),
+                }
+            }
+            None => crate::patterns::Thresholds::default(),
+        };
+
         Ok(ResolvedConfig {
             include,
             exclude,
@@ -458,6 +571,7 @@ impl HotspotsConfig {
             min_lrs: self.min_lrs,
             top_n: self.top,
             scoring_weights,
+            pattern_thresholds,
             co_change_window_days: self.co_change_window_days.unwrap_or(90),
             co_change_min_count: self.co_change_min_count.unwrap_or(3),
             per_function_touches: self.per_function_touches.unwrap_or(true),

--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -247,37 +247,46 @@ impl HotspotsConfig {
         if let Some(ref p) = self.patterns {
             validate_pattern_thresholds(p)?;
         }
-        if let Some(min) = self.min_lrs {
-            if min < 0.0 {
-                anyhow::bail!("min_lrs must be non-negative (got {})", min);
-            }
-        }
-        if let Some(w) = self.co_change_window_days {
-            if w == 0 {
-                anyhow::bail!("co_change_window_days must be at least 1");
-            }
-        }
-        if let Some(m) = self.co_change_min_count {
-            if m == 0 {
-                anyhow::bail!("co_change_min_count must be at least 1");
-            }
-        }
-        if let Some(p) = self.driver_threshold_percentile {
-            if p == 0 || p >= 100 {
-                anyhow::bail!(
-                    "driver_threshold_percentile must be between 1 and 99 (got {})",
-                    p
-                );
-            }
-        }
-        for pattern in &self.include {
-            Glob::new(pattern).with_context(|| format!("invalid include pattern: {}", pattern))?;
-        }
-        for pattern in &self.exclude {
-            Glob::new(pattern).with_context(|| format!("invalid exclude pattern: {}", pattern))?;
-        }
-        Ok(())
+        validate_scalar_fields(self)?;
+        validate_glob_patterns(&self.include, &self.exclude)
     }
+}
+
+fn validate_scalar_fields(c: &HotspotsConfig) -> Result<()> {
+    if let Some(min) = c.min_lrs {
+        if min < 0.0 {
+            anyhow::bail!("min_lrs must be non-negative (got {})", min);
+        }
+    }
+    if let Some(w) = c.co_change_window_days {
+        if w == 0 {
+            anyhow::bail!("co_change_window_days must be at least 1");
+        }
+    }
+    if let Some(m) = c.co_change_min_count {
+        if m == 0 {
+            anyhow::bail!("co_change_min_count must be at least 1");
+        }
+    }
+    if let Some(p) = c.driver_threshold_percentile {
+        if p == 0 || p >= 100 {
+            anyhow::bail!(
+                "driver_threshold_percentile must be between 1 and 99 (got {})",
+                p
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_glob_patterns(include: &[String], exclude: &[String]) -> Result<()> {
+    for pattern in include {
+        Glob::new(pattern).with_context(|| format!("invalid include pattern: {}", pattern))?;
+    }
+    for pattern in exclude {
+        Glob::new(pattern).with_context(|| format!("invalid exclude pattern: {}", pattern))?;
+    }
+    Ok(())
 }
 
 fn validate_thresholds(t: &ThresholdConfig) -> Result<()> {

--- a/hotspots-core/src/delta.rs
+++ b/hotspots-core/src/delta.rs
@@ -535,6 +535,8 @@ mod tests {
             lrs,
             band: band.to_string(),
             suppression_reason: None,
+            patterns: vec![],
+            pattern_details: None,
             callees: vec![],
         };
 

--- a/hotspots-core/src/html.rs
+++ b/hotspots-core/src/html.rs
@@ -20,6 +20,7 @@ pub fn render_html_snapshot(
     } else {
         render_trends_section(&history_json)
     };
+    let patterns_breakdown = render_pattern_breakdown(&snapshot.functions);
 
     format!(
         r#"<!DOCTYPE html>
@@ -36,6 +37,7 @@ pub fn render_html_snapshot(
         {summary}
         {trends}
         {triage}
+        {patterns_breakdown}
         {functions_table}
         {aggregates_section}
         {footer}
@@ -50,6 +52,7 @@ pub fn render_html_snapshot(
         summary = render_summary(snapshot),
         trends = trends,
         triage = render_triage_panel(&snapshot.functions),
+        patterns_breakdown = patterns_breakdown,
         functions_table = render_functions_table(&snapshot.functions),
         aggregates_section = aggregates.map(render_aggregates).unwrap_or_default(),
         footer = render_footer(),
@@ -442,6 +445,87 @@ footer {
 /* Safe-to-refactor indicator */
 .refactor-ready { color: #22c55e; font-weight: 600; }
 
+/* Pattern pill badges */
+.pattern {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.15rem 0.45rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-family: monospace;
+    cursor: default;
+    white-space: nowrap;
+}
+.pattern-cell { display: flex; flex-wrap: wrap; gap: 3px; align-items: center; }
+
+/* Tier 1 — structural (warm palette) */
+.pattern-complex_branching { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+.pattern-deeply_nested     { background: #fff7ed; color: #c2410c; border-color: #fed7aa; }
+.pattern-exit_heavy        { background: #f5f3ff; color: #7c3aed; border-color: #ddd6fe; }
+.pattern-god_function      { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+.pattern-long_function     { background: #fff1f2; color: #be123c; border-color: #fecdd3; }
+/* Tier 2 — behavioral (cool palette) */
+.pattern-churn_magnet      { background: #eff6ff; color: #1d4ed8; border-color: #bfdbfe; }
+.pattern-cyclic_hub        { background: #fdf4ff; color: #a21caf; border-color: #f0abfc; }
+.pattern-hub_function      { background: #eef2ff; color: #4338ca; border-color: #c7d2fe; }
+.pattern-middle_man        { background: #f1f5f9; color: #475569; border-color: #cbd5e1; }
+.pattern-neighbor_risk     { background: #f0fdfa; color: #0f766e; border-color: #99f6e4; }
+.pattern-shotgun_target    { background: #fdf2f8; color: #be185d; border-color: #fbcfe8; }
+.pattern-stale_complex     { background: #fefce8; color: #854d0e; border-color: #fef08a; }
+/* volatile_god — derived, most severe: inverted dark badge */
+.pattern-volatile_god      { background: #7f1d1d; color: #fef2f2; border-color: #991b1b; }
+
+/* Pattern breakdown widget */
+.pattern-breakdown {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    background: #f9fafb;
+    margin-bottom: 2rem;
+}
+.pattern-breakdown h2 { color: #374151; margin-bottom: 0.4rem; font-size: 1.1rem; }
+.pattern-breakdown-subtitle { font-size: 0.85rem; color: #6b7280; margin-bottom: 1rem; }
+.pattern-chips { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.pattern-chip {
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    border-left: 4px solid;
+    min-width: 130px;
+    flex: 1 1 130px;
+    max-width: 185px;
+}
+.pattern-chip-count { font-size: 1.75rem; font-weight: 800; line-height: 1.2; }
+.pattern-chip-name  { font-size: 0.7rem; font-weight: 700; font-family: monospace; margin-top: 0.25rem; }
+.pattern-chip-desc  { font-size: 0.65rem; color: #9ca3af; margin-top: 0.15rem; }
+
+.pattern-chip-complex_branching { border-left-color: #b45309; background: #fffbeb; }
+.pattern-chip-complex_branching .pattern-chip-count { color: #b45309; }
+.pattern-chip-deeply_nested     { border-left-color: #c2410c; background: #fff7ed; }
+.pattern-chip-deeply_nested     .pattern-chip-count { color: #c2410c; }
+.pattern-chip-exit_heavy        { border-left-color: #7c3aed; background: #f5f3ff; }
+.pattern-chip-exit_heavy        .pattern-chip-count { color: #7c3aed; }
+.pattern-chip-god_function      { border-left-color: #dc2626; background: #fef2f2; }
+.pattern-chip-god_function      .pattern-chip-count { color: #dc2626; }
+.pattern-chip-long_function     { border-left-color: #be123c; background: #fff1f2; }
+.pattern-chip-long_function     .pattern-chip-count { color: #be123c; }
+.pattern-chip-churn_magnet      { border-left-color: #1d4ed8; background: #eff6ff; }
+.pattern-chip-churn_magnet      .pattern-chip-count { color: #1d4ed8; }
+.pattern-chip-cyclic_hub        { border-left-color: #a21caf; background: #fdf4ff; }
+.pattern-chip-cyclic_hub        .pattern-chip-count { color: #a21caf; }
+.pattern-chip-hub_function      { border-left-color: #4338ca; background: #eef2ff; }
+.pattern-chip-hub_function      .pattern-chip-count { color: #4338ca; }
+.pattern-chip-middle_man        { border-left-color: #475569; background: #f1f5f9; }
+.pattern-chip-middle_man        .pattern-chip-count { color: #475569; }
+.pattern-chip-neighbor_risk     { border-left-color: #0f766e; background: #f0fdfa; }
+.pattern-chip-neighbor_risk     .pattern-chip-count { color: #0f766e; }
+.pattern-chip-shotgun_target    { border-left-color: #be185d; background: #fdf2f8; }
+.pattern-chip-shotgun_target    .pattern-chip-count { color: #be185d; }
+.pattern-chip-stale_complex     { border-left-color: #854d0e; background: #fefce8; }
+.pattern-chip-stale_complex     .pattern-chip-count { color: #854d0e; }
+.pattern-chip-volatile_god      { border-left-color: #7f1d1d; background: #fef2f2; }
+.pattern-chip-volatile_god      .pattern-chip-count { color: #7f1d1d; }
+
 /* Driver badges */
 .driver-badge { font-size: 0.75rem; padding: 0.15rem 0.4rem; border-radius: 0.25rem; margin-left: 0.4rem; }
 .driver-high_complexity    { background: #fff3e0; color: #e65100; }
@@ -644,6 +728,53 @@ th.sortable.desc::after {
     .recency-cold { color: #4b5563; }
     .triage-action { color: #9ca3af; }
     .trends-section canvas { background:#1f2937; }
+
+    /* Pattern badges — dark mode */
+    .pattern-complex_branching { background: #2d1b00; color: #fbbf24; border-color: #92400e; }
+    .pattern-deeply_nested     { background: #3a1500; color: #fb923c; border-color: #c2410c; }
+    .pattern-exit_heavy        { background: #1e0050; color: #c4b5fd; border-color: #6d28d9; }
+    .pattern-god_function      { background: #3a0000; color: #fca5a5; border-color: #991b1b; }
+    .pattern-long_function     { background: #3b0018; color: #fda4af; border-color: #9f1239; }
+    .pattern-churn_magnet      { background: #001a3d; color: #93c5fd; border-color: #1e40af; }
+    .pattern-cyclic_hub        { background: #2a0035; color: #e879f9; border-color: #86198f; }
+    .pattern-hub_function      { background: #13104a; color: #a5b4fc; border-color: #3730a3; }
+    .pattern-middle_man        { background: #1a2030; color: #94a3b8; border-color: #334155; }
+    .pattern-neighbor_risk     { background: #002020; color: #5eead4; border-color: #0f766e; }
+    .pattern-shotgun_target    { background: #3b0020; color: #f9a8d4; border-color: #9d174d; }
+    .pattern-stale_complex     { background: #1a1200; color: #fde047; border-color: #854d0e; }
+    .pattern-volatile_god      { background: #450a0a; color: #fef2f2; border-color: #7f1d1d; }
+
+    /* Pattern breakdown widget — dark mode */
+    .pattern-breakdown         { border-color: #374151; background: #1f2937; }
+    .pattern-breakdown h2      { color: #f9fafb; }
+    .pattern-breakdown-subtitle { color: #9ca3af; }
+    .pattern-chip-desc         { color: #6b7280; }
+    .pattern-chip-complex_branching { background: #2d1b00; }
+    .pattern-chip-complex_branching .pattern-chip-count { color: #fbbf24; }
+    .pattern-chip-deeply_nested     { background: #3a1500; }
+    .pattern-chip-deeply_nested     .pattern-chip-count { color: #fb923c; }
+    .pattern-chip-exit_heavy        { background: #1e0050; }
+    .pattern-chip-exit_heavy        .pattern-chip-count { color: #c4b5fd; }
+    .pattern-chip-god_function      { background: #3a0000; }
+    .pattern-chip-god_function      .pattern-chip-count { color: #fca5a5; }
+    .pattern-chip-long_function     { background: #3b0018; }
+    .pattern-chip-long_function     .pattern-chip-count { color: #fda4af; }
+    .pattern-chip-churn_magnet      { background: #001a3d; }
+    .pattern-chip-churn_magnet      .pattern-chip-count { color: #93c5fd; }
+    .pattern-chip-cyclic_hub        { background: #2a0035; }
+    .pattern-chip-cyclic_hub        .pattern-chip-count { color: #e879f9; }
+    .pattern-chip-hub_function      { background: #13104a; }
+    .pattern-chip-hub_function      .pattern-chip-count { color: #a5b4fc; }
+    .pattern-chip-middle_man        { background: #1a2030; }
+    .pattern-chip-middle_man        .pattern-chip-count { color: #94a3b8; }
+    .pattern-chip-neighbor_risk     { background: #002020; }
+    .pattern-chip-neighbor_risk     .pattern-chip-count { color: #5eead4; }
+    .pattern-chip-shotgun_target    { background: #3b0020; }
+    .pattern-chip-shotgun_target    .pattern-chip-count { color: #f9a8d4; }
+    .pattern-chip-stale_complex     { background: #1a1200; }
+    .pattern-chip-stale_complex     .pattern-chip-count { color: #fde047; }
+    .pattern-chip-volatile_god      { background: #450a0a; }
+    .pattern-chip-volatile_god      .pattern-chip-count { color: #fef2f2; }
 }
 "#
 }
@@ -1030,6 +1161,63 @@ fn render_summary(snapshot: &Snapshot) -> String {
     )
 }
 
+/// Render pattern breakdown widget — shows per-pattern counts sorted by frequency.
+/// Returns empty string when no functions have patterns.
+fn render_pattern_breakdown(functions: &[FunctionSnapshot]) -> String {
+    use std::collections::HashMap;
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for f in functions {
+        for p in &f.patterns {
+            *counts.entry(p.as_str()).or_insert(0) += 1;
+        }
+    }
+    if counts.is_empty() {
+        return String::new();
+    }
+    let mut sorted: Vec<(&str, usize)> = counts.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+
+    let chips: String = sorted
+        .iter()
+        .map(|(id, count)| {
+            let desc = pattern_description(id);
+            format!(
+                r#"<div class="pattern-chip pattern-chip-{id}"><div class="pattern-chip-count">{count}</div><div class="pattern-chip-name">{id}</div><div class="pattern-chip-desc">{desc}</div></div>"#,
+                id = html_escape(id),
+                count = count,
+                desc = desc,
+            )
+        })
+        .collect();
+
+    let affected = functions.iter().filter(|f| !f.patterns.is_empty()).count();
+    format!(
+        r#"<div class="pattern-breakdown"><h2>Pattern Breakdown</h2><p class="pattern-breakdown-subtitle">Detected across {affected} function{s}</p><div class="pattern-chips">{chips}</div></div>"#,
+        affected = affected,
+        s = if affected == 1 { "" } else { "s" },
+        chips = chips,
+    )
+}
+
+fn pattern_description(id: &str) -> &'static str {
+    match id {
+        "complex_branching" => "High cyclomatic complexity and nesting",
+        "deeply_nested" => "Nesting depth \u{2265} 5 levels",
+        "exit_heavy" => "Many early returns",
+        "god_function" => "Too many responsibilities",
+        "long_function" => "Exceeds recommended length",
+        "churn_magnet" => "Complex and frequently changed",
+        "cyclic_hub" => "Node in a dependency cycle",
+        "hub_function" => "High fan-in and complex",
+        "middle_man" => "High fan-out, trivial logic",
+        "neighbor_risk" => "Called from high-churn functions",
+        "shotgun_target" => "Many callers and high churn",
+        "stale_complex" => "Complex but rarely touched",
+        "volatile_god" => "God function under heavy churn",
+        _ => "",
+    }
+}
+
 /// Render functions table
 fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
     // Only show churn/fanin columns when enough functions actually have data
@@ -1039,6 +1227,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
     let has_touches = functions.iter().any(|f| f.touch_count_30d.is_some());
     let has_recency = functions.iter().any(|f| f.days_since_last_change.is_some());
     let has_fanin = functions.iter().filter(|f| f.callgraph.is_some()).count() >= sparse_min;
+    let has_patterns = functions.iter().any(|f| !f.patterns.is_empty());
 
     let rows: String = functions
         .iter()
@@ -1114,6 +1303,47 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
             } else {
                 String::new()
             };
+            let patterns_cell = if has_patterns {
+                if f.patterns.is_empty() {
+                    "<td>—</td>".to_string()
+                } else {
+                    let spans: String = f
+                        .patterns
+                        .iter()
+                        .enumerate()
+                        .map(|(i, id)| {
+                            let title = f
+                                .pattern_details
+                                .as_ref()
+                                .and_then(|ds| ds.get(i))
+                                .map(|d| {
+                                    let conds = d
+                                        .triggered_by
+                                        .iter()
+                                        .map(|t| {
+                                            format!(
+                                                "{}={} ({}{})",
+                                                t.metric, t.value, t.op, t.threshold
+                                            )
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(", ");
+                                    format!(" title=\"{}\"", html_escape(&conds))
+                                })
+                                .unwrap_or_default();
+                            format!(
+                                r#"<span class="pattern pattern-{}"{title}>{}</span>"#,
+                                html_escape(id),
+                                html_escape(id),
+                                title = title,
+                            )
+                        })
+                        .collect();
+                    format!("<td><div class=\"pattern-cell\">{}</div></td>", spans)
+                }
+            } else {
+                String::new()
+            };
 
             format!(
                 "<tr data-file=\"{file}\" data-function=\"{function}\" data-band=\"{band}\" \
@@ -1130,7 +1360,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
                  <td>{nd}</td>\n\
                  <td>{fo}</td>\n\
                  <td>{ns}</td>\n\
-                 {activity_cell}{churn_cell}{touches_cell}{recency_cell}{fanin_cell}\
+                 {activity_cell}{churn_cell}{touches_cell}{recency_cell}{fanin_cell}{patterns_cell}\
                  </tr>",
                 file = html_escape(&f.file),
                 file_display = html_escape(&f.file),
@@ -1165,6 +1395,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
                 touches_cell = touches_cell,
                 recency_cell = recency_cell,
                 fanin_cell = fanin_cell,
+                patterns_cell = patterns_cell,
             )
         })
         .collect();
@@ -1191,6 +1422,11 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
     };
     let fanin_header = if has_fanin {
         "<th class=\"sortable\" data-column=\"fanin\" title=\"Number of functions that call this one — higher means more callers, riskier to change\">Fan-in</th>"
+    } else {
+        ""
+    };
+    let patterns_header = if has_patterns {
+        "<th title=\"Detected structural and behavioral patterns\">Patterns</th>"
     } else {
         ""
     };
@@ -1248,6 +1484,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
                 {touches_header}
                 {recency_header}
                 {fanin_header}
+                {patterns_header}
             </tr>
         </thead>
         <tbody>
@@ -1262,6 +1499,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
         touches_header = touches_header,
         recency_header = recency_header,
         fanin_header = fanin_header,
+        patterns_header = patterns_header,
     )
 }
 

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod imports;
 pub mod language;
 pub mod metrics;
 pub mod parser;
+pub mod patterns;
 pub mod policy;
 pub mod prune;
 pub mod report;
@@ -98,6 +99,7 @@ pub fn analyze_with_config(
             &options,
             weights.as_ref(),
             thresholds.as_ref(),
+            resolved_config.map(|c| &c.pattern_thresholds),
         ) {
             Ok(reports) => {
                 all_reports.extend(reports);

--- a/hotspots-core/src/patterns.rs
+++ b/hotspots-core/src/patterns.rs
@@ -1,0 +1,1002 @@
+//! Pattern classification engine
+//!
+//! Pure, stateless pattern detection from function metrics.
+//! No I/O. Same inputs always produce the same outputs.
+//! See `docs/patterns.md` for the canonical specification.
+
+use serde::{Deserialize, Serialize};
+
+/// Input for Tier 1 (structural) pattern classification.
+/// Available in all analysis modes from raw metrics.
+pub struct Tier1Input {
+    pub cc: usize,
+    pub nd: usize,
+    pub fo: usize,
+    pub ns: usize,
+    pub loc: usize,
+}
+
+/// Input for Tier 2 (enriched) pattern classification.
+/// All fields are `Option` — absent outside snapshot mode.
+pub struct Tier2Input {
+    pub fan_in: Option<usize>,
+    pub scc_size: Option<usize>,
+    pub churn_lines: Option<usize>,
+    pub days_since_last_change: Option<u32>,
+    pub neighbor_churn: Option<usize>,
+    /// Suppresses `middle_man` and `neighbor_risk` when true.
+    /// Set from call graph entry point detection.
+    pub is_entrypoint: bool,
+}
+
+/// Default thresholds for all patterns. Values match `docs/patterns.md`.
+///
+/// Pass `&Thresholds::default()` unless the project has configured overrides
+/// via `.hotspotsrc.json`. The `classify` functions accept this by reference
+/// so the type signature accommodates overrides without any API change.
+#[derive(Debug, Clone)]
+pub struct Thresholds {
+    pub complex_branching_cc: usize,
+    pub complex_branching_nd: usize,
+    pub deeply_nested_nd: usize,
+    pub exit_heavy_ns: usize,
+    pub god_function_loc: usize,
+    pub god_function_fo: usize,
+    pub long_function_loc: usize,
+    pub churn_magnet_churn: usize,
+    pub churn_magnet_cc: usize,
+    pub cyclic_hub_scc: usize,
+    pub cyclic_hub_fan_in: usize,
+    pub hub_function_fan_in: usize,
+    pub hub_function_cc: usize,
+    pub middle_man_fan_in: usize,
+    pub middle_man_fo: usize,
+    pub middle_man_cc_max: usize,
+    pub neighbor_risk_churn: usize,
+    pub neighbor_risk_fo: usize,
+    pub shotgun_target_fan_in: usize,
+    pub shotgun_target_churn: usize,
+    pub stale_complex_cc: usize,
+    pub stale_complex_loc: usize,
+    pub stale_complex_days: u32,
+}
+
+impl Default for Thresholds {
+    fn default() -> Self {
+        Thresholds {
+            complex_branching_cc: 10,
+            complex_branching_nd: 4,
+            deeply_nested_nd: 5,
+            exit_heavy_ns: 5,
+            god_function_loc: 60,
+            god_function_fo: 10,
+            long_function_loc: 80,
+            churn_magnet_churn: 200,
+            churn_magnet_cc: 8,
+            cyclic_hub_scc: 2,
+            cyclic_hub_fan_in: 6,
+            hub_function_fan_in: 10,
+            hub_function_cc: 8,
+            middle_man_fan_in: 8,
+            middle_man_fo: 8,
+            middle_man_cc_max: 4,
+            neighbor_risk_churn: 400,
+            neighbor_risk_fo: 8,
+            shotgun_target_fan_in: 8,
+            shotgun_target_churn: 150,
+            stale_complex_cc: 10,
+            stale_complex_loc: 60,
+            stale_complex_days: 180,
+        }
+    }
+}
+
+/// A single metric condition that caused a pattern to fire.
+/// Populated only when `--explain-patterns` is requested.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TriggeredBy {
+    pub metric: String,
+    pub op: String,
+    pub value: usize,
+    pub threshold: usize,
+}
+
+/// Full detail for a single fired pattern.
+/// Populated only when `--explain-patterns` is requested.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PatternDetail {
+    pub id: String,
+    /// 1 = Tier 1 (structural), 2 = Tier 2 (enriched).
+    pub tier: u8,
+    /// "primitive" or "derived".
+    pub kind: String,
+    pub triggered_by: Vec<TriggeredBy>,
+}
+
+/// Classify patterns and return sorted IDs.
+///
+/// Ordering: Tier 1 patterns alphabetically, then Tier 2 alphabetically.
+/// Delegates entirely to `classify_detailed` — no separate threshold logic.
+pub fn classify(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Vec<String> {
+    classify_detailed(t1, t2, th)
+        .into_iter()
+        .map(|d| d.id)
+        .collect()
+}
+
+/// Classify patterns and return full detail for each.
+///
+/// This is the canonical implementation. `classify` delegates here.
+/// Use this when `--explain-patterns` is active.
+pub fn classify_detailed(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Vec<PatternDetail> {
+    let mut results = Vec::new();
+
+    // Compute primitives needed for derived pattern check up-front.
+    let god = check_god_function(t1, th);
+    let churn = check_churn_magnet(t1, t2, th);
+
+    // Tier 1 — alphabetical
+    if let Some(d) = check_complex_branching(t1, th) {
+        results.push(d);
+    }
+    if let Some(d) = check_deeply_nested(t1, th) {
+        results.push(d);
+    }
+    if let Some(d) = check_exit_heavy(t1, th) {
+        results.push(d);
+    }
+    if let Some(d) = god.clone() {
+        results.push(d);
+    }
+    if let Some(d) = check_long_function(t1, th) {
+        results.push(d);
+    }
+
+    // Tier 2 — alphabetical
+    if let Some(d) = churn.clone() {
+        results.push(d);
+    }
+    if let Some(d) = check_cyclic_hub(t2, th) {
+        results.push(d);
+    }
+    if let Some(d) = check_hub_function(t1, t2, th) {
+        results.push(d);
+    }
+    if let Some(d) = check_middle_man(t1, t2, th) {
+        results.push(d);
+    }
+    if let Some(d) = check_neighbor_risk(t1, t2, th) {
+        results.push(d);
+    }
+    if let Some(d) = check_shotgun_target(t2, th) {
+        results.push(d);
+    }
+    if let Some(d) = check_stale_complex(t1, t2, th) {
+        results.push(d);
+    }
+
+    // volatile_god: derived — fires iff both god_function AND churn_magnet fired.
+    // triggered_by is the union of both; no raw thresholds re-evaluated here.
+    if let (Some(ref g), Some(ref c)) = (&god, &churn) {
+        let mut triggered_by = g.triggered_by.clone();
+        triggered_by.extend(c.triggered_by.clone());
+        results.push(PatternDetail {
+            id: "volatile_god".to_string(),
+            tier: 2,
+            kind: "derived".to_string(),
+            triggered_by,
+        });
+    }
+
+    results
+}
+
+// ---------- Tier 1 helpers ----------
+
+fn check_complex_branching(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail> {
+    if t.cc >= th.complex_branching_cc && t.nd >= th.complex_branching_nd {
+        Some(PatternDetail {
+            id: "complex_branching".to_string(),
+            tier: 1,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("CC", ">=", t.cc, th.complex_branching_cc),
+                tb("ND", ">=", t.nd, th.complex_branching_nd),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_deeply_nested(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail> {
+    if t.nd >= th.deeply_nested_nd {
+        Some(PatternDetail {
+            id: "deeply_nested".to_string(),
+            tier: 1,
+            kind: "primitive".to_string(),
+            triggered_by: vec![tb("ND", ">=", t.nd, th.deeply_nested_nd)],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_exit_heavy(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail> {
+    if t.ns >= th.exit_heavy_ns {
+        Some(PatternDetail {
+            id: "exit_heavy".to_string(),
+            tier: 1,
+            kind: "primitive".to_string(),
+            triggered_by: vec![tb("NS", ">=", t.ns, th.exit_heavy_ns)],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_god_function(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail> {
+    if t.loc >= th.god_function_loc && t.fo >= th.god_function_fo {
+        Some(PatternDetail {
+            id: "god_function".to_string(),
+            tier: 1,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("LOC", ">=", t.loc, th.god_function_loc),
+                tb("FO", ">=", t.fo, th.god_function_fo),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_long_function(t: &Tier1Input, th: &Thresholds) -> Option<PatternDetail> {
+    if t.loc >= th.long_function_loc {
+        Some(PatternDetail {
+            id: "long_function".to_string(),
+            tier: 1,
+            kind: "primitive".to_string(),
+            triggered_by: vec![tb("LOC", ">=", t.loc, th.long_function_loc)],
+        })
+    } else {
+        None
+    }
+}
+
+// ---------- Tier 2 helpers ----------
+
+fn check_churn_magnet(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail> {
+    let churn = t2.churn_lines?;
+    if churn >= th.churn_magnet_churn && t1.cc >= th.churn_magnet_cc {
+        Some(PatternDetail {
+            id: "churn_magnet".to_string(),
+            tier: 2,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("churn_lines", ">=", churn, th.churn_magnet_churn),
+                tb("CC", ">=", t1.cc, th.churn_magnet_cc),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_cyclic_hub(t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail> {
+    let scc = t2.scc_size?;
+    let fan_in = t2.fan_in?;
+    if scc >= th.cyclic_hub_scc && fan_in >= th.cyclic_hub_fan_in {
+        Some(PatternDetail {
+            id: "cyclic_hub".to_string(),
+            tier: 2,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("scc_size", ">=", scc, th.cyclic_hub_scc),
+                tb("fan_in", ">=", fan_in, th.cyclic_hub_fan_in),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_hub_function(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail> {
+    let fan_in = t2.fan_in?;
+    if fan_in >= th.hub_function_fan_in && t1.cc >= th.hub_function_cc {
+        Some(PatternDetail {
+            id: "hub_function".to_string(),
+            tier: 2,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("fan_in", ">=", fan_in, th.hub_function_fan_in),
+                tb("CC", ">=", t1.cc, th.hub_function_cc),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_middle_man(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail> {
+    if t2.is_entrypoint {
+        return None;
+    }
+    let fan_in = t2.fan_in?;
+    if fan_in >= th.middle_man_fan_in && t1.fo >= th.middle_man_fo && t1.cc <= th.middle_man_cc_max
+    {
+        Some(PatternDetail {
+            id: "middle_man".to_string(),
+            tier: 2,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("fan_in", ">=", fan_in, th.middle_man_fan_in),
+                tb("FO", ">=", t1.fo, th.middle_man_fo),
+                tb("CC", "<=", t1.cc, th.middle_man_cc_max),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_neighbor_risk(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail> {
+    if t2.is_entrypoint {
+        return None;
+    }
+    let nc = t2.neighbor_churn?;
+    if nc >= th.neighbor_risk_churn && t1.fo >= th.neighbor_risk_fo {
+        Some(PatternDetail {
+            id: "neighbor_risk".to_string(),
+            tier: 2,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("neighbor_churn", ">=", nc, th.neighbor_risk_churn),
+                tb("FO", ">=", t1.fo, th.neighbor_risk_fo),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_shotgun_target(t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail> {
+    let fan_in = t2.fan_in?;
+    let churn = t2.churn_lines?;
+    if fan_in >= th.shotgun_target_fan_in && churn >= th.shotgun_target_churn {
+        Some(PatternDetail {
+            id: "shotgun_target".to_string(),
+            tier: 2,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("fan_in", ">=", fan_in, th.shotgun_target_fan_in),
+                tb("churn_lines", ">=", churn, th.shotgun_target_churn),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+fn check_stale_complex(t1: &Tier1Input, t2: &Tier2Input, th: &Thresholds) -> Option<PatternDetail> {
+    let days = t2.days_since_last_change?;
+    if t1.cc >= th.stale_complex_cc
+        && t1.loc >= th.stale_complex_loc
+        && days >= th.stale_complex_days
+    {
+        Some(PatternDetail {
+            id: "stale_complex".to_string(),
+            tier: 2,
+            kind: "primitive".to_string(),
+            triggered_by: vec![
+                tb("CC", ">=", t1.cc, th.stale_complex_cc),
+                tb("LOC", ">=", t1.loc, th.stale_complex_loc),
+                tb(
+                    "days_since_last_change",
+                    ">=",
+                    days as usize,
+                    th.stale_complex_days as usize,
+                ),
+            ],
+        })
+    } else {
+        None
+    }
+}
+
+/// Helper: construct a `TriggeredBy` record.
+fn tb(metric: &str, op: &str, value: usize, threshold: usize) -> TriggeredBy {
+    TriggeredBy {
+        metric: metric.to_string(),
+        op: op.to_string(),
+        value,
+        threshold,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t1(cc: usize, nd: usize, fo: usize, ns: usize, loc: usize) -> Tier1Input {
+        Tier1Input {
+            cc,
+            nd,
+            fo,
+            ns,
+            loc,
+        }
+    }
+
+    fn t2_none() -> Tier2Input {
+        Tier2Input {
+            fan_in: None,
+            scc_size: None,
+            churn_lines: None,
+            days_since_last_change: None,
+            neighbor_churn: None,
+            is_entrypoint: false,
+        }
+    }
+
+    fn t2(
+        fan_in: usize,
+        scc_size: usize,
+        churn_lines: usize,
+        days: u32,
+        neighbor_churn: usize,
+    ) -> Tier2Input {
+        Tier2Input {
+            fan_in: Some(fan_in),
+            scc_size: Some(scc_size),
+            churn_lines: Some(churn_lines),
+            days_since_last_change: Some(days),
+            neighbor_churn: Some(neighbor_churn),
+            is_entrypoint: false,
+        }
+    }
+
+    fn has(patterns: &[String], id: &str) -> bool {
+        patterns.iter().any(|p| p == id)
+    }
+
+    fn th() -> Thresholds {
+        Thresholds::default()
+    }
+
+    // ---------- complex_branching ----------
+
+    #[test]
+    fn complex_branching_below_threshold() {
+        let p = classify(&t1(9, 4, 0, 0, 0), &t2_none(), &th());
+        assert!(!has(&p, "complex_branching"));
+        let p = classify(&t1(10, 3, 0, 0, 0), &t2_none(), &th());
+        assert!(!has(&p, "complex_branching"));
+    }
+
+    #[test]
+    fn complex_branching_at_threshold() {
+        let p = classify(&t1(10, 4, 0, 0, 0), &t2_none(), &th());
+        assert!(has(&p, "complex_branching"));
+    }
+
+    #[test]
+    fn complex_branching_above_threshold() {
+        let p = classify(&t1(20, 8, 0, 0, 0), &t2_none(), &th());
+        assert!(has(&p, "complex_branching"));
+    }
+
+    // ---------- deeply_nested ----------
+
+    #[test]
+    fn deeply_nested_below_threshold() {
+        let p = classify(&t1(0, 4, 0, 0, 0), &t2_none(), &th());
+        assert!(!has(&p, "deeply_nested"));
+    }
+
+    #[test]
+    fn deeply_nested_at_threshold() {
+        let p = classify(&t1(0, 5, 0, 0, 0), &t2_none(), &th());
+        assert!(has(&p, "deeply_nested"));
+    }
+
+    #[test]
+    fn deeply_nested_above_threshold() {
+        let p = classify(&t1(0, 10, 0, 0, 0), &t2_none(), &th());
+        assert!(has(&p, "deeply_nested"));
+    }
+
+    // ---------- exit_heavy ----------
+
+    #[test]
+    fn exit_heavy_below_threshold() {
+        let p = classify(&t1(0, 0, 0, 4, 0), &t2_none(), &th());
+        assert!(!has(&p, "exit_heavy"));
+    }
+
+    #[test]
+    fn exit_heavy_at_threshold() {
+        let p = classify(&t1(0, 0, 0, 5, 0), &t2_none(), &th());
+        assert!(has(&p, "exit_heavy"));
+    }
+
+    #[test]
+    fn exit_heavy_above_threshold() {
+        let p = classify(&t1(0, 0, 0, 10, 0), &t2_none(), &th());
+        assert!(has(&p, "exit_heavy"));
+    }
+
+    // ---------- god_function ----------
+
+    #[test]
+    fn god_function_below_threshold() {
+        // LOC below
+        let p = classify(&t1(0, 0, 10, 0, 59), &t2_none(), &th());
+        assert!(!has(&p, "god_function"));
+        // FO below
+        let p = classify(&t1(0, 0, 9, 0, 60), &t2_none(), &th());
+        assert!(!has(&p, "god_function"));
+    }
+
+    #[test]
+    fn god_function_at_threshold() {
+        let p = classify(&t1(0, 0, 10, 0, 60), &t2_none(), &th());
+        assert!(has(&p, "god_function"));
+    }
+
+    #[test]
+    fn god_function_above_threshold() {
+        let p = classify(&t1(0, 0, 20, 0, 120), &t2_none(), &th());
+        assert!(has(&p, "god_function"));
+    }
+
+    // ---------- long_function ----------
+
+    #[test]
+    fn long_function_below_threshold() {
+        let p = classify(&t1(0, 0, 0, 0, 79), &t2_none(), &th());
+        assert!(!has(&p, "long_function"));
+    }
+
+    #[test]
+    fn long_function_at_threshold() {
+        let p = classify(&t1(0, 0, 0, 0, 80), &t2_none(), &th());
+        assert!(has(&p, "long_function"));
+    }
+
+    #[test]
+    fn long_function_above_threshold() {
+        let p = classify(&t1(0, 0, 0, 0, 200), &t2_none(), &th());
+        assert!(has(&p, "long_function"));
+    }
+
+    // ---------- churn_magnet ----------
+
+    #[test]
+    fn churn_magnet_below_threshold() {
+        // churn below
+        let t = Tier2Input {
+            churn_lines: Some(199),
+            ..t2(0, 1, 0, 0, 0)
+        };
+        let p = classify(&t1(8, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "churn_magnet"));
+        // cc below
+        let t = Tier2Input {
+            churn_lines: Some(200),
+            ..t2(0, 1, 0, 0, 0)
+        };
+        let p = classify(&t1(7, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "churn_magnet"));
+    }
+
+    #[test]
+    fn churn_magnet_at_threshold() {
+        let t = Tier2Input {
+            churn_lines: Some(200),
+            ..t2(0, 1, 0, 0, 0)
+        };
+        let p = classify(&t1(8, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "churn_magnet"));
+    }
+
+    #[test]
+    fn churn_magnet_above_threshold() {
+        let t = Tier2Input {
+            churn_lines: Some(500),
+            ..t2(0, 1, 0, 0, 0)
+        };
+        let p = classify(&t1(15, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "churn_magnet"));
+    }
+
+    // ---------- cyclic_hub ----------
+
+    #[test]
+    fn cyclic_hub_below_threshold() {
+        // scc below
+        let t = Tier2Input {
+            scc_size: Some(1),
+            fan_in: Some(6),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "cyclic_hub"));
+        // fan_in below
+        let t = Tier2Input {
+            scc_size: Some(2),
+            fan_in: Some(5),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "cyclic_hub"));
+    }
+
+    #[test]
+    fn cyclic_hub_at_threshold() {
+        let t = Tier2Input {
+            scc_size: Some(2),
+            fan_in: Some(6),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "cyclic_hub"));
+    }
+
+    #[test]
+    fn cyclic_hub_above_threshold() {
+        let t = Tier2Input {
+            scc_size: Some(5),
+            fan_in: Some(20),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "cyclic_hub"));
+    }
+
+    // ---------- hub_function ----------
+
+    #[test]
+    fn hub_function_below_threshold() {
+        // fan_in below
+        let t = Tier2Input {
+            fan_in: Some(9),
+            ..t2_none()
+        };
+        let p = classify(&t1(8, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "hub_function"));
+        // cc below
+        let t = Tier2Input {
+            fan_in: Some(10),
+            ..t2_none()
+        };
+        let p = classify(&t1(7, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "hub_function"));
+    }
+
+    #[test]
+    fn hub_function_at_threshold() {
+        let t = Tier2Input {
+            fan_in: Some(10),
+            ..t2_none()
+        };
+        let p = classify(&t1(8, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "hub_function"));
+    }
+
+    #[test]
+    fn hub_function_above_threshold() {
+        let t = Tier2Input {
+            fan_in: Some(25),
+            ..t2_none()
+        };
+        let p = classify(&t1(20, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "hub_function"));
+    }
+
+    // ---------- middle_man ----------
+
+    #[test]
+    fn middle_man_below_threshold() {
+        // fan_in below
+        let t = Tier2Input {
+            fan_in: Some(7),
+            ..t2_none()
+        };
+        let p = classify(&t1(2, 0, 8, 0, 0), &t, &th());
+        assert!(!has(&p, "middle_man"));
+        // fo below
+        let t = Tier2Input {
+            fan_in: Some(8),
+            ..t2_none()
+        };
+        let p = classify(&t1(2, 0, 7, 0, 0), &t, &th());
+        assert!(!has(&p, "middle_man"));
+        // cc above max
+        let t = Tier2Input {
+            fan_in: Some(8),
+            ..t2_none()
+        };
+        let p = classify(&t1(5, 0, 8, 0, 0), &t, &th());
+        assert!(!has(&p, "middle_man"));
+    }
+
+    #[test]
+    fn middle_man_at_threshold() {
+        let t = Tier2Input {
+            fan_in: Some(8),
+            ..t2_none()
+        };
+        let p = classify(&t1(4, 0, 8, 0, 0), &t, &th());
+        assert!(has(&p, "middle_man"));
+    }
+
+    #[test]
+    fn middle_man_above_threshold() {
+        let t = Tier2Input {
+            fan_in: Some(20),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 15, 0, 0), &t, &th());
+        assert!(has(&p, "middle_man"));
+    }
+
+    // ---------- neighbor_risk ----------
+
+    #[test]
+    fn neighbor_risk_below_threshold() {
+        // churn below
+        let t = Tier2Input {
+            neighbor_churn: Some(399),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 8, 0, 0), &t, &th());
+        assert!(!has(&p, "neighbor_risk"));
+        // fo below
+        let t = Tier2Input {
+            neighbor_churn: Some(400),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 7, 0, 0), &t, &th());
+        assert!(!has(&p, "neighbor_risk"));
+    }
+
+    #[test]
+    fn neighbor_risk_at_threshold() {
+        let t = Tier2Input {
+            neighbor_churn: Some(400),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 8, 0, 0), &t, &th());
+        assert!(has(&p, "neighbor_risk"));
+    }
+
+    #[test]
+    fn neighbor_risk_above_threshold() {
+        let t = Tier2Input {
+            neighbor_churn: Some(1000),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 20, 0, 0), &t, &th());
+        assert!(has(&p, "neighbor_risk"));
+    }
+
+    // ---------- shotgun_target ----------
+
+    #[test]
+    fn shotgun_target_below_threshold() {
+        // fan_in below
+        let t = Tier2Input {
+            fan_in: Some(7),
+            churn_lines: Some(150),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "shotgun_target"));
+        // churn below
+        let t = Tier2Input {
+            fan_in: Some(8),
+            churn_lines: Some(149),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(!has(&p, "shotgun_target"));
+    }
+
+    #[test]
+    fn shotgun_target_at_threshold() {
+        let t = Tier2Input {
+            fan_in: Some(8),
+            churn_lines: Some(150),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "shotgun_target"));
+    }
+
+    #[test]
+    fn shotgun_target_above_threshold() {
+        let t = Tier2Input {
+            fan_in: Some(30),
+            churn_lines: Some(500),
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 0, 0, 0), &t, &th());
+        assert!(has(&p, "shotgun_target"));
+    }
+
+    // ---------- stale_complex ----------
+
+    #[test]
+    fn stale_complex_below_threshold() {
+        // cc below
+        let t = Tier2Input {
+            days_since_last_change: Some(180),
+            ..t2_none()
+        };
+        let p = classify(&t1(9, 0, 0, 0, 60), &t, &th());
+        assert!(!has(&p, "stale_complex"));
+        // loc below
+        let t = Tier2Input {
+            days_since_last_change: Some(180),
+            ..t2_none()
+        };
+        let p = classify(&t1(10, 0, 0, 0, 59), &t, &th());
+        assert!(!has(&p, "stale_complex"));
+        // days below
+        let t = Tier2Input {
+            days_since_last_change: Some(179),
+            ..t2_none()
+        };
+        let p = classify(&t1(10, 0, 0, 0, 60), &t, &th());
+        assert!(!has(&p, "stale_complex"));
+    }
+
+    #[test]
+    fn stale_complex_at_threshold() {
+        let t = Tier2Input {
+            days_since_last_change: Some(180),
+            ..t2_none()
+        };
+        let p = classify(&t1(10, 0, 0, 0, 60), &t, &th());
+        assert!(has(&p, "stale_complex"));
+    }
+
+    #[test]
+    fn stale_complex_above_threshold() {
+        let t = Tier2Input {
+            days_since_last_change: Some(365),
+            ..t2_none()
+        };
+        let p = classify(&t1(20, 0, 0, 0, 200), &t, &th());
+        assert!(has(&p, "stale_complex"));
+    }
+
+    // ---------- volatile_god (derived) ----------
+
+    #[test]
+    fn volatile_god_only_god_does_not_fire() {
+        // god_function fires, churn_magnet does not
+        let t = Tier2Input {
+            churn_lines: Some(100),
+            ..t2_none()
+        }; // churn < 200
+        let p = classify(&t1(8, 0, 10, 0, 60), &t, &th());
+        assert!(has(&p, "god_function"));
+        assert!(!has(&p, "volatile_god"));
+    }
+
+    #[test]
+    fn volatile_god_only_churn_does_not_fire() {
+        // churn_magnet fires, god_function does not
+        let t = Tier2Input {
+            churn_lines: Some(200),
+            ..t2_none()
+        };
+        let p = classify(&t1(8, 0, 5, 0, 30), &t, &th()); // loc=30, fo=5 — god doesn't fire
+        assert!(has(&p, "churn_magnet"));
+        assert!(!has(&p, "volatile_god"));
+    }
+
+    #[test]
+    fn volatile_god_both_fire() {
+        let t = Tier2Input {
+            churn_lines: Some(200),
+            ..t2_none()
+        };
+        let p = classify(&t1(8, 0, 10, 0, 60), &t, &th());
+        assert!(has(&p, "god_function"));
+        assert!(has(&p, "churn_magnet"));
+        assert!(has(&p, "volatile_god"));
+    }
+
+    // ---------- entrypoint suppression ----------
+
+    #[test]
+    fn middle_man_suppressed_for_entrypoint() {
+        let base = Tier2Input {
+            fan_in: Some(8),
+            is_entrypoint: false,
+            ..t2_none()
+        };
+        let p = classify(&t1(4, 0, 8, 0, 0), &base, &th());
+        assert!(has(&p, "middle_man"), "should fire when not entrypoint");
+
+        let ep = Tier2Input {
+            is_entrypoint: true,
+            ..base
+        };
+        let p = classify(&t1(4, 0, 8, 0, 0), &ep, &th());
+        assert!(!has(&p, "middle_man"), "should not fire for entrypoint");
+    }
+
+    #[test]
+    fn neighbor_risk_suppressed_for_entrypoint() {
+        let base = Tier2Input {
+            neighbor_churn: Some(400),
+            is_entrypoint: false,
+            ..t2_none()
+        };
+        let p = classify(&t1(0, 0, 8, 0, 0), &base, &th());
+        assert!(has(&p, "neighbor_risk"), "should fire when not entrypoint");
+
+        let ep = Tier2Input {
+            is_entrypoint: true,
+            ..base
+        };
+        let p = classify(&t1(0, 0, 8, 0, 0), &ep, &th());
+        assert!(!has(&p, "neighbor_risk"), "should not fire for entrypoint");
+    }
+
+    // ---------- ordering ----------
+
+    #[test]
+    fn all_tier1_ordering() {
+        // Triggers: complex_branching (cc=10,nd=5), deeply_nested (nd=5),
+        //           exit_heavy (ns=5), god_function (loc=80,fo=10), long_function (loc=80)
+        let p = classify(&t1(10, 5, 10, 5, 80), &t2_none(), &th());
+        assert_eq!(
+            p,
+            vec![
+                "complex_branching",
+                "deeply_nested",
+                "exit_heavy",
+                "god_function",
+                "long_function",
+            ]
+        );
+    }
+
+    // ---------- classify_detailed ----------
+
+    #[test]
+    fn classify_detailed_god_function() {
+        let details = classify_detailed(&t1(0, 0, 12, 0, 85), &t2_none(), &th());
+        let god = details.iter().find(|d| d.id == "god_function").unwrap();
+        assert_eq!(god.tier, 1);
+        assert_eq!(god.kind, "primitive");
+        assert_eq!(god.triggered_by.len(), 2);
+
+        let loc_tb = god.triggered_by.iter().find(|t| t.metric == "LOC").unwrap();
+        assert_eq!(loc_tb.value, 85);
+        assert_eq!(loc_tb.threshold, 60);
+        assert_eq!(loc_tb.op, ">=");
+
+        let fo_tb = god.triggered_by.iter().find(|t| t.metric == "FO").unwrap();
+        assert_eq!(fo_tb.value, 12);
+        assert_eq!(fo_tb.threshold, 10);
+    }
+
+    #[test]
+    fn classify_delegates_to_classify_detailed() {
+        // classify() and classify_detailed() must agree on which IDs fire
+        let t1_in = t1(10, 5, 10, 5, 80);
+        let t2_in = t2_none();
+        let ids = classify(&t1_in, &t2_in, &th());
+        let detail_ids: Vec<String> = classify_detailed(&t1_in, &t2_in, &th())
+            .into_iter()
+            .map(|d| d.id)
+            .collect();
+        assert_eq!(ids, detail_ids);
+    }
+}

--- a/hotspots-core/src/trends.rs
+++ b/hotspots-core/src/trends.rs
@@ -457,6 +457,8 @@ mod tests {
                 lrs: f.lrs,
                 band: f.band.clone(),
                 suppression_reason: None,
+                patterns: vec![],
+                pattern_details: None,
                 callees: vec![],
             })
             .collect();
@@ -495,6 +497,8 @@ mod tests {
                     driver: None,
                     driver_detail: None,
                     quadrant: None,
+                    patterns: vec![],
+                    pattern_details: None,
                 }],
             ),
             create_test_snapshot(
@@ -525,6 +529,8 @@ mod tests {
                     driver: None,
                     driver_detail: None,
                     quadrant: None,
+                    patterns: vec![],
+                    pattern_details: None,
                 }],
             ),
         ];
@@ -567,6 +573,8 @@ mod tests {
                     driver: None,
                     driver_detail: None,
                     quadrant: None,
+                    patterns: vec![],
+                    pattern_details: None,
                 }],
             ),
             create_test_snapshot(
@@ -597,6 +605,8 @@ mod tests {
                     driver: None,
                     driver_detail: None,
                     quadrant: None,
+                    patterns: vec![],
+                    pattern_details: None,
                 }],
             ),
         ];
@@ -638,6 +648,8 @@ mod tests {
                         driver: None,
                         driver_detail: None,
                         quadrant: None,
+                        patterns: vec![],
+                        pattern_details: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -664,6 +676,8 @@ mod tests {
                         driver: None,
                         driver_detail: None,
                         quadrant: None,
+                        patterns: vec![],
+                        pattern_details: None,
                     },
                 ],
             ),
@@ -696,6 +710,8 @@ mod tests {
                         driver: None,
                         driver_detail: None,
                         quadrant: None,
+                        patterns: vec![],
+                        pattern_details: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -722,6 +738,8 @@ mod tests {
                         driver: None,
                         driver_detail: None,
                         quadrant: None,
+                        patterns: vec![],
+                        pattern_details: None,
                     },
                 ],
             ),

--- a/hotspots-core/tests/ci_invariant_tests.rs
+++ b/hotspots-core/tests/ci_invariant_tests.rs
@@ -43,6 +43,8 @@ fn create_test_snapshot(sha: &str, parent_sha: &str) -> snapshot::Snapshot {
         lrs: 4.8,
         band: "moderate".to_string(),
         suppression_reason: None,
+        patterns: vec![],
+        pattern_details: None,
         callees: vec![],
     };
 
@@ -175,6 +177,8 @@ fn test_delta_single_parent_only() {
         lrs: 4.8,
         band: "moderate".to_string(),
         suppression_reason: None,
+        patterns: vec![],
+        pattern_details: None,
         callees: vec![],
     };
 
@@ -255,6 +259,8 @@ fn test_delta_negative_deltas_allowed() {
         lrs: 2.5, // Lower than parent
         band: "low".to_string(),
         suppression_reason: None,
+        patterns: vec![],
+        pattern_details: None,
         callees: vec![],
     };
 

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -120,6 +120,11 @@ fn test_golden_pathological() {
 }
 
 #[test]
+fn test_golden_patterns_tier1() {
+    test_golden("patterns_tier1");
+}
+
+#[test]
 fn test_golden_determinism() {
     // Test that running analysis twice produces identical output
     let fixture = fixture_path("simple.ts");

--- a/tests/fixtures/patterns_tier1.ts
+++ b/tests/fixtures/patterns_tier1.ts
@@ -1,0 +1,230 @@
+// Fixture for Tier 1 pattern detection golden tests.
+// Each function is engineered to trigger specific patterns.
+
+declare function funcA(x: any): any;
+declare function funcB(x: any): any;
+declare function funcC(x: any): any;
+declare function funcD(x: any): any;
+declare function funcE(x: any): any;
+declare function funcF(x: any, y: any): any;
+declare function funcG(x: any, y: any): any;
+declare function funcH(x: any, y: any): any;
+declare function funcI(x: any, y: any): any;
+declare function funcJ(x: any, y: any): any;
+
+// Triggers: god_function (LOC>=60, FO>=10) + long_function (LOC>=80)
+function godAndLong(a: any, b: any, c: any, d: any, e: any): any {
+  const r1 = funcA(a);
+  const r2 = funcB(b);
+  const r3 = funcC(c);
+  const r4 = funcD(d);
+  const r5 = funcE(e);
+  const r6 = funcF(a, b);
+  const r7 = funcG(b, c);
+  const r8 = funcH(c, d);
+  const r9 = funcI(d, e);
+  const r10 = funcJ(a, e);
+  let x = 0;
+  x += 1;
+  x += 2;
+  x += 3;
+  x += 4;
+  x += 5;
+  x += 6;
+  x += 7;
+  x += 8;
+  x += 9;
+  x += 10;
+  x += 11;
+  x += 12;
+  x += 13;
+  x += 14;
+  x += 15;
+  x += 16;
+  x += 17;
+  x += 18;
+  x += 19;
+  x += 20;
+  x += 21;
+  x += 22;
+  x += 23;
+  x += 24;
+  x += 25;
+  x += 26;
+  x += 27;
+  x += 28;
+  x += 29;
+  x += 30;
+  x += 31;
+  x += 32;
+  x += 33;
+  x += 34;
+  x += 35;
+  x += 36;
+  x += 37;
+  x += 38;
+  x += 39;
+  x += 40;
+  x += 41;
+  x += 42;
+  x += 43;
+  x += 44;
+  x += 45;
+  x += 46;
+  x += 47;
+  x += 48;
+  x += 49;
+  x += 50;
+  x += 51;
+  x += 52;
+  x += 53;
+  x += 54;
+  x += 55;
+  x += 56;
+  x += 57;
+  x += 58;
+  x += 59;
+  x += 60;
+  x += 61;
+  x += 62;
+  x += 63;
+  x += 64;
+  x += 65;
+  x += 66;
+  return [r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, x];
+}
+
+// Triggers: complex_branching (CC>=10, ND>=4) but NOT deeply_nested (ND<5) or exit_heavy (NS<5).
+// Uses independent ifs at depth 4; switch breaks inflate NS so we avoid them.
+function complexBranching(a: number, b: number, c: number, d: number): string {
+  let result = "";
+  if (a > 0) {
+    if (b > 0) {
+      if (c > 0) {
+        if (d === 1) result = "d1";
+        if (d === 2) result = "d2";
+        if (d === 3) result = "d3";
+        if (d === 4) result = "d4";
+        if (d === 5) result = "d5";
+        if (d === 6) result = "d6";
+        if (d === 7) result = "d7";
+        if (d === 8) result = "d8";
+        if (d === 9) result = "d9";
+      }
+    }
+  }
+  return result;
+}
+
+// Triggers: deeply_nested alone (ND>=5, CC<10). No early returns.
+function deeplyNested(a: any, b: any, c: any, d: any, e: any): string {
+  let result = "";
+  if (a) {
+    if (b) {
+      if (c) {
+        if (d) {
+          if (e) {
+            result = "deep";
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// Triggers: exit_heavy (NS>=5)
+function exitHeavy(x: number): number {
+  if (x < 0) { return -1; }
+  if (x === 0) { return 0; }
+  if (x > 1000) { return 1000; }
+  if (x % 2 === 0) { return x / 2; }
+  if (x % 3 === 0) { return x / 3; }
+  return x;
+}
+
+// Triggers: all five Tier 1 patterns simultaneously
+// Needs: CC>=10, ND>=5, NS>=5, LOC>=60+FO>=10 (god_function), LOC>=80 (long_function)
+function allFiveTier1(a: any, b: any, c: any, d: any, e: any, n: number): any {
+  const r1 = funcA(a);
+  const r2 = funcB(b);
+  const r3 = funcC(c);
+  const r4 = funcD(d);
+  const r5 = funcE(e);
+  const r6 = funcF(a, b);
+  const r7 = funcG(b, c);
+  const r8 = funcH(c, d);
+  const r9 = funcI(d, e);
+  const r10 = funcJ(a, e);
+  if (n < 0) { return r1; }
+  if (n === 0) { return r2; }
+  if (n > 999) { return r3; }
+  if (n % 2 === 0) { return r4; }
+  if (n % 3 === 0) { return r5; }
+  if (a) {
+    if (b) {
+      if (c) {
+        if (d) {
+          if (e) {
+            switch (n) {
+              case 1: return r6;
+              case 2: return r7;
+              case 3: return r8;
+              case 4: return r9;
+              default: return r10;
+            }
+          }
+        }
+      }
+    }
+  }
+  let x = 0;
+  x += 1;
+  x += 2;
+  x += 3;
+  x += 4;
+  x += 5;
+  x += 6;
+  x += 7;
+  x += 8;
+  x += 9;
+  x += 10;
+  x += 11;
+  x += 12;
+  x += 13;
+  x += 14;
+  x += 15;
+  x += 16;
+  x += 17;
+  x += 18;
+  x += 19;
+  x += 20;
+  x += 21;
+  x += 22;
+  x += 23;
+  x += 24;
+  x += 25;
+  x += 26;
+  x += 27;
+  x += 28;
+  x += 29;
+  x += 30;
+  x += 31;
+  x += 32;
+  x += 33;
+  x += 34;
+  x += 35;
+  x += 36;
+  x += 37;
+  x += 38;
+  x += 39;
+  x += 40;
+  x += 41;
+  x += 42;
+  x += 43;
+  x += 44;
+  x += 45;
+  x += 46;
+  x += 47;
+  return x;
+}

--- a/tests/golden/pathological.json
+++ b/tests/golden/pathological.json
@@ -18,6 +18,10 @@
       "r_ns": 3.0
     },
     "lrs": 11.29231742277876,
-    "band": "critical"
+    "band": "critical",
+    "patterns": [
+      "complex_branching",
+      "deeply_nested"
+    ]
   }
 ]

--- a/tests/golden/patterns_tier1.json
+++ b/tests/golden/patterns_tier1.json
@@ -1,0 +1,127 @@
+[
+  {
+    "file": "tests/fixtures/patterns_tier1.ts",
+    "function": "allFiveTier1",
+    "line": 148,
+    "language": "TypeScript",
+    "metrics": {
+      "cc": 28,
+      "nd": 6,
+      "fo": 10,
+      "ns": 10,
+      "loc": 83
+    },
+    "risk": {
+      "r_cc": 4.857980995127572,
+      "r_nd": 6.0,
+      "r_fo": 3.4594316186372973,
+      "r_ns": 6.0
+    },
+    "lrs": 15.93363996630995,
+    "band": "critical",
+    "patterns": [
+      "complex_branching",
+      "deeply_nested",
+      "exit_heavy",
+      "god_function",
+      "long_function"
+    ]
+  },
+  {
+    "file": "tests/fixtures/patterns_tier1.ts",
+    "function": "exitHeavy",
+    "line": 137,
+    "language": "TypeScript",
+    "metrics": {
+      "cc": 13,
+      "nd": 1,
+      "fo": 0,
+      "ns": 5,
+      "loc": 8
+    },
+    "risk": {
+      "r_cc": 3.807354922057604,
+      "r_nd": 1.0,
+      "r_fo": 0.0,
+      "r_ns": 5.0
+    },
+    "lrs": 8.107354922057604,
+    "band": "high",
+    "patterns": [
+      "exit_heavy"
+    ]
+  },
+  {
+    "file": "tests/fixtures/patterns_tier1.ts",
+    "function": "complexBranching",
+    "line": 99,
+    "language": "TypeScript",
+    "metrics": {
+      "cc": 15,
+      "nd": 4,
+      "fo": 0,
+      "ns": 0,
+      "loc": 19
+    },
+    "risk": {
+      "r_cc": 4.0,
+      "r_nd": 4.0,
+      "r_fo": 0.0,
+      "r_ns": 0.0
+    },
+    "lrs": 7.2,
+    "band": "high",
+    "patterns": [
+      "complex_branching"
+    ]
+  },
+  {
+    "file": "tests/fixtures/patterns_tier1.ts",
+    "function": "deeplyNested",
+    "line": 120,
+    "language": "TypeScript",
+    "metrics": {
+      "cc": 8,
+      "nd": 5,
+      "fo": 0,
+      "ns": 0,
+      "loc": 15
+    },
+    "risk": {
+      "r_cc": 3.169925001442312,
+      "r_nd": 5.0,
+      "r_fo": 0.0,
+      "r_ns": 0.0
+    },
+    "lrs": 7.169925001442312,
+    "band": "high",
+    "patterns": [
+      "deeply_nested"
+    ]
+  },
+  {
+    "file": "tests/fixtures/patterns_tier1.ts",
+    "function": "godAndLong",
+    "line": 16,
+    "language": "TypeScript",
+    "metrics": {
+      "cc": 3,
+      "nd": 0,
+      "fo": 10,
+      "ns": 0,
+      "loc": 80
+    },
+    "risk": {
+      "r_cc": 2.0,
+      "r_nd": 0.0,
+      "r_fo": 3.4594316186372973,
+      "r_ns": 0.0
+    },
+    "lrs": 4.075658971182378,
+    "band": "moderate",
+    "patterns": [
+      "god_function",
+      "long_function"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- **Adds 13 code pattern labels** derived from existing metrics (5 Tier 1 structural, 8 Tier 2 enriched). Patterns are informational — they do not affect LRS scores or risk bands.
- **HTML report**: colored pill badges per pattern in the function table; a pattern breakdown panel showing repo-wide frequencies with per-pattern color coding and descriptions.
- **`--explain-patterns` flag**: populates `pattern_details` in JSON output and prints indented trigger lines in text output (e.g. `complex_branching: cc=15 (>=10), nd=5 (>=4)`).
- **Patterns in triage JSON** (`--mode snapshot --format json`): the `patterns` array is now included on each function entry in the `triage.fire/debt/watch/ok.top` quadrants — AI agents consuming the triage output can see the structural smell alongside `driver`, `action`, and `lrs` without re-deriving it.
- **Per-project threshold overrides** via the `patterns` section of `.hotspotsrc.json` — each threshold is independently nullable, partial configs fall back to defaults.
- **Refactoring follow-up** (demonstrating the feature on itself): `compute_summary`, `HotspotsConfig::validate`, and `analyze_file_with_config` refactored after patterns flagged them as `god_function`/`long_function`/`exit_heavy`. Delta report confirms LRS reductions of 2.3–4.6 points and patterns cleared.

## Tier 1 patterns (structural — all modes)

| Pattern | Triggers |
|---|---|
| `complex_branching` | CC ≥ 10 AND ND ≥ 4 |
| `deeply_nested` | ND ≥ 5 |
| `exit_heavy` | NS ≥ 5 |
| `god_function` | LOC ≥ 60 AND FO ≥ 10 |
| `long_function` | LOC ≥ 80 |

## Tier 2 patterns (enriched — snapshot mode only)

| Pattern | Triggers |
|---|---|
| `churn_magnet` | churn_lines ≥ 200 AND CC ≥ 8 |
| `cyclic_hub` | scc_size ≥ 2 AND fan_in ≥ 6 |
| `hub_function` | fan_in ≥ 10 AND CC ≥ 8 |
| `middle_man` | fan_in ≥ 8 AND FO ≥ 8 AND CC ≤ 4 |
| `neighbor_risk` | neighbor_churn ≥ 400 AND FO ≥ 8 |
| `shotgun_target` | fan_in ≥ 8 AND churn_lines ≥ 150 |
| `stale_complex` | CC ≥ 10 AND LOC ≥ 60 AND days_since_last_change ≥ 180 |
| `volatile_god` | derived: `god_function` + `churn_magnet` |

## Triage JSON example (agent-optimized output)

```json
{
  "triage": {
    "fire": {
      "count": 12,
      "top": [
        {
          "function": "resolve_cargo_workspace_edges",
          "lrs": 14.10,
          "band": "critical",
          "quadrant": "fire",
          "driver": "high_complexity",
          "action": "Extract sub-functions now — actively changing",
          "patterns": ["complex_branching", "deeply_nested", "god_function", "long_function"],
          "metrics": { "cc": 26, "nd": 5, "fo": 18 }
        }
      ]
    }
  }
}
```

`patterns` is omitted when empty (forward-compatible).

## Test plan

- [x] Unit tests for every pattern: below threshold (must not fire), at threshold (must fire), compound condition (partial must not fire)
- [x] `volatile_god` derived pattern: each component alone must not fire, both together must fire
- [x] Entrypoint suppression: `middle_man` and `neighbor_risk` suppressed when `is_entrypoint: true`
- [x] Ordering test: all 5 Tier 1 patterns in correct deterministic order
- [x] Golden test: `tests/fixtures/patterns_tier1.ts` with 5 synthetic functions; `tests/golden/patterns_tier1.json` locks expected output
- [x] Config validation: negative thresholds rejected; partial override merges correctly
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` — 354 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)