### PR TITLE
docs: document SARIF format and hotspots init --hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,24 @@ This file contains conventions and rules for Claude Code when working on this pr
 - Only add comments, docstrings, or type annotations to code you actually changed.
 - Avoid over-engineering. Don't add features, configurability, or abstractions that weren't requested.
 
+## Git Branching
+
+**ALWAYS create a feature branch before starting any new work.** Never commit directly to `main`.
+
+- Branch naming: `<type>/<short-description>` — use the same type prefix as the commit
+  - `feat/sarif-output`, `fix/cfg-panic-on-dead-code`, `chore/update-deps`, `refactor/simplify-risk-scoring`
+- Create the branch before making any file changes: `git checkout -b <branch-name>`
+- One logical unit of work per branch. If a task spawns unrelated changes, split them into separate branches.
+- After the branch is ready, open a PR rather than merging directly to `main`.
+
+This applies to **all** work categories:
+- **feat** — new features or capabilities
+- **fix** — bug fixes
+- **chore** — dependency updates, release prep, CI/tooling changes
+- **refactor** — code restructuring with no behavior change
+- **test** — adding or fixing tests
+- **docs** — documentation-only changes
+
 ## Git Commits
 
 - **All commit messages MUST be a single line, under 72 characters.**

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,99 @@
+# Hotspots — Ideas & Future Directions
+
+Captured after v1.9.0 (2026-03-24).
+
+---
+
+## Prioritized by Bang for Buck
+
+### Tier 1 — High Value, Low Effort
+
+**SARIF output format**
+- Add `OutputFormat::Sarif` variant alongside Text/Json/Html/Jsonl
+- SARIF is the standard for GitHub code scanning — enables native GitHub Actions integration with zero user config
+- Effort: ~1–2 days (new output format, well-specified schema, no core changes)
+
+**Pre-commit hook template generation**
+- `hotspots init --hooks` writes a ready-to-use pre-commit config snippet
+- Effort: ~half a day (mostly docs/template string)
+
+**Kotlin support**
+- Java CFG builder is 669 lines; Kotlin is structurally similar (JVM, tree-sitter grammar available)
+- Effort: ~2–3 days (new parser + cfg_builder, update FunctionBody enum + all match arms)
+- High reach: Kotlin is now the default Android language
+
+---
+
+### Tier 2 — High Value, Moderate Effort
+
+**`hotspots diff <base> <head>` command**
+- PR-focused: show only functions whose LRS or CC changed between two refs
+- Builds on existing delta machinery; needs a new CLI subcommand and diff render
+- Effort: ~3–5 days
+- High value for CI/CD and PR review workflows
+
+**File-level aggregation in output**
+- Roll up function scores to file level (max CC, avg LRS, total touches)
+- `OutputLevel::File` already exists as an enum variant — it may be partially stubbed
+- Effort: ~2–3 days
+- Makes reports actionable for large codebases where function-level noise is overwhelming
+
+**Configurable thresholds per language**
+- Config file (already supported) gains language-specific CC/LRS cutoffs
+- e.g., Python tends to have higher CC for idiomatic code than Go
+- Effort: ~2–3 days (config schema + per-language filter pass)
+
+**Historical trend charts in HTML report**
+- html.rs is already 2820 lines with a full scatter plot
+- Add a time-series chart using existing snapshot/trend data
+- Effort: ~3–4 days (JS chart rendering, data serialization, HTML template work)
+
+---
+
+### Tier 3 — Moderate Value, Higher Effort
+
+**C/C++ support**
+- Tree-sitter grammar exists but C/C++ is complex: macros, headers, no clear function boundary convention
+- Effort: ~1–2 weeks (parser + cfg_builder + significant edge-case handling)
+- High corpus size but requires robust handling to avoid noisy results
+
+**Cross-function call graph risk propagation**
+- `callgraph.rs` (789 lines) already computes fan-in/fan-out and PageRank
+- Would propagate risk scores up the call graph so callers of high-CC functions inherit risk
+- Effort: ~3–5 days (scoring.rs + risk.rs changes, callgraph integration, golden test updates)
+
+**Rust/Python `match`/`match-case` CFG accuracy**
+- Rust CFG builder is 325 lines, Python 596 — match arms are partially handled
+- Getting edge cases right (guards, binding patterns, exhaustiveness) is fiddly
+- Effort: ~3–5 days per language
+
+**Ruby support**
+- No existing patterns to reuse (unlike Kotlin/Java)
+- Effort: ~1 week
+
+---
+
+### Tier 4 — Lower Priority / Large Effort
+
+**VS Code extension**
+- Separate project, different tech stack (TypeScript extension API)
+- Requires language server protocol or subprocess integration
+- Effort: ~2–4 weeks
+
+**async/await control flow modeling**
+- Affects JS/TS, Python, Rust — each has different semantics
+- Would significantly improve CC accuracy for modern codebases
+- Effort: ~1–2 weeks per language, high correctness risk
+
+**Exception propagation edges in CFG**
+- Needs an exception overlay graph across the whole call graph
+- High complexity, moderate CC accuracy gain
+- Effort: ~2–3 weeks
+
+---
+
+## Raw Ideas (Unprioritized)
+
+- Swift support (mobile)
+- PHP support
+- Dead code detection (CFG nodes unreachable from entry — infrastructure already exists)

