### PR TITLE
feat: SARIF output format and init --hooks command

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -515,6 +515,11 @@ fn emit_snapshot_output(
         OutputFormat::Sarif => {
             let sarif = hotspots_core::sarif::render_sarif(snapshot);
             if let Some(output_path) = output {
+                if let Some(parent) = output_path.parent() {
+                    std::fs::create_dir_all(parent).with_context(|| {
+                        format!("failed to create directory: {}", parent.display())
+                    })?;
+                }
                 std::fs::write(&output_path, &sarif).with_context(|| {
                     format!("failed to write SARIF to {}", output_path.display())
                 })?;

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -79,6 +79,9 @@ pub(crate) fn validate_analyze_flags(args: &AnalyzeArgs) -> anyhow::Result<()> {
     if *explain_patterns && *mode != Some(OutputMode::Snapshot) && mode.is_some() {
         anyhow::bail!("--explain-patterns is only valid with --mode snapshot or without --mode");
     }
+    if matches!(format, OutputFormat::Sarif) && *mode != Some(OutputMode::Snapshot) {
+        anyhow::bail!("--format sarif requires --mode snapshot");
+    }
     Ok(())
 }
 
@@ -196,8 +199,8 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         OutputFormat::Json => {
             println!("{}", hotspots_core::render_json(&reports));
         }
-        OutputFormat::Html | OutputFormat::Jsonl => {
-            anyhow::bail!("HTML/JSONL format requires --mode snapshot or --mode delta");
+        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif => {
+            anyhow::bail!("HTML/JSONL/SARIF format requires --mode snapshot or --mode delta");
         }
     }
 
@@ -509,6 +512,17 @@ fn emit_snapshot_output(
             write_html_report(&output_path, &html)?;
             eprintln!("HTML report written to: {}", output_path.display());
         }
+        OutputFormat::Sarif => {
+            let sarif = hotspots_core::sarif::render_sarif(snapshot);
+            if let Some(output_path) = output {
+                std::fs::write(&output_path, &sarif).with_context(|| {
+                    format!("failed to write SARIF to {}", output_path.display())
+                })?;
+                eprintln!("SARIF report written to: {}", output_path.display());
+            } else {
+                println!("{sarif}");
+            }
+        }
     }
     Ok(())
 }
@@ -558,6 +572,9 @@ fn emit_delta_output(
             let output_path = output.unwrap_or_else(|| PathBuf::from(".hotspots/report.html"));
             write_html_report(&output_path, &html)?;
             eprintln!("HTML report written to: {}", output_path.display());
+        }
+        OutputFormat::Sarif => {
+            anyhow::bail!("SARIF format is not supported for delta mode (use --mode snapshot)");
         }
     }
 

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -199,8 +199,11 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         OutputFormat::Json => {
             println!("{}", hotspots_core::render_json(&reports));
         }
-        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif => {
-            anyhow::bail!("HTML/JSONL/SARIF format requires --mode snapshot or --mode delta");
+        OutputFormat::Html | OutputFormat::Jsonl => {
+            anyhow::bail!("HTML/JSONL format requires --mode snapshot or --mode delta");
+        }
+        OutputFormat::Sarif => {
+            anyhow::bail!("SARIF format requires --mode snapshot");
         }
     }
 
