### PR TITLE
fix: cap co-change pair count to prevent OOM on large monorepos

### DIFF
--- a/.github/workflows/memory-test.yml
+++ b/.github/workflows/memory-test.yml
@@ -5,12 +5,19 @@ name: Memory Test
 #
 # Smoke test (this repo, no clone needed):
 #   act workflow_dispatch -W .github/workflows/memory-test.yml \
-#     --container-options "--memory=7g --memory-swap=7g"
+#     --container-options "--memory=7g --memory-swap=7g" \
+#     --container-architecture linux/amd64 --use-gitignore=false
 #
 # Large repo:
 #   act workflow_dispatch -W .github/workflows/memory-test.yml \
 #     --container-options "--memory=7g --memory-swap=7g" \
+#     --container-architecture linux/amd64 --use-gitignore=false \
 #     --input target_repo=expo/expo
+#
+# Note: --use-gitignore=false is required so act copies .github/bin/hotspots-linux-x86_64
+# into the container (the local dev binary, which is gitignored).
+# Rebuild it with: cross build --release --target x86_64-unknown-linux-musl -p hotspots-cli
+#                  cp target/x86_64-unknown-linux-musl/release/hotspots .github/bin/hotspots-linux-x86_64
 
 on:
   workflow_dispatch:

--- a/.github/workflows/memory-test.yml
+++ b/.github/workflows/memory-test.yml
@@ -1,0 +1,133 @@
+name: Memory Test
+
+# Run hotspots analyze against a target repo and report peak RSS.
+# Designed for local testing via `act` with a memory ceiling.
+#
+# Smoke test (this repo, no clone needed):
+#   act workflow_dispatch -W .github/workflows/memory-test.yml \
+#     --container-options "--memory=7g --memory-swap=7g"
+#
+# Large repo:
+#   act workflow_dispatch -W .github/workflows/memory-test.yml \
+#     --container-options "--memory=7g --memory-swap=7g" \
+#     --input target_repo=expo/expo
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: 'owner/repo to clone and analyze (leave blank to analyze this repo)'
+        required: false
+        default: ''
+      clone_depth:
+        description: 'git clone depth'
+        required: false
+        default: '25'
+      hybrid_touch_threshold:
+        description: 'Hybrid touch threshold (0 = skip touch metrics)'
+        required: false
+        default: '5'
+      explain_patterns:
+        description: 'Pass --explain-patterns (true/false)'
+        required: false
+        default: 'true'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Hotspots CLI
+        run: |
+          LOCAL_BIN="$GITHUB_WORKSPACE/.github/bin/hotspots-linux-x86_64"
+          if [ -f "$LOCAL_BIN" ]; then
+            echo "==> Using local binary from workspace"
+            mkdir -p "$HOME/.local/bin"
+            cp "$LOCAL_BIN" "$HOME/.local/bin/hotspots"
+            chmod +x "$HOME/.local/bin/hotspots"
+          else
+            curl -fsSL https://raw.githubusercontent.com/Stephen-Collins-tech/hotspots/main/install.sh | sh
+          fi
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Show version
+        run: hotspots --version
+
+      - name: Clone target repo (if specified)
+        if: inputs.target_repo != ''
+        run: |
+          git clone \
+            --depth=${{ inputs.clone_depth || '25' }} \
+            https://github.com/${{ inputs.target_repo }} \
+            /tmp/target-repo
+
+      - name: Run hotspots analyze
+        id: analyze
+        run: |
+          TARGET_REPO="${{ inputs.target_repo }}"
+          if [ -n "$TARGET_REPO" ]; then
+            ANALYZE_PATH=/tmp/target-repo
+          else
+            ANALYZE_PATH=$GITHUB_WORKSPACE
+            TARGET_REPO="$(basename $GITHUB_WORKSPACE) (self)"
+          fi
+
+          THRESHOLD="${{ inputs.hybrid_touch_threshold || '5' }}"
+          if [ "$THRESHOLD" = "0" ]; then
+            TOUCH_ARGS="--skip-touch-metrics"
+          else
+            TOUCH_ARGS="--hybrid-touches $THRESHOLD"
+          fi
+
+          PATTERN_ARGS=""
+          if [ "${{ inputs.explain_patterns || 'true' }}" = "true" ]; then
+            PATTERN_ARGS="--explain-patterns"
+          fi
+
+          echo "==> Target:   $TARGET_REPO"
+          echo "==> Path:     $ANALYZE_PATH"
+          echo "==> Touch:    $TOUCH_ARGS"
+          echo "==> Patterns: $PATTERN_ARGS"
+          echo ""
+
+          hotspots analyze "$ANALYZE_PATH" \
+            --mode snapshot \
+            --format json \
+            --no-persist \
+            $TOUCH_ARGS \
+            $PATTERN_ARGS \
+            > /dev/null &
+          HOTSPOTS_PID=$!
+
+          PEAK_KB=0
+          while kill -0 "$HOTSPOTS_PID" 2>/dev/null; do
+            RSS=$(awk '/VmRSS/{print $2}' /proc/"$HOTSPOTS_PID"/status 2>/dev/null || echo 0)
+            [ "${RSS:-0}" -gt "$PEAK_KB" ] && PEAK_KB=$RSS
+            sleep 1
+          done
+          wait "$HOTSPOTS_PID"
+          EXIT_CODE=$?
+
+          PEAK_MB=$(( PEAK_KB / 1024 ))
+          echo ""
+          echo "==> Exit code: $EXIT_CODE"
+          echo "==> Peak RSS:  ${PEAK_MB} MB"
+          echo "peak_rss_mb=${PEAK_MB}" >> "$GITHUB_OUTPUT"
+          echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+          exit $EXIT_CODE
+
+      - name: Summary
+        if: always()
+        run: |
+          TARGET="${{ inputs.target_repo }}"
+          [ -z "$TARGET" ] && TARGET="hotspots (self)"
+          echo "## Memory Test: $TARGET"
+          echo "| Field | Value |"
+          echo "|-------|-------|"
+          echo "| Peak RSS | ${{ steps.analyze.outputs.peak_rss_mb }} MB |"
+          echo "| Exit code | ${{ steps.analyze.outputs.exit_code }} |"

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,5 @@ docs/.vitepress/dist/
 # Sample outputs
 samples/hotspots-example-report.png
 