--- a/docs/guide/ci-integration.md
+++ b/docs/guide/ci-integration.md
@@ -734,7 +734,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Hotspots (snapshot)
-        run: hotspots analyze . --mode snapshot --format sarif
+        run: hotspots analyze . --mode snapshot --format sarif --output .hotspots/results.sarif
 
       - name: Upload SARIF to GitHub
         uses: github/codeql-action/upload-sarif@v3

--- a/docs/guide/ci-integration.md
+++ b/docs/guide/ci-integration.md
@@ -645,6 +645,129 @@ hotspots analyze src/ --mode delta --policy
 
 ---
 
+## Pre-commit Hooks
+
+Block pushes with complexity regressions before they reach CI using `hotspots init --hooks`.
+
+### Setup
+
+```bash
+# 1. Seed a baseline snapshot (required — delta mode compares against this)
+hotspots analyze . --mode snapshot
+
+# 2. Print hook templates
+hotspots init --hooks
+```
+
+### Option 1: pre-commit Framework
+
+Add the printed YAML block to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: hotspots
+        name: hotspots risk check
+        language: system
+        entry: hotspots analyze . --mode delta --policy --format text
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+Then install:
+
+```bash
+pre-commit install --hook-type pre-push
+```
+
+### Option 2: Raw Shell Hook
+
+Copy the printed shell block (starting with `#!/usr/bin/env sh`) to `.git/hooks/pre-push`:
+
+```bash
+hotspots init --hooks 2>/dev/null | sed -n '/^#!/,$ p' > .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+Or copy manually — the hook content is:
+
+```sh
+#!/usr/bin/env sh
+set -e
+hotspots analyze . --mode delta --policy --format text
+```
+
+### How It Works
+
+- Runs on `pre-push`, not `pre-commit`, to avoid slowing down every commit
+- Delta mode compares the working tree against the last snapshot
+- Exits non-zero if blocking policy violations are found, preventing the push
+- If no baseline snapshot exists yet, policy evaluation is silently skipped
+
+---
+
+## GitHub Code Scanning (SARIF)
+
+Upload SARIF output to GitHub to get inline annotations on pull requests and alerts in the Security tab.
+
+### Workflow
+
+```yaml
+name: Hotspots SARIF
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # Required for upload-sarif
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Hotspots (snapshot)
+        run: hotspots analyze . --mode snapshot --format sarif
+
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: .hotspots/results.sarif
+```
+
+### Risk Band → SARIF Level Mapping
+
+| Hotspots band | SARIF level | GitHub annotation |
+|---------------|-------------|-------------------|
+| `critical` | `error` | Red |
+| `high` | `warning` | Yellow |
+| `moderate` | `note` | Blue |
+| `low` | — | Not emitted |
+
+### Custom Output Path
+
+```bash
+hotspots analyze . --mode snapshot --format sarif --output sarif-results/hotspots.sarif
+```
+
+```yaml
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: sarif-results/hotspots.sarif
+```
+
+See [SARIF Format](./output-formats.md#sarif-format) for complete output format documentation.
+
+---
+
 ## Best Practices
 
 ### 1. Use Delta Mode in CI
@@ -723,7 +846,7 @@ Then tighten:
 - [GitHub Action Guide](./github-action.md) - Complete GitHub Action documentation
 - [Configuration](./configuration.md) - Config file format and options
 - [CLI Reference](../reference/cli.md) - All CLI commands and flags
-- [Output Formats](./output-formats.md) - JSON schema and HTML reports
+- [Output Formats](./output-formats.md) - JSON schema, HTML reports, SARIF
 - [Policy Engine](./usage.md#policy-engine) - Policy rules and enforcement
 
 ---

--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -517,16 +517,16 @@ SARIF 2.1.0 output for GitHub code scanning. Produces inline annotations on pull
 ### Basic Usage
 
 ```bash
