### PR TITLE
fix: resolve clippy lint errors from Rust 1.95 stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore: [ CHANGELOG.md ]
   pull_request:
     branches: [ main, develop ]
+    paths-ignore: [ CHANGELOG.md ]
 
 jobs:
   test:

--- a/.github/workflows/hotspots.yml
+++ b/.github/workflows/hotspots.yml
@@ -3,7 +3,9 @@ name: Hotspots Analysis
 on:
   push:
     branches: [main]
+    paths-ignore: [ CHANGELOG.md ]
   pull_request:
+    paths-ignore: [ CHANGELOG.md ]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,9 @@ name: Security
 on:
   push:
     branches: [main]
+    paths-ignore: [ CHANGELOG.md ]
   pull_request:
+    paths-ignore: [ CHANGELOG.md ]
   schedule:
     - cron: '0 6 * * 1' # Weekly, Monday 06:00 UTC
 

--- a/hotspots-core/src/metrics.rs
+++ b/hotspots-core/src/metrics.rs
@@ -1112,11 +1112,8 @@ fn rust_non_structured_exits(block: &syn::Block) -> usize {
 
     fn expr_exits(expr: &Expr, count: &mut usize, is_tail: bool) {
         match expr {
-            Expr::Return(_) => {
-                // Don't count final tail return
-                if !is_tail {
-                    *count += 1;
-                }
+            Expr::Return(_) if !is_tail => {
+                *count += 1;
             }
             Expr::Try(_) => {
                 // ? operator counts as early return

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -437,7 +437,7 @@ impl Snapshot {
             let mut commits = Index::load_or_new(&index_path(repo_root))
                 .map(|idx| idx.commits)
                 .unwrap_or_default();
-            commits.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+            commits.sort_by_key(|c| std::cmp::Reverse(c.timestamp));
             let mut shas = vec![sha.clone()];
             shas.extend(commits.into_iter().map(|e| e.sha).filter(|s| s != &sha));
             shas
@@ -1335,7 +1335,7 @@ fn compute_near_miss_detail(
     .filter(|(_, rank)| *rank >= 40)
     .collect();
 
-    near.sort_by(|a, b| b.1.cmp(&a.1));
+    near.sort_by_key(|a| std::cmp::Reverse(a.1));
     near.truncate(3);
 
     if near.is_empty() {


### PR DESCRIPTION
## Summary
- Fix `collapsible_match` in `metrics.rs:1117` — collapsed `if !is_tail` guard into match arm
- Fix two `unnecessary_sort_by` in `snapshot.rs` — `sort_by(|a,b| b.x.cmp(&a.x))` → `sort_by_key(|x| Reverse(...))`
- Add `paths-ignore: [CHANGELOG.md]` to CI, Security, and Hotspots Analysis workflows to eliminate the double-run cascade on every merge

**Root cause of cascade:** `changelog.yml` pushes via `RELEASE_PAT` (attributed to the user, not `github-actions[bot]`), so the `github.actor != 'github-actions[bot]'` guards on other workflows don't fire. This caused ~8 workflow runs per merge instead of ~4.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] All 313 tests pass
- [x] Changelog-only pushes will now be skipped by CI, Security, and Hotspots Analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)