### PR TITLE
feat: implement --auto-analyze for hotspots diff

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -738,6 +738,72 @@ fn make_progress_reporter(total: usize) -> Box<dyn Fn(usize, usize)> {
     }
 }
 
+/// Analyze the source tree at `sha`, enrich it, persist it to `repo_root`, and
+/// return the resulting snapshot.
+///
+/// Used by `hotspots diff --auto-analyze` to generate missing snapshots on
+/// demand. A temporary git worktree is created at `sha` and torn down
+/// automatically when this function returns (or on error).
+///
+/// Per-function touch metrics are skipped (the touch cache lives in
+/// `repo_root/.hotspots/` and cannot be pre-warmed for historical refs; file-
+/// level batched metrics are still computed as normal).
+pub(crate) fn analyze_and_persist_at_ref(
+    repo_root: &Path,
+    sha: &str,
+    resolved_config: &hotspots_core::ResolvedConfig,
+) -> anyhow::Result<hotspots_core::snapshot::Snapshot> {
+    let worktree = hotspots_core::git::create_worktree(repo_root, sha)
+        .with_context(|| format!("failed to create worktree for {sha}"))?;
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    let progress = make_analysis_progress();
+    let reports = analyze_with_progress(
+        &worktree.path,
+        options,
+        Some(resolved_config),
+        Some(progress.as_ref()),
+    )
+    .with_context(|| format!("analysis failed for ref {sha}"))?;
+
+    // Build enriched snapshot using the worktree as the repo root so that
+    // git context (HEAD, parents, timestamp) is read from the checked-out ref.
+    // Touch cache is skipped (per_function_touches = false).
+    let mut snapshot = build_enriched_snapshot(&worktree.path, resolved_config, reports, false)
+        .with_context(|| format!("enrichment failed for ref {sha}"))?;
+
+    // Rewrite absolute worktree paths back to real repo paths so that
+    // function_ids are stable across snapshots (each worktree lives in a
+    // unique temp dir, so without this diff matching produces 0 matches).
+    let worktree_prefix = worktree.path.to_string_lossy().replace('\\', "/");
+    let repo_prefix = repo_root.to_string_lossy().replace('\\', "/");
+    for f in &mut snapshot.functions {
+        if f.file.starts_with(&worktree_prefix) {
+            let rel = f.file[worktree_prefix.len()..].to_string();
+            let old_file = f.file.clone();
+            f.file = format!("{}{}", repo_prefix, rel);
+            // function_id is "<file>::<symbol>" — rebuild using the corrected file path
+            if let Some(symbol) = f.function_id.strip_prefix(&format!("{old_file}::")) {
+                f.function_id = format!("{}::{}", f.file, symbol);
+            }
+        }
+    }
+
+    snapshot.populate_patterns(&resolved_config.pattern_thresholds);
+
+    // Persist into the *real* repo's .hotspots/ directory, not the worktree.
+    hotspots_core::snapshot::persist_snapshot(repo_root, &snapshot, false)
+        .with_context(|| format!("failed to persist snapshot for {sha}"))?;
+    hotspots_core::snapshot::append_to_index(repo_root, &snapshot)
+        .with_context(|| format!("failed to update index for {sha}"))?;
+
+    // Drop of `worktree` runs `git worktree remove` here.
+    Ok(snapshot)
+}
+
 pub(crate) fn make_analysis_progress() -> Box<dyn Fn(usize, usize) + Send + Sync> {
     use std::io::IsTerminal;
     if !std::io::stderr().is_terminal() {

--- a/hotspots-cli/src/cmd/diff.rs
+++ b/hotspots-cli/src/cmd/diff.rs
@@ -1,3 +1,4 @@
+use crate::cmd::analyze::analyze_and_persist_at_ref;
 use crate::util::{find_repo_root, write_html_report};
 use crate::OutputFormat;
 use anyhow::Context;
@@ -31,6 +32,10 @@ pub(crate) fn handle_diff(args: DiffArgs) -> anyhow::Result<()> {
 
     let repo_root = find_repo_root(&std::env::current_dir()?)?;
 
+    let resolved_config =
+        hotspots_core::config::load_and_resolve(&repo_root, config_path.as_deref())
+            .context("failed to load configuration")?;
+
     // Resolve both refs to full SHAs
     let base_sha = git::resolve_ref_to_sha(&repo_root, &base)
         .with_context(|| format!("failed to resolve base ref '{base}'"))?;
@@ -38,8 +43,10 @@ pub(crate) fn handle_diff(args: DiffArgs) -> anyhow::Result<()> {
         .with_context(|| format!("failed to resolve head ref '{head}'"))?;
 
     // Check both snapshots exist before bailing, so the user sees all missing refs at once
-    let base_snapshot = load_snapshot_or_report(&repo_root, &base, &base_sha, auto_analyze);
-    let head_snapshot = load_snapshot_or_report(&repo_root, &head, &head_sha, auto_analyze);
+    let base_snapshot =
+        load_snapshot_or_report(&repo_root, &base, &base_sha, auto_analyze, &resolved_config);
+    let head_snapshot =
+        load_snapshot_or_report(&repo_root, &head, &head_sha, auto_analyze, &resolved_config);
 
     let (base_snapshot, head_snapshot) = match (base_snapshot, head_snapshot) {
         (Ok(b), Ok(h)) => (b, h),
@@ -103,9 +110,6 @@ pub(crate) fn handle_diff(args: DiffArgs) -> anyhow::Result<()> {
 
     // Evaluate policy if requested
     if policy {
-        let resolved_config =
-            hotspots_core::config::load_and_resolve(&repo_root, config_path.as_deref())
-                .context("failed to load configuration")?;
         let policy_results = hotspots_core::policy::evaluate_policies(
             &delta_val,
             &head_snapshot,
@@ -127,29 +131,33 @@ pub(crate) fn handle_diff(args: DiffArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Try to load a snapshot, returning a descriptive Err string if missing.
-/// Calls process::exit on auto_analyze (not yet implemented).
+/// Try to load a snapshot. When `auto_analyze` is true and the snapshot is
+/// missing, runs a full analysis at `sha` and persists the result before
+/// returning it. Returns a descriptive `Err` string on failure.
 fn load_snapshot_or_report(
     repo_root: &std::path::Path,
     git_ref: &str,
     sha: &str,
     auto_analyze: bool,
+    resolved_config: &hotspots_core::config::ResolvedConfig,
 ) -> Result<hotspots_core::snapshot::Snapshot, String> {
     match snapshot::load_snapshot(repo_root, sha) {
         Ok(Some(s)) => Ok(s),
         Ok(None) => {
             if auto_analyze {
-                eprintln!(
-                    "[hotspots] --auto-analyze: no snapshot for '{git_ref}' ({}) — auto-analysis not yet implemented",
+                eprintln!("[hotspots] auto-analyzing '{}' ({})...", git_ref, &sha[..8]);
+                analyze_and_persist_at_ref(repo_root, sha, resolved_config).map_err(|e| {
+                    format!(
+                        "error: auto-analysis failed for '{git_ref}' ({}): {e}",
+                        &sha[..8]
+                    )
+                })
+            } else {
+                Err(format!(
+                    "error: no snapshot found for ref '{git_ref}' ({})\n  → run: git checkout {git_ref} && hotspots analyze --mode snapshot",
                     &sha[..8]
-                );
-                eprintln!("  → run: git checkout {git_ref} && hotspots analyze --mode snapshot");
-                std::process::exit(2);
+                ))
             }
-            Err(format!(
-                "error: no snapshot found for ref '{git_ref}' ({})\n  → run: git checkout {git_ref} && hotspots analyze --mode snapshot",
-                &sha[..8]
-            ))
         }
         Err(e) => Err(format!(
             "error: failed to load snapshot for '{git_ref}' ({}): {e}",

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -331,6 +331,55 @@ pub fn resolve_ref_to_sha(repo_root: &Path, git_ref: &str) -> Result<String> {
         .with_context(|| format!("failed to resolve git ref '{git_ref}'"))
 }
 
+/// A temporary git worktree that is removed when dropped.
+///
+/// Created by [`create_worktree`]. The worktree directory is cleaned up via
+/// `git worktree remove --force` on drop, so it is always removed even if the
+/// caller returns an error mid-analysis.
+pub struct TempWorktree {
+    /// Absolute path to the worktree root.
+    pub path: std::path::PathBuf,
+    /// Repo root used to issue `git worktree remove`.
+    repo_root: std::path::PathBuf,
+}
+
+impl Drop for TempWorktree {
+    fn drop(&mut self) {
+        let result = git_at(
+            &self.repo_root,
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                &self.path.to_string_lossy(),
+            ],
+        );
+        if let Err(e) = result {
+            eprintln!(
+                "warning: failed to remove temporary worktree {}: {e}",
+                self.path.display()
+            );
+        }
+    }
+}
+
+/// Create a temporary detached worktree at `sha` and return a drop guard.
+///
+/// The worktree is placed in a system temp directory and is automatically
+/// removed when the returned [`TempWorktree`] is dropped.
+pub fn create_worktree(repo_root: &Path, sha: &str) -> Result<TempWorktree> {
+    let dir = std::env::temp_dir().join(format!("hotspots-worktree-{sha}"));
+    git_at(
+        repo_root,
+        &["worktree", "add", "--detach", &dir.to_string_lossy(), sha],
+    )
+    .with_context(|| format!("failed to create worktree for {sha} at {}", dir.display()))?;
+    Ok(TempWorktree {
+        path: dir,
+        repo_root: repo_root.to_path_buf(),
+    })
+}
+
 /// Find the merge-base SHA and Unix timestamp between HEAD and main/master.
 /// Returns None when already on main (merge-base == HEAD) or no divergence found.
 pub fn find_merge_base(repo_root: &Path) -> Option<(String, i64)> {


### PR DESCRIPTION
## Summary

- Adds `TempWorktree` drop guard + `create_worktree()` to `git.rs` — creates a detached worktree at any ref via `git worktree add`, tears it down automatically on drop (even on error)
- Adds `analyze_and_persist_at_ref()` to `analyze.rs` — runs the full analyze → enrich → persist pipeline at a given SHA using a worktree, then rewrites worktree-prefixed paths back to real repo paths so function IDs are stable across snapshots
- Replaces the `process::exit(2)` stub in `diff.rs` with a real call to `analyze_and_persist_at_ref`; config is now loaded once at the top of `handle_diff` rather than twice
- Second run loads from persisted snapshots instantly with no re-analysis

Closes #52

## Test plan

- [x] `cargo test` — 304 unit + all integration/golden tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Tested against this repo: `hotspots diff 20d9b71 9a6ab9c --auto-analyze` correctly produced 4 modified / 3 new / 0 deleted (the CI workflow addition between those two commits)
- [x] Second run with warm snapshots skips auto-analysis and returns instantly
- [x] Worktree cleanup verified — no stale `/tmp/hotspots-worktree-*` dirs left after runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)