### PR TITLE
docs: fix CLI reference gaps found by running --help

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -280,6 +280,22 @@ is written after the first run; subsequent warm runs are significantly faster. D
 touch metrics are file-level (all functions in a file share the same `touch_count_30d`).
 Use this flag when precise per-function activity signals are required.
 
+##### `--all-functions`
+**Optional.** Output all functions as a flat array instead of the default triage-first
+structure (quadrant buckets).
+**Only valid with:** `--mode snapshot --format json`
+
+```bash
+hotspots analyze . --mode snapshot --format json --all-functions
+```
+
+Produces schema v3 output: a flat `functions` array containing every function, regardless
+of quadrant. The default triage-first structure groups functions into `fire`, `debt`,
+`watch`, and `ok` buckets. Use `--all-functions` when consuming output in tooling or AI
+agents that prefer a flat list.
+
+See [JSON Schema Reference](../guide/output-formats.md#schema-versions) for the v3 schema.
+
 #### Examples
 
 **Basic analysis (text output):**
@@ -469,11 +485,12 @@ hotspots trends . --format json > trends.json
 **Required.** Path to repository root.
 
 ##### `--format <format>`
-**Optional.** Output format: `json` or `text`.
+**Optional.** Output format: `text`, `json`, `jsonl`, or `html`.
 **Default:** `json`
 
 ```bash
 hotspots trends . --format text
+hotspots trends . --format html
 ```
 
 ##### `--window <N>`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # Hotspots Roadmap
 
-**Last Updated:** 2026-02-20
-**Current Version:** Pre-release (approaching v1.0.0)
+**Last Updated:** 2026-03-03
+**Current Version:** v1.2.1
 **Vision:** Universal complexity analysis for modern software development
 
 ---
@@ -895,8 +895,8 @@ For each language candidate:
 
 ---
 
-**Last Updated:** 2026-02-20
-**Next Review:** 2026-03-15
+**Last Updated:** 2026-03-03
+**Next Review:** 2026-04-01
 **Maintained By:** Core team
 
 **Changes to this roadmap require:**


### PR DESCRIPTION
## Summary

- Add missing `--all-functions` flag documentation to `analyze` section in `cli.md` (flag existed in CLI but had no reference entry)
- Fix `trends --format` to list all four supported values (`text`, `json`, `html`, `jsonl`) — was incorrectly documented as `json` or `text` only
- Update `roadmap.md` version header from pre-release to v1.2.1 and refresh dates

## How found

Ran `hotspots --help` and `hotspots analyze --help` / `hotspots trends --help` and diffed against the docs.

## Test plan

- [x] No code changes — docs only
- [x] All 285 tests pass (pre-commit hook verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)