-# Snapshot mode SARIF (required — delta not supported)
-hotspots analyze . --mode snapshot --format sarif
+# Snapshot mode SARIF — write to a file with --output
+hotspots analyze . --mode snapshot --format sarif --output .hotspots/results.sarif
 
-# Write to a custom path
-hotspots analyze . --mode snapshot --format sarif --output results.sarif
+# Or capture stdout directly
+hotspots analyze . --mode snapshot --format sarif > results.sarif
 ```
 
-**Default output:** `.hotspots/results.sarif`
-
 **Requires:** `--mode snapshot`. SARIF is not supported with `--mode delta`.
+
+**Note:** Unlike HTML, SARIF has no default output file. Without `--output`, SARIF is written to stdout. Always pass `--output <path>` or redirect stdout when using `upload-sarif`.
 
 ### GitHub Code Scanning Integration
 
@@ -538,7 +538,7 @@ Upload the SARIF file as a GitHub code scanning result using the `upload-sarif` 
     fetch-depth: 0
 
 - name: Run Hotspots (snapshot)
-  run: hotspots analyze . --mode snapshot --format sarif
+  run: hotspots analyze . --mode snapshot --format sarif --output .hotspots/results.sarif
 
 - name: Upload SARIF to GitHub
   uses: github/codeql-action/upload-sarif@v3

--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -1,6 +1,6 @@
 # Output Formats
 
-Hotspots supports three output formats: JSON (machine-readable), HTML (interactive reports), and Text (human-readable terminal output).
+Hotspots supports five output formats: JSON (machine-readable), HTML (interactive reports), Text (human-readable terminal output), SARIF (GitHub code scanning), and JSONL (streaming).
 
 ## Format Overview
 
@@ -9,6 +9,8 @@ Hotspots supports three output formats: JSON (machine-readable), HTML (interacti
 | **JSON** | CI/CD, tooling, AI agents | Structured, versioned schema, machine-parseable |
 | **HTML** | Reports, dashboards, sharing | Interactive, charts, filterable, standalone |
 | **Text** | Terminal, quick inspection | Color-coded, compact, human-friendly |
+| **SARIF** | GitHub code scanning | SARIF 2.1.0, annotations on PRs and files |
+| **JSONL** | Streaming pipelines | One JSON object per line |
 
 ---
 
@@ -508,6 +510,98 @@ NO_COLOR=1 hotspots analyze src/ --format text
 
 ---
 
+## SARIF Format
+
+SARIF 2.1.0 output for GitHub code scanning. Produces inline annotations on pull requests and file views in the GitHub Security tab.
+
+### Basic Usage
+
+```bash
+# Snapshot mode SARIF (required — delta not supported)
+hotspots analyze . --mode snapshot --format sarif
+
+# Write to a custom path
+hotspots analyze . --mode snapshot --format sarif --output results.sarif
+```
+
+**Default output:** `.hotspots/results.sarif`
+
+**Requires:** `--mode snapshot`. SARIF is not supported with `--mode delta`.
+
+### GitHub Code Scanning Integration
+
+Upload the SARIF file as a GitHub code scanning result using the `upload-sarif` action:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+- name: Run Hotspots (snapshot)
+  run: hotspots analyze . --mode snapshot --format sarif
+
+- name: Upload SARIF to GitHub
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: .hotspots/results.sarif
+```
+
+This produces:
+- **Inline annotations** on changed files in pull requests
+- **Security tab alerts** grouped by rule (critical / high / moderate)
+- **Dismissable alerts** for acknowledged risk
+
+### Risk Band Mapping
+
+| Hotspots band | SARIF level | GitHub display |
+|---------------|-------------|----------------|
+| `critical` | `error` | Red annotation |
+| `high` | `warning` | Yellow annotation |
+| `moderate` | `note` | Blue annotation |
+| `low` | — | Not emitted |
+
+Only functions at `moderate` risk or above are included in the SARIF output.
+
+### Output Structure
+
+The emitted file follows SARIF 2.1.0 with `uriBaseId: "%SRCROOT%"` so GitHub resolves file paths correctly:
+
+```json
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/...",
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {
+      "driver": {
+        "name": "hotspots",
+        "version": "1.9.0",
+        "informationUri": "https://hotspots.dev",
+        "rules": [
+          { "id": "hotspots/critical-risk", "defaultConfiguration": { "level": "error" } },
+          { "id": "hotspots/high-risk",     "defaultConfiguration": { "level": "warning" } },
+          { "id": "hotspots/moderate-risk", "defaultConfiguration": { "level": "note" } }
+        ]
+      }
+    },
+    "results": [
+      {
+        "ruleId": "hotspots/high-risk",
+        "level": "warning",
+        "message": { "text": "Function `processOrder` has a high risk score (LRS=7.20, CC=10)." },
+        "locations": [{
+          "physicalLocation": {
+            "artifactLocation": { "uri": "src/orders.ts", "uriBaseId": "%SRCROOT%" },
+            "region": { "startLine": 42 }
+          }
+        }]
+      }
+    ]
+  }]
+}
+```
+
+---
+
 ## Format Comparison
 
 ### When to Use Each Format