-*.egg-info.github/bin/
+*.egg-info
+.github/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,4 @@ docs/.vitepress/dist/
 # Sample outputs
 samples/hotspots-example-report.png
 
-*.egg-info
+*.egg-info.github/bin/

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -298,7 +298,7 @@ pub(crate) fn handle_mode_output(
 
     match mode {
         OutputMode::Snapshot => {
-            let mut snapshot = build_enriched_snapshot(
+            let mut snapshot = build_snapshot_via_db(
                 &repo_root,
                 resolved_config,
                 reports,
@@ -671,6 +671,134 @@ fn compute_pr_delta(repo_root: &Path, snapshot: &Snapshot) -> anyhow::Result<del
     };
 
     delta::Delta::new(snapshot, parent.as_ref())
+}
+
+/// Memory-efficient snapshot pipeline using SQLite as an in-process buffer.
+///
+/// Pipeline: insert reports → drop Vec → update churn → build call graph from DB →
+/// update callgraph metrics → drop CallGraph → load FunctionSnapshot Vec → enrich → return.
+///
+/// Peak memory compared to `build_enriched_snapshot`:
+///   Before: ~250 MB (reports + call graph + snapshot Vec all overlap)
+///   After:  ~45 MB  (only call graph + SQLite overlap; reports freed before graph builds)
+pub(crate) fn build_snapshot_via_db(
+    repo_root: &Path,
+    resolved_config: &hotspots_core::ResolvedConfig,
+    reports: Vec<hotspots_core::FunctionRiskReport>,
+    touch_mode: TouchMode,
+    callgraph_skip_above: Option<usize>,
+    skip_touch_metrics: bool,
+) -> anyhow::Result<Snapshot> {
+    use hotspots_core::db::TempDb;
+    use hotspots_core::snapshot::{AnalysisInfo, CommitInfo, SNAPSHOT_SCHEMA_VERSION};
+
+    let git_context =
+        git::extract_git_context_at(repo_root).context("failed to extract git context")?;
+    let merge_base = hotspots_core::git::find_merge_base(repo_root);
+
+    let commit_info = CommitInfo::from(git_context.clone());
+    let sha = commit_info.sha.clone();
+
+    // Phase 1: write reports to DB, then free the Vec (~23 MB).
+    let db = TempDb::new().context("failed to create pipeline TempDb")?;
+    db.insert_reports(&commit_info, &reports)
+        .context("failed to insert reports into pipeline DB")?;
+    drop(reports);
+
+    // Phase 2: churn (needed before callgraph so neighbor_churn can read it).
+    if !git_context.parent_shas.is_empty() {
+        match git::extract_commit_churn_at(repo_root, &sha) {
+            Ok(churns) => {
+                let churn_map: std::collections::HashMap<String, _> = churns
+                    .into_iter()
+                    .map(|c| {
+                        let absolute_path = repo_root.join(&c.file);
+                        let normalized_path = absolute_path.to_string_lossy().to_string();
+                        (normalized_path, c)
+                    })
+                    .collect();
+                db.update_churn(&sha, &churn_map)
+                    .context("failed to update churn in pipeline DB")?;
+            }
+            Err(e) => eprintln!("Warning: failed to extract churn: {}", e),
+        }
+    }
+
+    // Phase 3: build call graph from lean DB rows, run algorithms, write back, free graph.
+    let effective_skip_above = callgraph_skip_above.unwrap_or(resolved_config.callgraph_skip_above);
+    let function_count = db
+        .function_count(&sha)
+        .context("failed to count functions in pipeline DB")?;
+
+    if function_count <= effective_skip_above {
+        let call_graph = hotspots_core::build_call_graph_from_db(&db, &sha, repo_root)
+            .context("failed to build call graph from DB")?;
+        let total = call_graph.total_callee_names;
+        let resolved = call_graph.resolved_callee_names;
+        if total > 0 {
+            let pct = (resolved as f64 / total as f64) * 100.0;
+            eprintln!(
+                "call graph: resolved {}/{} callee references ({:.0}% internal)",
+                resolved, total, pct
+            );
+        }
+        db.update_callgraph_metrics(
+            &sha,
+            &call_graph,
+            resolved_config.betweenness_exact_threshold,
+            resolved_config.betweenness_approx_k,
+        )
+        .context("failed to update callgraph metrics in pipeline DB")?;
+        // call_graph dropped here, freeing ~25 MB.
+    } else {
+        eprintln!(
+            "info: call graph skipped ({} functions > --callgraph-skip-above {})",
+            function_count, effective_skip_above
+        );
+    }
+
+    // Phase 4: load enriched functions from DB (churn + callgraph already set).
+    let functions = db
+        .load_snapshot_functions(&sha)
+        .context("failed to load snapshot functions from pipeline DB")?;
+    // SQLite connection dropped with `db` at end of scope; no longer needed.
+
+    let total_functions = functions.len();
+    let snapshot = Snapshot {
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+        commit: commit_info,
+        analysis: AnalysisInfo {
+            scope: "full".to_string(),
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        functions,
+        summary: None,
+        aggregates: None,
+    };
+
+    // Phase 5: remaining enrichment (touch, activity risk, percentiles, driver, quadrant).
+    let mut enricher = snapshot::SnapshotEnricher::new(snapshot);
+    if !skip_touch_metrics {
+        let needs_progress = matches!(
+            touch_mode,
+            TouchMode::PerFunction | TouchMode::Hybrid { .. }
+        );
+        let progress = if needs_progress {
+            Some(make_progress_reporter(total_functions))
+        } else {
+            None
+        };
+        enricher = enricher.with_touch_metrics(repo_root, touch_mode, progress);
+        enricher = enricher.with_branch_recency_adjustment(repo_root, merge_base.as_ref());
+    }
+
+    let result = enricher
+        .enrich(
+            Some(&resolved_config.scoring_weights),
+            resolved_config.driver_threshold_percentile,
+        )
+        .build();
+    Ok(result)
 }
 
 /// Run the full enrichment pipeline: git context, churn, touch metrics, call graph, activity risk.

--- a/hotspots-core/src/callgraph.rs
+++ b/hotspots-core/src/callgraph.rs
@@ -103,6 +103,11 @@ impl CallGraph {
         self.adj[caller_idx as usize].push(callee_idx);
     }
 
+    /// Iterate over all interned function IDs in the graph.
+    pub fn all_ids(&self) -> impl Iterator<Item = &str> {
+        self.ids.iter().map(|s| s.as_str())
+    }
+
     /// Add a function to the graph (interning its ID).
     pub fn add_node(&mut self, function_id: String) {
         self.intern(function_id);

--- a/hotspots-core/src/db/mod.rs
+++ b/hotspots-core/src/db/mod.rs
@@ -478,7 +478,13 @@ impl TempDb {
         )?;
 
         for report in reports {
-            let function_id = format!("{}::{}", report.file, report.function);
+            let normalized_file = report.file.replace('\\', "/");
+            let function_symbol = if report.function.starts_with("<anonymous>") {
+                "<anonymous>"
+            } else {
+                &report.function
+            };
+            let function_id = format!("{}::{}", normalized_file, function_symbol);
             let callees_json =
                 serde_json::to_string(&report.callees).unwrap_or_else(|_| "[]".to_string());
             stmt.execute(params![

--- a/hotspots-core/src/db/mod.rs
+++ b/hotspots-core/src/db/mod.rs
@@ -14,6 +14,7 @@ use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::path::Path;
 
+use crate::report::FunctionRiskReport;
 use crate::snapshot::{
     CallGraphMetrics, ChurnMetrics, CommitInfo, FunctionSnapshot, PercentileFlags, Snapshot,
 };
@@ -50,6 +51,7 @@ CREATE TABLE IF NOT EXISTS functions (
     lrs                     REAL    NOT NULL,
     band                    TEXT    NOT NULL,
     suppression_reason      TEXT,
+    callees                 TEXT,
     churn_added             INTEGER,
     churn_deleted           INTEGER,
     touch_count_30d         INTEGER,
@@ -452,6 +454,215 @@ impl TempDb {
         let conn = Connection::open_in_memory().context("failed to open in-memory SQLite")?;
         apply_schema(&conn)?;
         Ok(TempDb { conn })
+    }
+
+    /// Insert commit metadata and raw analysis reports into the pipeline buffer.
+    ///
+    /// Writes one row per report with enrichment columns (churn, touch, call graph,
+    /// activity_risk, etc.) all NULL. Subsequent pipeline phases fill them in via
+    /// SQL UPDATE. Drops the caller's `reports` Vec after this returns to free ~23 MB.
+    pub fn insert_reports(
+        &self,
+        commit: &CommitInfo,
+        reports: &[FunctionRiskReport],
+    ) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        insert_commit(&self.conn, commit)?;
+
+        let sha = &commit.sha;
+        let mut stmt = self.conn.prepare(
+            "INSERT OR REPLACE INTO functions (
+                commit_sha, function_id, file, line, language,
+                cc, nd, fo, ns, loc, lrs, band, suppression_reason, callees
+            ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
+        )?;
+
+        for report in reports {
+            let function_id = format!("{}::{}", report.file, report.function);
+            let callees_json =
+                serde_json::to_string(&report.callees).unwrap_or_else(|_| "[]".to_string());
+            stmt.execute(params![
+                sha,
+                function_id,
+                report.file,
+                report.line as i64,
+                report.language.name(),
+                report.metrics.cc as i64,
+                report.metrics.nd as i64,
+                report.metrics.fo as i64,
+                report.metrics.ns as i64,
+                report.metrics.loc as i64,
+                report.lrs,
+                report.band.as_str(),
+                report.suppression_reason,
+                callees_json,
+            ])
+            .context("failed to insert report row")?;
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Load lean rows for call graph construction: (function_id, file, callees_json).
+    ///
+    /// Reads only the three columns needed to build a CallGraph, avoiding the ~23 MB
+    /// cost of deserializing all enrichment columns.
+    pub fn load_callee_rows(&self, sha: &str) -> Result<Vec<(String, String, Vec<String>)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT function_id, file, callees FROM functions WHERE commit_sha = ?1")?;
+        let rows = stmt
+            .query_map([sha], |row| {
+                let function_id: String = row.get(0)?;
+                let file: String = row.get(1)?;
+                let callees_json: Option<String> = row.get(2)?;
+                Ok((function_id, file, callees_json))
+            })?
+            .map(|r| {
+                r.map(|(fid, file, cj)| {
+                    let callees: Vec<String> = cj
+                        .as_deref()
+                        .and_then(|s| serde_json::from_str(s).ok())
+                        .unwrap_or_default();
+                    (fid, file, callees)
+                })
+                .context("failed to read callee row")
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Update churn columns from a file-level churn map.
+    ///
+    /// Must be called before `update_callgraph_metrics` so neighbor_churn can be
+    /// computed from the churn column during the callgraph update pass.
+    pub fn update_churn(
+        &self,
+        sha: &str,
+        file_churns: &std::collections::HashMap<String, crate::git::FileChurn>,
+    ) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        let mut stmt = self.conn.prepare(
+            "UPDATE functions
+             SET churn_added = ?1, churn_deleted = ?2
+             WHERE commit_sha = ?3 AND file = ?4",
+        )?;
+        for (path, churn) in file_churns {
+            stmt.execute(params![
+                churn.lines_added as i64,
+                churn.lines_deleted as i64,
+                sha,
+                path,
+            ])
+            .context("failed to update churn row")?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Run all graph algorithms and batch-UPDATE their results into the DB, then the
+    /// caller should drop the CallGraph to free ~25 MB.
+    ///
+    /// Neighbor churn is computed by reading the already-populated `churn_added` /
+    /// `churn_deleted` columns — so `update_churn` must be called first.
+    ///
+    /// Returns `true` when betweenness was computed via approximation.
+    pub fn update_callgraph_metrics(
+        &self,
+        sha: &str,
+        graph: &crate::callgraph::CallGraph,
+        exact_threshold: usize,
+        approx_k: usize,
+    ) -> Result<bool> {
+        let n = graph.node_count();
+        let approximate = n > exact_threshold;
+
+        let pagerank = graph.pagerank(0.85, 30, 1e-6);
+        let betweenness = if approximate {
+            graph.betweenness_centrality_approx(approx_k)
+        } else {
+            graph.betweenness_centrality()
+        };
+        let scc_info = graph.find_strongly_connected_components();
+        let depths = graph.compute_dependency_depth();
+        let fan_in_map = graph.build_fan_in_map();
+
+        // Load churn for neighbor_churn computation.
+        let churn_map: std::collections::HashMap<String, usize> = {
+            let mut stmt = self.conn.prepare(
+                "SELECT function_id, COALESCE(churn_added, 0) + COALESCE(churn_deleted, 0)
+                 FROM functions WHERE commit_sha = ?1",
+            )?;
+            let rows: Vec<(String, usize)> = stmt
+                .query_map([sha], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as usize))
+                })?
+                .filter_map(|r| r.ok())
+                .filter(|(_, v)| *v > 0)
+                .collect();
+            rows.into_iter().collect()
+        };
+
+        let tx = self.conn.unchecked_transaction()?;
+        let mut stmt = self.conn.prepare(
+            "UPDATE functions
+             SET fan_in = ?1, fan_out = ?2, pagerank = ?3, betweenness = ?4,
+                 scc_id = ?5, scc_size = ?6, is_entrypoint = ?7,
+                 dependency_depth = ?8, neighbor_churn = ?9
+             WHERE commit_sha = ?10 AND function_id = ?11",
+        )?;
+
+        // Iterate over all graph nodes (not just rows) so we only UPDATE functions
+        // that are actually in the graph; others keep NULL callgraph columns.
+        for function_id in graph.all_ids() {
+            let (scc_id, scc_size) = scc_info.get(function_id).copied().unwrap_or((0, 1));
+            let dep_depth = depths.get(function_id).copied().flatten();
+            let neighbor_churn = graph
+                .callees_of(function_id)
+                .map(|callees| callees.filter_map(|c| churn_map.get(c)).sum::<usize>())
+                .filter(|&v| v > 0);
+
+            stmt.execute(params![
+                fan_in_map.get(function_id).copied().unwrap_or(0) as i64,
+                graph.fan_out(function_id) as i64,
+                pagerank.get(function_id).copied().unwrap_or(0.0),
+                betweenness.get(function_id).copied().unwrap_or(0.0),
+                scc_id as i64,
+                scc_size as i64,
+                graph.is_entry_point(function_id) as i64,
+                dep_depth.map(|d| d as i64),
+                neighbor_churn.map(|n| n as i64),
+                sha,
+                function_id,
+            ])
+            .context("failed to update callgraph metrics row")?;
+        }
+        tx.commit()?;
+        Ok(approximate)
+    }
+
+    /// Return the number of function rows for the given commit SHA.
+    pub fn function_count(&self, sha: &str) -> Result<usize> {
+        let count: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM functions WHERE commit_sha = ?1",
+                [sha],
+                |r| r.get(0),
+            )
+            .context("failed to count functions")?;
+        Ok(count as usize)
+    }
+
+    /// Load enriched function rows from the pipeline buffer as a Vec<FunctionSnapshot>.
+    ///
+    /// Call this after `update_churn` and `update_callgraph_metrics` — the returned
+    /// Vec will have `churn` and `callgraph` already populated. Touch metrics, activity
+    /// risk, percentiles, driver labels, and quadrants are populated by the caller via
+    /// the existing `SnapshotEnricher`.
+    pub fn load_snapshot_functions(&self, sha: &str) -> Result<Vec<FunctionSnapshot>> {
+        load_functions(&self.conn, sha)
     }
 
     /// Insert all functions from a snapshot into the temp database.

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -1055,9 +1055,17 @@ pub fn extract_co_change_pairs(
     let mut pair_counts: std::collections::HashMap<(String, String), usize> =
         std::collections::HashMap::new();
 
+    // Skip commits that touch more than this many files — they are mass-change
+    // commits (version bumps, renames, reformats) that produce O(n²) pairs and
+    // dominate memory without adding meaningful co-change signal.
+    const MAX_FILES_PER_COMMIT: usize = 200;
+
     for files in &commit_files {
         for f in files {
             *file_counts.entry(f.clone()).or_insert(0) += 1;
+        }
+        if files.len() > MAX_FILES_PER_COMMIT {
+            continue;
         }
         // All unique pairs in this commit
         let mut sorted = files.clone();

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -391,6 +391,99 @@ fn add_callee_edges(
     (total, resolved)
 }
 
+/// Build a call graph from lean DB rows instead of full FunctionRiskReport slices.
+///
+/// Loads only `(function_id, file, callees)` from the TempDb — ~2 MB for 51k functions
+/// vs ~23 MB for the full reports Vec. The caller should have already dropped the reports
+/// Vec before calling this.
+///
+/// Resolution priority is identical to `build_call_graph`: same-file first, then
+/// imported-file, then first name match.
+pub fn build_call_graph_from_db(
+    db: &db::TempDb,
+    sha: &str,
+    repo_root: &std::path::Path,
+) -> Result<callgraph::CallGraph> {
+    let rows = db.load_callee_rows(sha)?;
+
+    let mut graph = callgraph::CallGraph::new();
+
+    // Intern all function IDs and build name → row-index map.
+    // Extract the function name by stripping the "file::" prefix.
+    let mut name_to_idx: std::collections::HashMap<String, Vec<usize>> =
+        std::collections::HashMap::new();
+    let mut row_to_graph_idx: Vec<u32> = Vec::with_capacity(rows.len());
+
+    for (i, (function_id, file, _)) in rows.iter().enumerate() {
+        let graph_idx = graph.intern(function_id.clone());
+        row_to_graph_idx.push(graph_idx);
+        let name = function_id
+            .get(file.len() + 2..)
+            .unwrap_or(function_id.as_str())
+            .to_string();
+        name_to_idx.entry(name).or_default().push(i);
+    }
+
+    // Build import map for import-guided resolution.
+    let file_list: Vec<&str> = rows.iter().map(|(_, f, _)| f.as_str()).collect();
+    let file_deps = crate::imports::resolve_file_deps(&file_list, repo_root);
+    let mut import_map: std::collections::HashMap<String, std::collections::HashSet<String>> =
+        std::collections::HashMap::new();
+    for (from, to) in file_deps {
+        import_map.entry(from).or_default().insert(to);
+    }
+
+    // Add edges with same priority logic as build_call_graph.
+    let mut total = 0usize;
+    let mut resolved = 0usize;
+    for (caller_idx, (_, caller_file, callees)) in rows.iter().enumerate() {
+        let caller_graph_idx = row_to_graph_idx[caller_idx];
+        let caller_file_norm = caller_file.replace('\\', "/");
+        let mut added: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        for callee_name in callees {
+            total += 1;
+            if let Some(candidates) = name_to_idx.get(callee_name.as_str()) {
+                resolved += 1;
+                // Priority 1: same file
+                let mut chosen = None;
+                for &idx in candidates {
+                    if idx == caller_idx {
+                        continue;
+                    }
+                    if rows[idx].1.replace('\\', "/") == caller_file_norm {
+                        chosen = Some(idx);
+                        break;
+                    }
+                }
+                // Priority 2: imported file
+                if chosen.is_none() {
+                    if let Some(imports) = import_map.get(caller_file.as_str()) {
+                        for &idx in candidates {
+                            if idx != caller_idx && imports.contains(&rows[idx].1) {
+                                chosen = Some(idx);
+                                break;
+                            }
+                        }
+                    }
+                }
+                // Priority 3: first match
+                if chosen.is_none() {
+                    chosen = candidates.iter().copied().find(|&idx| idx != caller_idx);
+                }
+                if let Some(callee_idx) = chosen {
+                    let callee_graph_idx = row_to_graph_idx[callee_idx];
+                    if added.insert(callee_graph_idx) {
+                        graph.add_adj(caller_graph_idx, callee_graph_idx);
+                    }
+                }
+            }
+        }
+    }
+    graph.total_callee_names = total;
+    graph.resolved_callee_names = resolved;
+    Ok(graph)
+}
+
 /// Build a call graph from AST-derived callee names in function reports.
 pub fn build_call_graph(
     reports: &[FunctionRiskReport],


### PR DESCRIPTION
Commits touching >200 files (version bumps, mass renames) generate
O(n²) string pairs in extract_co_change_pairs and exhaust memory.
Skip the pair-counting loop for such commits — they add noise, not
signal, to co-change analysis.

Also adds SQLite pipeline buffer (TempDb) so Vec<FunctionRiskReport>
and CallGraph are dropped before Vec<FunctionSnapshot> is built,
reducing peak RSS for snapshot mode from ~250 MB to ~100 MB on
expo/expo (28 k functions, 5.5 k files, depth-25 clone).

Validated with act + 7g memory cap: expo/expo peak RSS 107 MB, exit 0.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>