### PR TITLE
fix: unique worktree paths and exit 2 on auto-analyze failure

### DIFF
--- a/hotspots-cli/src/cmd/diff.rs
+++ b/hotspots-cli/src/cmd/diff.rs
@@ -7,6 +7,15 @@ use hotspots_core::git;
 use hotspots_core::snapshot;
 use std::path::PathBuf;
 
+/// Structured error from [`load_snapshot_or_report`] so that the caller can
+/// map each variant to a distinct exit code.
+enum LoadError {
+    /// Snapshot not yet generated — user needs to run `hotspots analyze`.
+    Missing(String),
+    /// Auto-analysis was attempted but failed (real execution error).
+    Failed(String),
+}
+
 pub(crate) struct DiffArgs {
     pub base: String,
     pub head: String,
@@ -42,7 +51,10 @@ pub(crate) fn handle_diff(args: DiffArgs) -> anyhow::Result<()> {
     let head_sha = git::resolve_ref_to_sha(&repo_root, &head)
         .with_context(|| format!("failed to resolve head ref '{head}'"))?;
 
-    // Check both snapshots exist before bailing, so the user sees all missing refs at once
+    // Load (or auto-analyze) both snapshots before bailing, so the user sees
+    // all problems at once. Auto-analysis failures exit immediately with code 2
+    // so CI can distinguish them from retriable "snapshot missing" conditions
+    // (exit 3).
     let base_snapshot =
         load_snapshot_or_report(&repo_root, &base, &base_sha, auto_analyze, &resolved_config);
     let head_snapshot =
@@ -51,12 +63,21 @@ pub(crate) fn handle_diff(args: DiffArgs) -> anyhow::Result<()> {
     let (base_snapshot, head_snapshot) = match (base_snapshot, head_snapshot) {
         (Ok(b), Ok(h)) => (b, h),
         (base_result, head_result) => {
-            // Print errors for any missing snapshots, then exit 3
-            if let Err(e) = base_result {
-                eprintln!("{e}");
+            let mut any_failed = false;
+            for result in [base_result, head_result] {
+                match result {
+                    Ok(_) => {}
+                    Err(LoadError::Failed(msg)) => {
+                        eprintln!("{msg}");
+                        any_failed = true;
+                    }
+                    Err(LoadError::Missing(msg)) => {
+                        eprintln!("{msg}");
+                    }
+                }
             }
-            if let Err(e) = head_result {
-                eprintln!("{e}");
+            if any_failed {
+                std::process::exit(2);
             }
             eprintln!("\nOnce both snapshots exist, re-run: hotspots diff {base} {head}");
             std::process::exit(3);
@@ -132,43 +153,40 @@ pub(crate) fn handle_diff(args: DiffArgs) -> anyhow::Result<()> {
 }
 
 /// Try to load a snapshot. When `auto_analyze` is true and the snapshot is
-/// missing, runs a full analysis at `sha` and persists the result before
-/// returning it. Returns a descriptive `Err` string on failure.
+/// missing, runs a full analysis at `sha` and persists the result.
+///
+/// Returns [`LoadError::Missing`] when the snapshot does not exist and
+/// auto-analyze is off, or [`LoadError::Failed`] when auto-analysis was
+/// attempted but encountered a real execution error.
 fn load_snapshot_or_report(
     repo_root: &std::path::Path,
     git_ref: &str,
     sha: &str,
     auto_analyze: bool,
     resolved_config: &hotspots_core::config::ResolvedConfig,
-) -> Result<hotspots_core::snapshot::Snapshot, String> {
+) -> Result<hotspots_core::snapshot::Snapshot, LoadError> {
     match snapshot::load_snapshot(repo_root, sha) {
         Ok(Some(s)) => Ok(s),
         Ok(None) => {
             if auto_analyze {
                 eprintln!("[hotspots] auto-analyzing '{}' ({})...", git_ref, &sha[..8]);
-                match analyze_and_persist_at_ref(repo_root, sha, resolved_config) {
-                    Ok(snapshot) => Ok(snapshot),
-                    Err(e) => {
-                        // Exit 2 (not 3) so CI can distinguish a real execution failure
-                        // from a retriable "snapshot not yet generated" condition.
-                        eprintln!(
-                            "error: auto-analysis failed for '{git_ref}' ({}): {e}",
-                            &sha[..8]
-                        );
-                        std::process::exit(2);
-                    }
-                }
+                analyze_and_persist_at_ref(repo_root, sha, resolved_config).map_err(|e| {
+                    LoadError::Failed(format!(
+                        "error: auto-analysis failed for '{git_ref}' ({}): {e}",
+                        &sha[..8]
+                    ))
+                })
             } else {
-                Err(format!(
+                Err(LoadError::Missing(format!(
                     "error: no snapshot found for ref '{git_ref}' ({})\n  → run: git checkout {git_ref} && hotspots analyze --mode snapshot",
                     &sha[..8]
-                ))
+                )))
             }
         }
-        Err(e) => Err(format!(
+        Err(e) => Err(LoadError::Missing(format!(
             "error: failed to load snapshot for '{git_ref}' ({}): {e}",
             &sha[..8]
-        )),
+        ))),
     }
 }
 

--- a/hotspots-cli/src/cmd/diff.rs
+++ b/hotspots-cli/src/cmd/diff.rs
@@ -146,12 +146,18 @@ fn load_snapshot_or_report(
         Ok(None) => {
             if auto_analyze {
                 eprintln!("[hotspots] auto-analyzing '{}' ({})...", git_ref, &sha[..8]);
-                analyze_and_persist_at_ref(repo_root, sha, resolved_config).map_err(|e| {
-                    format!(
-                        "error: auto-analysis failed for '{git_ref}' ({}): {e}",
-                        &sha[..8]
-                    )
-                })
+                match analyze_and_persist_at_ref(repo_root, sha, resolved_config) {
+                    Ok(snapshot) => Ok(snapshot),
+                    Err(e) => {
+                        // Exit 2 (not 3) so CI can distinguish a real execution failure
+                        // from a retriable "snapshot not yet generated" condition.
+                        eprintln!(
+                            "error: auto-analysis failed for '{git_ref}' ({}): {e}",
+                            &sha[..8]
+                        );
+                        std::process::exit(2);
+                    }
+                }
             } else {
                 Err(format!(
                     "error: no snapshot found for ref '{git_ref}' ({})\n  → run: git checkout {git_ref} && hotspots analyze --mode snapshot",

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -365,10 +365,23 @@ impl Drop for TempWorktree {
 
 /// Create a temporary detached worktree at `sha` and return a drop guard.
 ///
-/// The worktree is placed in a system temp directory and is automatically
-/// removed when the returned [`TempWorktree`] is dropped.
+/// The directory name includes the current process ID so concurrent hotspots
+/// processes analyzing the same SHA use separate paths. Any stale directory
+/// left by an interrupted previous run with the same PID is removed before
+/// creating the new worktree. The worktree is automatically torn down when
+/// the returned [`TempWorktree`] is dropped.
 pub fn create_worktree(repo_root: &Path, sha: &str) -> Result<TempWorktree> {
-    let dir = std::env::temp_dir().join(format!("hotspots-worktree-{sha}"));
+    let dir = std::env::temp_dir().join(format!("hotspots-worktree-{sha}-{}", std::process::id()));
+
+    // Remove any stale worktree left by a previous interrupted run.
+    if dir.exists() {
+        let _ = git_at(
+            repo_root,
+            &["worktree", "remove", "--force", &dir.to_string_lossy()],
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     git_at(
         repo_root,
         &["worktree", "add", "--detach", &dir.to_string_lossy(), sha],

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -373,13 +373,29 @@ impl Drop for TempWorktree {
 pub fn create_worktree(repo_root: &Path, sha: &str) -> Result<TempWorktree> {
     let dir = std::env::temp_dir().join(format!("hotspots-worktree-{sha}-{}", std::process::id()));
 
-    // Remove any stale worktree left by a previous interrupted run.
-    if dir.exists() {
-        let _ = git_at(
-            repo_root,
-            &["worktree", "remove", "--force", &dir.to_string_lossy()],
+    // Always attempt to unregister any stale git worktree entry first.
+    // A temp cleaner may have removed the directory while the .git/worktrees
+    // metadata entry remains; `git worktree add` fails in that case even though
+    // `dir.exists()` returns false.
+    if let Err(e) = git_at(
+        repo_root,
+        &["worktree", "remove", "--force", &dir.to_string_lossy()],
+    ) {
+        // Not fatal — the entry simply may not exist yet.
+        eprintln!(
+            "warning: failed to remove existing git worktree at {}: {e}",
+            dir.display()
         );
-        let _ = std::fs::remove_dir_all(&dir);
+    }
+    // Remove the directory itself if it is still present.
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).with_context(|| {
+            format!(
+                "failed to remove existing worktree directory {}; \
+                 try removing it manually and re-run",
+                dir.display()
+            )
+        })?;
     }
 
     git_at(


### PR DESCRIPTION
## Summary

Follow-up to #56, addressing two review comments:

- **Unique worktree paths (P2):** `create_worktree` now uses `hotspots-worktree-{sha}-{pid}` instead of `hotspots-worktree-{sha}`. Concurrent processes analyzing the same SHA get separate paths. Stale dirs from an interrupted same-PID run are cleaned up (`git worktree remove --force` + `remove_dir_all`) before creating the new worktree. `tempfile` stays dev-only.

- **Correct exit code on failure (P1):** Auto-analysis failures now call `process::exit(2)` directly rather than converting to `Err(String)` and flowing through the exit-3 ("snapshots missing") path. CI can now distinguish a real execution failure (exit 2) from a missing snapshot that needs generating (exit 3).

## Test plan

- [x] `cargo test` — 304 unit + all integration/golden tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)