### PR TITLE
feat: warn on cold cache miss + per-item progress for touch metrics

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -781,8 +781,8 @@ fn make_progress_reporter(total: usize) -> Box<dyn Fn(usize, usize)> {
                 .progress_chars("##-"),
         );
         Box::new(move |i: usize, t: usize| {
-            pb.set_position((i + 1) as u64);
-            if i + 1 >= t {
+            pb.set_position(i as u64);
+            if i >= t {
                 pb.finish_and_clear();
             }
         })
@@ -793,13 +793,13 @@ fn make_progress_reporter(total: usize) -> Box<dyn Fn(usize, usize)> {
         );
         let last_print = std::sync::Mutex::new(std::time::Instant::now());
         Box::new(move |i: usize, t: usize| {
-            if i + 1 >= t {
-                eprintln!("Building touch cache: {}/{} functions [done]", i + 1, t);
+            if i >= t {
+                eprintln!("Building touch cache: {}/{} functions [done]", i, t);
                 return;
             }
             if let Ok(mut last) = last_print.try_lock() {
                 if last.elapsed().as_secs() >= 30 {
-                    eprintln!("Building touch cache: {}/{} functions", i + 1, t);
+                    eprintln!("Building touch cache: {}/{} functions", i, t);
                     *last = std::time::Instant::now();
                 }
             }

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -76,7 +76,10 @@ enum Commands {
         #[arg(long, value_name = "LEVEL")]
         level: Option<OutputLevel>,
 
-        /// Use per-function git log -L for touch metrics
+        /// Use per-function git log -L for touch metrics (more accurate than file-level
+        /// batching). Results are cached in .hotspots/touch-cache.json.zst — the first
+        /// run on a new commit is slow (~9 ms per uncached function); subsequent runs
+        /// are fast. A warning is printed when 50+ functions need to be fetched.
         #[arg(long)]
         per_function_touches: bool,
 

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -374,19 +374,31 @@ impl Snapshot {
             }
         }
 
+        let hits = total - misses.len();
         if let Some(f) = progress_fn {
-            f(total - misses.len(), total);
+            f(hits, total);
         }
 
         if misses.is_empty() {
             return Ok(());
         }
 
+        // Warn when cold-cache miss count is high enough that the user might wonder
+        // why analysis is stalling. Estimate is conservative (sequential ~9 ms each);
+        // rayon parallelism makes the real wall time lower.
+        const COLD_CACHE_WARN_THRESHOLD: usize = 50;
+        if misses.len() >= COLD_CACHE_WARN_THRESHOLD {
+            let est_secs = (misses.len() * 9).div_ceil(1000);
+            eprintln!(
+                "note: {} functions not in touch cache — this may take ~{}s on first run. \
+                 Subsequent runs will be fast.",
+                misses.len(),
+                est_secs.max(1)
+            );
+        }
+
         // Phase 2: run git subprocesses in parallel for all cache misses.
-        // Results are sent through a channel as they complete, avoiding a full
-        // intermediate Vec that would coexist with the already-allocated misses Vec.
-        // Progress is not reported per-item here (progress_fn is not Sync);
-        // the caller sees a jump from cache-hits-done to total at phase end.
+        // Results are sent through a channel as they complete.
         let timestamp = self.commit.timestamp;
         let (tx, rx) = std::sync::mpsc::channel::<(usize, String, (usize, Option<u32>))>();
         misses
@@ -406,14 +418,16 @@ impl Snapshot {
             });
 
         // Phase 3: apply results and write cache.
+        // Progress is reported per-item here since rx drains on the main thread.
+        let mut completed = hits;
         for (idx, key, (count, days)) in rx {
             self.functions[idx].touch_count_30d = Some(count);
             self.functions[idx].days_since_last_change = days;
             cache.insert(key, (count, days));
-        }
-
-        if let Some(f) = progress_fn {
-            f(total, total);
+            completed += 1;
+            if let Some(f) = progress_fn {
+                f(completed, total);
+            }
         }
 
         // Evict stale entries (most-recent SHAs first) then write.
@@ -1983,6 +1997,42 @@ mod tests {
         let calls = calls.lock().unwrap();
         // Phase 1 fires once; misses=0 so we return early with (total, total)
         assert!(!calls.is_empty(), "progress should have been called");
+        assert_eq!(*calls.last().unwrap(), (1, 1));
+    }
+
+    #[test]
+    fn test_populate_touch_metrics_progress_fires_per_miss() {
+        // When there are cache misses, progress_fn should be called once per
+        // resolved miss in the phase-3 drain loop, not just at the end.
+        use std::sync::{Arc, Mutex};
+
+        let snapshot = create_test_snapshot();
+        // Empty cache → 1 function = 1 miss
+        let dir = tempfile::tempdir().unwrap();
+
+        let calls: Arc<Mutex<Vec<(usize, usize)>>> = Arc::new(Mutex::new(Vec::new()));
+        let calls_ref = calls.clone();
+
+        let mut snapshot = snapshot;
+        // populate_touch_metrics will shell out to git for the miss; in a temp
+        // dir with no git repo it will return (0, None) via the error path.
+        let _ = snapshot.populate_touch_metrics(
+            dir.path(),
+            true,
+            Some(&|i, n| {
+                calls_ref.lock().unwrap().push((i, n));
+            }),
+        );
+
+        let calls = calls.lock().unwrap();
+        // Phase 1: (0, 1) — 0 hits out of 1 total
+        // Phase 3: (1, 1) — 1 resolved miss
+        assert!(
+            calls.len() >= 2,
+            "expected at least 2 progress calls, got {}",
+            calls.len()
+        );
+        assert_eq!(calls[0], (0, 1));
         assert_eq!(*calls.last().unwrap(), (1, 1));
     }
 }


### PR DESCRIPTION
Closes #55

## Summary

- **Cold-cache warning:** when 50+ functions are missing from the touch cache, prints a note before phase 2 starts with the miss count and a rough time estimate. Users know why analysis is slow and that the second run will be fast.
- **Per-item progress during phase 2:** progress callbacks now fire once per resolved miss as results drain from the channel (phase 3 loop), instead of jumping from `(hits, total)` directly to `(total, total)`. The phase 3 drain is single-threaded so no Sync constraints.
- **`--per-function-touches` help text:** documents the cache location, the cold/warm cost tradeoff, and the 50-miss warning threshold.
- **New test:** `test_populate_touch_metrics_progress_fires_per_miss` — verifies phase 1 fires `(0, 1)` and phase 3 fires `(1, 1)` for a single-function cold-cache miss.

## Test plan
- [ ] 313/313 tests pass
- [ ] `hotspots analyze . --per-function-touches` on a cold cache shows the note with count + estimate
- [ ] Second run produces no note (warm cache)
- [ ] Progress bar advances per function during phase 2 (not a single jump at the end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)