@@ -535,6 +629,13 @@ NO_COLOR=1 hotspots analyze src/ --format text
 - ✅ Local development
 - ❌ Automation (use JSON)
 - ❌ Visual analysis (use HTML)
+
+**SARIF:**
+- ✅ GitHub code scanning annotations
+- ✅ Security tab integration
+- ✅ PR inline comments on risk functions
+- ❌ Programmatic analysis (use JSON)
+- ❌ Human inspection (use Text/HTML)
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,7 +55,7 @@ hotspots analyze lib/utils.ts
 ```
 
 ##### `--format <format>`
-**Optional.** Output format: `text`, `json`, `jsonl`, or `html`.
+**Optional.** Output format: `text`, `json`, `jsonl`, `html`, or `sarif`.
 **Default:** `text`
 
 ```bash
@@ -70,9 +70,14 @@ hotspots analyze src/ --format jsonl
 
 # Interactive HTML report (requires --mode)
 hotspots analyze src/ --format html --mode snapshot
+
+# SARIF 2.1.0 for GitHub code scanning (requires --mode snapshot)
+hotspots analyze . --mode snapshot --format sarif
 ```
 
-**Note:** HTML format requires `--mode snapshot` or `--mode delta`.
+**Notes:**
+- HTML format requires `--mode snapshot` or `--mode delta`.
+- SARIF format requires `--mode snapshot`. Default output: `.hotspots/results.sarif`.
 
 ##### `--mode <mode>`
 **Optional.** Output mode: `snapshot` or `delta`.
@@ -647,6 +652,79 @@ Filters:
 
 ---
 
+### `hotspots init`
+
+Print hook templates for CI/CD integration.
+
+#### Usage
+
+```bash
+# Print pre-commit and shell hook templates
+hotspots init --hooks
+```
+
+#### Options
+
+##### `--hooks`
+**Required to produce output.** Prints two hook templates to stdout:
+
+1. **Option 1 — pre-commit framework** (`.pre-commit-config.yaml` snippet)
+2. **Option 2 — raw shell hook** (standalone `#!/usr/bin/env sh` script for `.git/hooks/pre-push`)
+
+If `--hooks` is not specified, prints a usage hint and exits successfully.
+
+#### Setup
+
+Delta mode requires a baseline snapshot to compare against. Seed one before enabling the hook:
+
+```bash
+# 1. Seed the baseline
+hotspots analyze . --mode snapshot
+
+# 2. Print and copy the hook template
+hotspots init --hooks
+
+# 3a. pre-commit framework: append the YAML block to .pre-commit-config.yaml
+#     then install with: pre-commit install --hook-type pre-push
+
+# 3b. Raw shell hook: save the sh block (starting with #!/usr/bin/env sh)
+#     as .git/hooks/pre-push and run: chmod +x .git/hooks/pre-push
+```
+
+#### Example Output
+
+```
+# ── SETUP (run once before enabling the hook) ─────────────────────
+# Seed the baseline first:
+#
+#   hotspots analyze . --mode snapshot
+
+# ── Option 1: pre-commit framework ───────────────────────────────────
+# Add the following to .pre-commit-config.yaml:
+
+repos:
+  - repo: local
+    hooks:
+      - id: hotspots
+        name: hotspots risk check
+        language: system
+        entry: hotspots analyze . --mode delta --policy --format text
+        pass_filenames: false
+        stages: [pre-push]
+
+# ── Option 2: raw shell hook ─────────────────────────────────────────
+# Save the lines below (starting with the shebang) as .git/hooks/pre-push
+# and run: chmod +x .git/hooks/pre-push
+
+#!/usr/bin/env sh
+set -e
+hotspots analyze . --mode delta --policy --format text
+```
+
+Both hooks run `--mode delta --policy` on push and exit non-zero if blocking policy violations are found.
+
+---
+
 ## Exit Codes
 
 | Code | Meaning |
