### PR TITLE
chore: automate changelog with git-cliff on main push

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,36 @@
+name: Update Changelog
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  update-changelog:
+    name: Regenerate CHANGELOG.md
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet CHANGELOG.md; then
+            git add CHANGELOG.md
+            git commit -m "chore: update CHANGELOG.md"
+            git push
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,133 +5,79 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] - 2026-03-06
+
+### Performance
+- Parallelize file analysis with rayon (#30)
+
+## [1.3.0] - 2026-03-06
+
+### Documentation
+- Add Homebrew install instructions for macOS
+- Restructure installation page, lead with brew for macOS
+
+
+### Features
+- Add analysis progress bar with ETA (#29)
+
+## [1.2.2] - 2026-03-04
+
+### Documentation
+- Add --all-functions, fix trends formats, update roadmap version (#27)
+
+## [1.2.1] - 2026-03-03
+
+### Bug Fixes
+- CFG orphaned nodes, CC inflation, and JSX/decorator parser support (#25)
+
+## [1.2.0] - 2026-02-28
+
+### Features
+- Pattern detection — 13 code smell labels with HTML dashboard and --explain-patterns (#24)
+
+## [1.1.1] - 2026-02-24
+
+### Bug Fixes
+- Explicitly trigger release.yml after cargo-release pushes tag
+- Prevent CFG builder panic and orphaned join nodes on dead code (#23)
+- Use RELEASE_PAT so tag push triggers release.yml
+
+## [1.1.0] - 2026-02-22
+
+### Bug Fixes
+- Replace yourorg placeholder with correct org in action
+- Remove invalid post-release-commit-message from release.toml
+- Remove invalid workspace field from release.toml
+- Commit Cargo.lock changes before cargo-release runs
+
+
+### Documentation
+- No-sudo install, user-land path, fix broken links; add deploy config
+- Update install instructions to use install.sh
+- Use GitHub raw URL for install.sh, redirect hotspots.dev later
+- Add website/docs links to README header
+- Add hotspots.dev link to nav and footer
+- Note GitHub Action is not yet available
+- Sync README with docs content
+- Add logo as favicon and README header
+- Add OG and Twitter Card meta tags to docs site
+
+
+### Features
+- Add install.sh for one-line install
+- Add progress bar, fix CFG traversal for typescript (#22)
 
 ## [1.0.0] - 2026-02-21
 
-### Added
+### Features
+- Add GitHub Action for CI/CD integration (Task 2.1) (#3)
 
-#### Multi-Language Support
-- **Go** (`.go`) — full CFG with defer, goroutines, select, type switches
-- **Python** (`.py`) — full CFG with comprehensions, context managers, match statements, exception handlers
-- **Rust** (`.rs`) — full CFG with match, if-let, `?` operator, loop labels
-- **Java** (`.java`) — full CFG with lambdas, try-with-resources, switch expressions, synchronized blocks
-
-#### Call Graph Engine
-- Import-based call graph resolution (TypeScript/JavaScript/Go/Python/Rust/Java)
-- PageRank, betweenness centrality, and strongly-connected-component (SCC) detection
-- Dependency depth computation per function
-- Call graph signals fed into activity risk scoring
-
-#### Activity Risk Scoring
-- Per-function **Activity Risk** score combining:
-  - `complexity` — LRS (base)
-  - `churn` — lines changed in the last 30 days
-  - `activity` — commit count in the last 30 days
-  - `recency` — days since last change (branch-aware)
-  - `fan_in` — number of callers detected by call graph
-  - `cyclic_dependency` — SCC membership penalty
-  - `depth` — dependency depth penalty
-  - `neighbor_churn` — lines changed in direct dependencies
-- Branch-aware recency: compares against branch divergence point, not just HEAD
-
-#### Driver Labels & Explain Mode
-- **`--explain`** flag: human-readable per-function risk breakdown with individual metric
-  contributions, activity signals, and a co-change coupling section
-- **Driver labels** classify the primary reason a function is flagged: `high_complexity`,
-  `deep_nesting`, `high_churn_low_cc`, `high_fanout_churning`, `high_fanin_complex`,
-  `cyclic_dep`, or `composite`
-- **`driver_detail`** field: near-miss dimension detail for composite drivers (e.g., `cc (P72), nd (P68)`)
-- Percentile-relative thresholds for each driver dimension (default P=75)
-- **Quadrant classification**: each function tagged `fire`, `debt`, `watch`, or `ok` based on
-  band × activity (high/critical + active = `fire`, high/critical + quiet = `debt`, etc.)
-- **Action text**: per-function refactoring recommendation derived from driver × quadrant
-
-#### Higher-Level Views
-- **`--level file`** — ranked file risk table (max CC, avg CC, function count, LOC, churn)
-- **`--level module`** — module instability table (afferent/efferent coupling, instability score)
-
-#### HTML Report
-- **Trend charts** in snapshot HTML report: stacked band-count chart, activity-risk line, and
-  top-1% share line — all drawn with Canvas 2D from embedded history (up to 30 snapshots)
-- **Action column** in triage table: per-function refactoring recommendation (driver × quadrant)
-- Hover tooltip on band chart showing date + per-band counts
-
-#### Agent-Optimized JSON (Schema v3)
-- `--all-functions` flag: emit all functions (overrides `--min-lrs` / `--top` filters) for
-  agent consumption
-- Schema v3 (`AgentSnapshotOutput`): triage-first structure with `fire`/`debt`/`watch`/`ok`
-  quadrant buckets, each entry carrying `action`, `driver`, `quadrant`, and key metrics
-
-#### Output & CLI
-- **JSONL output format** (`--format jsonl`) — one JSON object per line for streaming pipelines
-- **`--no-persist`** flag — run snapshot analysis without writing to `.hotspots/`
-- **`--per-function-touches`** flag — precise per-function touch counts via `git log -L`;
-  results cached on disk (cold run ~50× slower; subsequent warm runs significantly faster)
-- **`hotspots config show`** — display resolved configuration (weights, thresholds, filters)
-- **`hotspots config validate`** — validate config file without running analysis
-
-#### Performance
-- Per-function touch cache: warm runs reuse on-disk cache instead of re-running `git log -L`
-
-## [0.0.1] - 2025-01-25
-
-### Added
-
-#### Core Analysis Features
-- **Local Risk Score (LRS)** computation for TypeScript functions
-- Four complexity metrics: Cyclomatic Complexity (CC), Nesting Depth (ND), Fan-Out (FO), Non-Structured Exits (NS)
-- Risk band classification: Low, Moderate, High, Critical
-- Deterministic, byte-for-byte identical output for identical input
-
-#### Analysis Modes
-- **Snapshot Mode**: Capture codebase state at a point in time
-- **Delta Mode**: Compare two snapshots to detect risk changes
-- Git-native integration with automatic snapshot management
-
-#### Policy Engine
-- **Critical Introduction**: Block when functions become Critical risk
-- **Excessive Risk Regression**: Block when LRS increases by ≥1.0
-- **Net Repo Regression**: Warn when total repository risk increases
-- CI/CD integration with exit code enforcement
-
-#### Trend Analysis
-- **Risk Velocity**: Track rate of LRS change over commit history
-- **Hotspot Stability**: Identify stable vs. volatile high-risk functions
-- **Refactor Effectiveness**: Detect and classify refactoring outcomes
-- Configurable history window (default: 10 snapshots)
-
-#### Aggregation Views
-- File-level aggregates: sum LRS, max LRS, High+ count
-- Directory-level aggregates with recursive rollup
-- Delta aggregates: net LRS delta, regression count per file
-
-#### Visualizations
-- Interactive Vega-Lite charts showing risk evolution
-- Risk concentration over time (stacked area chart)
-- LRS timeline, band timeline, delta breakdown
-- Repository distribution histogram
-- Example code for generating visualization data
-
-#### CLI Features
-- Multiple output formats: text (default) and JSON
-- Filtering options: `--top N`, `--min-lrs <threshold>`
-- Git-based dynamic versioning
-- Comprehensive help and usage documentation
-
-### Technical
-- TypeScript parsing via SWC
-- Rust 1.75+ required
-- MIT License
-- Comprehensive test suite (46 unit tests + integration tests)
-- Full documentation in `docs/`
-
-### Repository Structure
-- `hotspots-core`: Core library for LRS computation
-- `hotspots-cli`: Command-line interface
-- `examples/`: Example code (visualization export)
-- `visualizations/`: Interactive charts and specs
-- `docs/`: Comprehensive documentation
-
+[1.4.0]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.4.0
+[1.3.0]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.3.0
+[1.2.2]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.2.2
+[1.2.1]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.2.1
+[1.2.0]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.2.0
+[1.1.1]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.1.1
+[1.1.0]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.1.0
 [1.0.0]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v1.0.0
-[0.0.1]: https://github.com/Stephen-Collins-tech/hotspots/releases/tag/v0.0.1
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -29,6 +29,7 @@ tag_pattern = "v[0-9]*"
 commit_parsers = [
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
   { message = "^docs", group = "Documentation" },
   { message = "^chore: release", skip = true },
   { message = "^chore", skip = true },


### PR DESCRIPTION
## Summary

- Adds `perf` commit type to `cliff.toml` so `perf:` commits appear under a **Performance** section (previously silently dropped)
- Regenerates `CHANGELOG.md` from full git history via `git-cliff` — all versions v1.0.0–v1.4.0 are now present in the correct format (the old hand-written content is replaced)
- Adds `.github/workflows/changelog.yml` — runs on every push to `main`, uses `orhun/git-cliff-action@v4` to regenerate `CHANGELOG.md`, and auto-commits if anything changed

## How it fits together

| Event | What happens |
|-------|-------------|
| Push to `main` | `changelog.yml` regenerates CHANGELOG with an `[Unreleased]` section |
| Release | `release.toml` pre-release-hook runs `git-cliff --tag v{{version}}`, collapsing `[Unreleased]` into the versioned section before tagging |

## Test plan

- [ ] Verify CHANGELOG.md content looks correct for all versions
- [ ] Trigger the workflow on a push to main and confirm CHANGELOG.md is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)