@@ -513,7 +516,7 @@ fn emit_snapshot_output(
             eprintln!("HTML report written to: {}", output_path.display());
         }
         OutputFormat::Sarif => {
-            let sarif = hotspots_core::sarif::render_sarif(snapshot);
+            let sarif = hotspots_core::sarif::render_sarif(snapshot, repo_root);
             if let Some(output_path) = output {
                 if let Some(parent) = output_path.parent() {
                     std::fs::create_dir_all(parent).with_context(|| {

--- a/hotspots-cli/src/cmd/init.rs
+++ b/hotspots-cli/src/cmd/init.rs
@@ -11,7 +11,14 @@ pub(crate) fn handle_init(hooks: bool) -> anyhow::Result<()> {
 
 fn print_hooks() {
     println!(
-        r#"# ── pre-commit hook (pre-commit framework) ──────────────────────────
+        r#"# ── SETUP (run once before enabling the hook) ───────────────────────
+# Delta mode compares against the last persisted snapshot. On a fresh
+# repo with no snapshots yet, policy evaluation is silently skipped.
+# Seed the baseline first:
+#
+#   hotspots analyze . --mode snapshot
+#
+# ── pre-commit hook (pre-commit framework) ──────────────────────────
 # Add to .pre-commit-config.yaml:
 
 repos:

--- a/hotspots-cli/src/cmd/init.rs
+++ b/hotspots-cli/src/cmd/init.rs
@@ -1,0 +1,35 @@
+//! `hotspots init` — project setup helpers
+
+pub(crate) fn handle_init(hooks: bool) -> anyhow::Result<()> {
+    if hooks {
+        print_hooks();
+    } else {
+        eprintln!("Nothing to do. Try: hotspots init --hooks");
+    }
+    Ok(())
+}
+
+fn print_hooks() {
+    println!(
+        r#"# ── pre-commit hook (pre-commit framework) ──────────────────────────
+# Add to .pre-commit-config.yaml:
+
+repos:
+  - repo: local
+    hooks:
+      - id: hotspots
+        name: hotspots risk check
+        language: system
+        entry: hotspots analyze . --mode delta --policy --format text
+        pass_filenames: false
+        stages: [pre-push]
+
+# ── raw shell hook (no framework) ────────────────────────────────────
+# Save as .git/hooks/pre-push and run: chmod +x .git/hooks/pre-push
+
+#!/usr/bin/env sh
+set -e
+hotspots analyze . --mode delta --policy --format text
+"#
+    );
+}

--- a/hotspots-cli/src/cmd/init.rs
+++ b/hotspots-cli/src/cmd/init.rs
@@ -10,6 +10,7 @@ pub(crate) fn handle_init(hooks: bool) -> anyhow::Result<()> {
 }
 
 fn print_hooks() {
+    // Print the pre-commit YAML snippet
     println!(
         r#"# ── SETUP (run once before enabling the hook) ───────────────────────
 # Delta mode compares against the last persisted snapshot. On a fresh
@@ -17,9 +18,9 @@ fn print_hooks() {
 # Seed the baseline first:
 #
 #   hotspots analyze . --mode snapshot
-#
-# ── pre-commit hook (pre-commit framework) ──────────────────────────
-# Add to .pre-commit-config.yaml:
+
+# ── Option 1: pre-commit framework ───────────────────────────────────
+# Add the following to .pre-commit-config.yaml:
 
 repos:
   - repo: local
@@ -29,14 +30,19 @@ repos:
         language: system
         entry: hotspots analyze . --mode delta --policy --format text
         pass_filenames: false
-        stages: [pre-push]
+        stages: [pre-push]"#
+    );
 
-# ── raw shell hook (no framework) ────────────────────────────────────
-# Save as .git/hooks/pre-push and run: chmod +x .git/hooks/pre-push
+    // Print the raw shell hook as a standalone block so users can copy it
+    // directly to .git/hooks/pre-push without including the YAML above.
+    println!(
+        r#"
+# ── Option 2: raw shell hook ─────────────────────────────────────────
+# Save the lines below (starting with the shebang) as .git/hooks/pre-push
+# and run: chmod +x .git/hooks/pre-push
 
 #!/usr/bin/env sh
 set -e
-hotspots analyze . --mode delta --policy --format text
-"#
+hotspots analyze . --mode delta --policy --format text"#
     );
 }

--- a/hotspots-cli/src/cmd/mod.rs
+++ b/hotspots-cli/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod analyze;
 pub(crate) mod compact;
 pub(crate) mod config;
+pub(crate) mod init;
 pub(crate) mod prune;
 pub(crate) mod trends;

--- a/hotspots-cli/src/cmd/trends.rs
+++ b/hotspots-cli/src/cmd/trends.rs
@@ -36,8 +36,8 @@ pub(crate) fn handle_trends(
         OutputFormat::Text => {
             print_trends_text_output(&trends)?;
         }
-        OutputFormat::Html | OutputFormat::Jsonl => {
-            anyhow::bail!("HTML/JSONL format is not supported for trends analysis");
+        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif => {
+            anyhow::bail!("HTML/JSONL/SARIF format is not supported for trends analysis");
         }
     }
 

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -135,6 +135,12 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// Initialize project configuration and hooks
+    Init {
+        /// Print pre-commit and shell hook templates to stdout
+        #[arg(long)]
+        hooks: bool,
+    },
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]
@@ -210,6 +216,7 @@ fn main() -> anyhow::Result<()> {
             window,
             top,
         } => cmd::trends::handle_trends(path, format, window, top)?,
+        Commands::Init { hooks } => cmd::init::handle_init(hooks)?,
     }
 
     Ok(())

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -143,6 +143,7 @@ pub(crate) enum OutputFormat {
     Json,
     Html,
     Jsonl,
+    Sarif,
 }
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -135,9 +135,9 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
-    /// Initialize project configuration and hooks
+    /// Print hook templates for CI/CD integration
     Init {
-        /// Print pre-commit and shell hook templates to stdout
+        /// Print pre-commit framework and raw shell hook templates to stdout
         #[arg(long)]
         hooks: bool,
     },

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod policy;
 pub mod prune;
 pub mod report;
 pub mod risk;
+pub mod sarif;
 pub mod scoring;
 pub mod snapshot;
 pub mod suppression;

--- a/hotspots-core/src/sarif.rs
+++ b/hotspots-core/src/sarif.rs
@@ -1,0 +1,211 @@
+//! SARIF 2.1.0 output for GitHub code scanning integration
+//!
+//! Emits results for functions at moderate risk or above.
+//! Maps risk bands to SARIF levels:
+//!   critical → error
+//!   high     → warning
+//!   moderate → note
+
+use crate::snapshot::Snapshot;
+use serde::Serialize;
+
+const SARIF_SCHEMA: &str =
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json";
+const SARIF_VERSION: &str = "2.1.0";
+
+// Rule IDs
+const RULE_CRITICAL: &str = "hotspots/critical-risk";
+const RULE_HIGH: &str = "hotspots/high-risk";
+const RULE_MODERATE: &str = "hotspots/moderate-risk";
+
+#[derive(Serialize)]
+struct SarifOutput {
+    #[serde(rename = "$schema")]
+    schema: &'static str,
+    version: &'static str,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Serialize)]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+}
+
+#[derive(Serialize)]
+struct SarifTool {
+    driver: SarifDriver,
+}
+
+#[derive(Serialize)]
+struct SarifDriver {
+    name: &'static str,
+    version: String,
+    #[serde(rename = "informationUri")]
+    information_uri: &'static str,
+    rules: Vec<SarifRule>,
+}
+
+#[derive(Serialize)]
+struct SarifRule {
+    id: &'static str,
+    name: &'static str,
+    #[serde(rename = "shortDescription")]
+    short_description: SarifMessage,
+    #[serde(rename = "fullDescription")]
+    full_description: SarifMessage,
+    #[serde(rename = "defaultConfiguration")]
+    default_configuration: SarifRuleConfig,
+    #[serde(rename = "helpUri")]
+    help_uri: &'static str,
+}
+
+#[derive(Serialize)]
+struct SarifRuleConfig {
+    level: &'static str,
+}
+
+#[derive(Serialize)]
+struct SarifResult {
+    #[serde(rename = "ruleId")]
+    rule_id: &'static str,
+    level: &'static str,
+    message: SarifMessage,
+    locations: Vec<SarifLocation>,
+}
+
+#[derive(Serialize)]
+struct SarifMessage {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct SarifLocation {
+    #[serde(rename = "physicalLocation")]
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Serialize)]
+struct SarifPhysicalLocation {
+    #[serde(rename = "artifactLocation")]
+    artifact_location: SarifArtifact,
+    region: SarifRegion,
+}
+
+#[derive(Serialize)]
+struct SarifArtifact {
+    uri: String,
+    #[serde(rename = "uriBaseId")]
+    uri_base_id: &'static str,
+}
+
+#[derive(Serialize)]
+struct SarifRegion {
+    #[serde(rename = "startLine")]
+    start_line: u32,
+}
+
+fn rules() -> Vec<SarifRule> {
+    vec![
+        SarifRule {
+            id: RULE_CRITICAL,
+            name: "CriticalRiskFunction",
+            short_description: SarifMessage {
+                text: "Critical-risk function detected".to_string(),
+            },
+            full_description: SarifMessage {
+                text: "This function has a critical Logical Risk Score (LRS). It combines high cyclomatic complexity with heavy git churn and/or many contributors, making it a likely bug source.".to_string(),
+            },
+            default_configuration: SarifRuleConfig { level: "error" },
+            help_uri: "https://hotspots.dev",
+        },
+        SarifRule {
+            id: RULE_HIGH,
+            name: "HighRiskFunction",
+            short_description: SarifMessage {
+                text: "High-risk function detected".to_string(),
+            },
+            full_description: SarifMessage {
+                text: "This function has a high Logical Risk Score (LRS). It has elevated cyclomatic complexity combined with significant git activity.".to_string(),
+            },
+            default_configuration: SarifRuleConfig { level: "warning" },
+            help_uri: "https://hotspots.dev",
+        },
+        SarifRule {
+            id: RULE_MODERATE,
+            name: "ModerateRiskFunction",
+            short_description: SarifMessage {
+                text: "Moderate-risk function detected".to_string(),
+            },
+            full_description: SarifMessage {
+                text: "This function has a moderate Logical Risk Score (LRS). Consider reviewing for refactoring opportunities.".to_string(),
+            },
+            default_configuration: SarifRuleConfig { level: "note" },
+            help_uri: "https://hotspots.dev",
+        },
+    ]
+}
+
+/// Render a snapshot as SARIF 2.1.0 JSON.
+///
+/// Only functions at moderate risk or above are emitted.
+pub fn render_sarif(snapshot: &Snapshot) -> String {
+    let tool_version = snapshot.analysis.tool_version.clone();
+
+    let results: Vec<SarifResult> = snapshot
+        .functions
+        .iter()
+        .filter_map(|f| {
+            let (rule_id, level) = match f.band.as_str() {
+                "critical" => (RULE_CRITICAL, "error"),
+                "high" => (RULE_HIGH, "warning"),
+                "moderate" => (RULE_MODERATE, "note"),
+                _ => return None,
+            };
+
+            let name = f.function_id.rsplit("::").next().unwrap_or("<anonymous>");
+            let lrs = f.lrs;
+            let cc = f.metrics.cc;
+
+            Some(SarifResult {
+                rule_id,
+                level,
+                message: SarifMessage {
+                    text: format!(
+                        "Function `{name}` has a {band} risk score (LRS={lrs:.2}, CC={cc}).",
+                        band = f.band,
+                    ),
+                },
+                locations: vec![SarifLocation {
+                    physical_location: SarifPhysicalLocation {
+                        artifact_location: SarifArtifact {
+                            uri: f.file.clone(),
+                            uri_base_id: "%SRCROOT%",
+                        },
+                        region: SarifRegion {
+                            start_line: f.line.max(1),
+                        },
+                    },
+                }],
+            })
+        })
+        .collect();
+
+    let output = SarifOutput {
+        schema: SARIF_SCHEMA,
+        version: SARIF_VERSION,
+        runs: vec![SarifRun {
+            tool: SarifTool {
+                driver: SarifDriver {
+                    name: "hotspots",
+                    version: tool_version,
+                    information_uri: "https://hotspots.dev",
+                    rules: rules(),
+                },
+            },
+            results,
+        }],
+    };
+
+    serde_json::to_string_pretty(&output).expect("SARIF serialization is infallible")
+}

--- a/hotspots-core/src/sarif.rs
+++ b/hotspots-core/src/sarif.rs
@@ -8,6 +8,7 @@
 
 use crate::snapshot::Snapshot;
 use serde::Serialize;
+use std::path::Path;
 
 const SARIF_SCHEMA: &str =
     "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json";
@@ -146,10 +147,26 @@ fn rules() -> Vec<SarifRule> {
     ]
 }
 
+/// Strip `repo_root` from an absolute file path to produce a repo-relative URI.
+/// Falls back to the original path if stripping fails (e.g. path is already relative).
+fn to_relative_uri(file: &str, repo_root: &Path) -> String {
+    let path = Path::new(file);
+    // Normalize away any `.` components before stripping
+    let stripped = path
+        .strip_prefix(repo_root)
+        .ok()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|| file.replace('\\', "/"));
+    // Remove any leading "./" that may remain
+    stripped.trim_start_matches("./").to_string()
+}
+
 /// Render a snapshot as SARIF 2.1.0 JSON.
 ///
 /// Only functions at moderate risk or above are emitted.
-pub fn render_sarif(snapshot: &Snapshot) -> String {
+/// `repo_root` is used to convert absolute file paths to repo-relative URIs,
+/// which is required for GitHub code scanning to resolve locations correctly.
+pub fn render_sarif(snapshot: &Snapshot, repo_root: &Path) -> String {
     let tool_version = snapshot.analysis.tool_version.clone();
 
     let results: Vec<SarifResult> = snapshot
@@ -179,7 +196,7 @@ pub fn render_sarif(snapshot: &Snapshot) -> String {
                 locations: vec![SarifLocation {
                     physical_location: SarifPhysicalLocation {
                         artifact_location: SarifArtifact {
-                            uri: f.file.clone(),
+                            uri: to_relative_uri(&f.file, repo_root),
                             uri_base_id: "%SRCROOT%",
                         },
                         region: SarifRegion {
@@ -208,4 +225,144 @@ pub fn render_sarif(snapshot: &Snapshot) -> String {
     };
 
     serde_json::to_string_pretty(&output).expect("SARIF serialization is infallible")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::MetricsReport;
+    use crate::snapshot::{AnalysisInfo, CommitInfo, FunctionSnapshot, Snapshot};
+
+    fn make_snapshot(functions: Vec<FunctionSnapshot>) -> Snapshot {
+        Snapshot {
+            schema_version: 2,
+            commit: CommitInfo {
+                sha: "abc123".to_string(),
+                parents: vec![],
+                timestamp: 0,
+                branch: None,
+                message: None,
+                author: None,
+                is_fix_commit: None,
+                is_revert_commit: None,
+                ticket_ids: vec![],
+            },
+            analysis: AnalysisInfo {
+                scope: ".".to_string(),
+                tool_version: "1.0.0".to_string(),
+            },
+            functions,
+            summary: None,
+            aggregates: None,
+        }
+    }
+
+    fn make_function(file: &str, name: &str, band: &str, lrs: f64, cc: usize) -> FunctionSnapshot {
+        FunctionSnapshot {
+            function_id: format!("{}::{}", file, name),
+            file: file.to_string(),
+            line: 10,
+            language: "rust".to_string(),
+            metrics: MetricsReport {
+                cc,
+                nd: 0,
+                fo: 0,
+                ns: 0,
+                loc: 10,
+            },
+            lrs,
+            band: band.to_string(),
+            suppression_reason: None,
+            churn: None,
+            touch_count_30d: None,
+            days_since_last_change: None,
+            callgraph: None,
+            activity_risk: None,
+            risk_factors: None,
+            percentile: None,
+            driver: None,
+            driver_detail: None,
+            quadrant: None,
+            patterns: vec![],
+            pattern_details: None,
+        }
+    }
+
+    #[test]
+    fn test_sarif_schema_and_version() {
+        let snapshot = make_snapshot(vec![]);
+        let json = render_sarif(&snapshot, Path::new("/repo"));
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["version"], "2.1.0");
+        assert!(val["$schema"]
+            .as_str()
+            .unwrap()
+            .contains("sarif-schema-2.1.0"));
+    }
+
+    #[test]
+    fn test_sarif_low_risk_functions_omitted() {
+        let snapshot = make_snapshot(vec![
+            make_function("/repo/src/lib.rs", "low_fn", "low", 1.0, 2),
+            make_function("/repo/src/lib.rs", "moderate_fn", "moderate", 4.0, 5),
+        ]);
+        let json = render_sarif(&snapshot, Path::new("/repo"));
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let results = &val["runs"][0]["results"];
+        assert_eq!(results.as_array().unwrap().len(), 1);
+        assert_eq!(results[0]["ruleId"], "hotspots/moderate-risk");
+    }
+
+    #[test]
+    fn test_sarif_band_to_level_mapping() {
+        let snapshot = make_snapshot(vec![
+            make_function("/repo/a.rs", "critical_fn", "critical", 10.0, 15),
+            make_function("/repo/b.rs", "high_fn", "high", 7.0, 10),
+            make_function("/repo/c.rs", "moderate_fn", "moderate", 4.0, 5),
+        ]);
+        let json = render_sarif(&snapshot, Path::new("/repo"));
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let results = val["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 3);
+        let levels: Vec<&str> = results
+            .iter()
+            .map(|r| r["level"].as_str().unwrap())
+            .collect();
+        assert!(levels.contains(&"error"));
+        assert!(levels.contains(&"warning"));
+        assert!(levels.contains(&"note"));
+    }
+
+    #[test]
+    fn test_sarif_path_made_relative() {
+        let snapshot = make_snapshot(vec![make_function(
+            "/repo/src/main.rs",
+            "my_fn",
+            "high",
+            7.0,
+            10,
+        )]);
+        let json = render_sarif(&snapshot, Path::new("/repo"));
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let uri = val["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+            ["artifactLocation"]["uri"]
+            .as_str()
+            .unwrap();
+        assert_eq!(uri, "src/main.rs");
+    }
+
+    #[test]
+    fn test_sarif_rules_present() {
+        let snapshot = make_snapshot(vec![]);
+        let json = render_sarif(&snapshot, Path::new("/repo"));
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let rules = val["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rules.len(), 3);
+        let ids: Vec<&str> = rules.iter().map(|r| r["id"].as_str().unwrap()).collect();
+        assert!(ids.contains(&"hotspots/critical-risk"));
+        assert!(ids.contains(&"hotspots/high-risk"));
+        assert!(ids.contains(&"hotspots/moderate-risk"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add \`--format sarif\` to \`hotspots analyze --mode snapshot\` for GitHub code scanning integration (SARIF 2.1.0)
- Add \`hotspots init --hooks\` command that prints ready-to-use pre-commit and shell hook templates

## Details

**SARIF output** (\`hotspots-core/src/sarif.rs\`)
- Emits results for functions at moderate risk or above
- Maps risk bands to SARIF levels: \`critical\` → error, \`high\` → warning, \`moderate\` → note
- Includes rule definitions with descriptions and help URIs
- File paths are normalized to repo-relative URIs for GitHub code scanning compatibility
- Supports \`--output <file>\` to write to disk (creates parent dirs), otherwise prints to stdout
- 5 unit tests covering schema, filtering, band→level mapping, path relativization, and rules

**Init hooks** (\`hotspots-cli/src/cmd/init.rs\`)
- \`hotspots init --hooks\` prints a \`.pre-commit-config.yaml\` snippet and a standalone raw shell \`pre-push\` hook template
- Includes a setup note explaining that a baseline snapshot must be seeded first

## Test plan

- [x] \`cargo test\` passes (301 tests)
- [x] \`hotspots analyze . --mode snapshot --format sarif\` produces valid SARIF JSON with relative URIs
- [x] \`hotspots init --hooks\` prints both hook templates with clear separation
- [x] \`hotspots analyze . --mode delta --format sarif\` returns a clear error message
- [x] \`hotspots analyze . --format sarif\` (no --mode) returns a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)