@@ -790,6 +868,15 @@ hotspots analyze src/ --mode delta --policy
 **Fix:**
 ```bash
 hotspots analyze src/ --format html --mode snapshot
+```
+
+### "SARIF format requires --mode snapshot"
+
+**Cause:** Using `--format sarif` without `--mode snapshot`.
+
+**Fix:**
+```bash
+hotspots analyze . --mode snapshot --format sarif
 ```
 
 ### "Config validation failed"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,12 +72,15 @@ hotspots analyze src/ --format jsonl
 hotspots analyze src/ --format html --mode snapshot
 
 # SARIF 2.1.0 for GitHub code scanning (requires --mode snapshot)
-hotspots analyze . --mode snapshot --format sarif
+hotspots analyze . --mode snapshot --format sarif --output .hotspots/results.sarif
+
+# Or capture stdout
+hotspots analyze . --mode snapshot --format sarif > results.sarif
 ```
 
 **Notes:**
 - HTML format requires `--mode snapshot` or `--mode delta`.
-- SARIF format requires `--mode snapshot`. Default output: `.hotspots/results.sarif`.
+- SARIF format requires `--mode snapshot`. Unlike HTML, SARIF has no default output file — without `--output`, SARIF is written to stdout.
 
 ##### `--mode <mode>`
 **Optional.** Output mode: `snapshot` or `delta`.


### PR DESCRIPTION
## Summary

- `docs/guide/output-formats.md` — add SARIF format section (risk band → SARIF level mapping, output structure, GitHub code scanning workflow)
- `docs/guide/ci-integration.md` — add Pre-commit Hooks section (`hotspots init --hooks` setup) and GitHub Code Scanning (SARIF) section
- `docs/reference/cli.md` — document `--format sarif` option, add `hotspots init` command reference, add SARIF troubleshooting entry
- `CLAUDE.md` — add Git Branching rules section
- `IDEAS.md` — initial ideas and prioritization document

## Test plan

- [ ] Docs render correctly in GitHub markdown preview
- [ ] SARIF section accurately reflects `hotspots-core/src/sarif.rs` behavior
- [ ] `hotspots init` section matches `hotspots-cli/src/cmd/init.rs` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)