### PR TITLE
feat: add model risk map mode

### DIFF
--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -694,8 +694,8 @@ Hotspots produces versioned JSON output. The `schema_version` field indicates th
 
 | Version | Scope | Added fields |
 |---------|-------|--------------|
-| **v2** (current) | Snapshot and delta output | `driver`, `driver_detail`, `patterns`, `pattern_details`, enriched `aggregates` (file_risk, co_change, modules) |
-| **v3** | Agent-optimized (`--all-functions`) | `fire`/`debt`/`watch`/`ok` quadrant buckets, per-function `action` text |
+| **v3** (current default snapshot JSON) | Agent-optimized snapshot output | `summary`, `fire`/`debt`/`watch`/`ok` triage buckets, per-function `action` text, `architecture` aggregates |
+| **v2** | Full snapshot JSON (`--all-functions`) and delta output | `driver`, `driver_detail`, `patterns`, `pattern_details`, enriched `aggregates` (file_risk, co_change, modules) |
 | **v1** | Delta output (legacy constant) | — |
 
 Always check `schema_version` before consuming output in tooling.
@@ -722,7 +722,13 @@ When a function receives the `composite` label, `driver_detail` lists the top di
 
 `driver_detail` is omitted from JSON when null (forward-compatible).
 
-### Aggregates (Snapshot Mode)
+### Architecture Aggregates (Default Snapshot JSON)
+
+Default snapshot JSON groups architectural concentration under `architecture`:
+`architecture.file_risk`, `architecture.modules`, and, when requested,
+`architecture.models`.
+
+### Aggregates (`--all-functions` Snapshot JSON)
 
 Snapshot output includes an `aggregates` object with these arrays:
 
@@ -777,13 +783,13 @@ Robert Martin's instability metric at the directory level: `instability = effere
 }
 ```
 
-#### `aggregates.models` — Model Risk Map
+#### `aggregates.models` / `architecture.models` — Model Risk Map
 
 Present only when snapshot JSON is generated with `--include-models`.
 
 ```typescript
 {
-  models: [{
+  items: [{
     name: "Snapshot",
     file: "hotspots-core/src/snapshot.rs",
     line: 219,

--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -255,6 +255,9 @@ Interactive HTML reports with charts and visualizations.
 # Snapshot mode HTML
 hotspots analyze src/ --mode snapshot --format html
 
+# Snapshot HTML with model risk map
+hotspots analyze src/ --mode snapshot --format html --include-models
+
 # Delta mode HTML
 hotspots analyze src/ --mode delta --format html
 
@@ -291,6 +294,12 @@ hotspots analyze src/ --mode snapshot --format html --output reports/complexity.
 - **Risk Landscape scatter plot:** all functions plotted by Complexity (LRS, x-axis) vs Change Frequency (recent touches, y-axis). Dots are color-coded by risk band (critical = orange, high = amber, moderate = teal, low = grey). Dashed median lines divide the chart into four quadrants — the top-right quadrant (high complexity + high churn) is the classic Tornhill hotspot zone. Hover any dot to see function name, file path, LRS, and touch count.
 - Historical trend charts: stacked band count, activity risk line, top-1% share line
   (requires ≥2 prior snapshots; up to 30 history points; hover for per-bar detail)
+
+**Model Risk Map** (when generated with `--include-models`):
+- Draggable relationship graph of top data/control models
+- Node size reflects concentrated associated function risk
+- Edge width reflects shared AST/CFG-derived associated references
+- Collapsed raw model table for audit detail
 
 **Delta Mode Additions:**
 - Before/after comparison
@@ -715,7 +724,7 @@ When a function receives the `composite` label, `driver_detail` lists the top di
 
 ### Aggregates (Snapshot Mode)
 
-Snapshot output includes an `aggregates` object with three arrays:
+Snapshot output includes an `aggregates` object with these arrays:
 
 #### `aggregates.file_risk` — File-Level Risk
 
@@ -765,6 +774,43 @@ Robert Martin's instability metric at the directory level: `instability = effere
   efferent: 3,       // external modules this one depends on
   instability: 0.27, // near 0 = risky to change; near 1 = safe
   module_risk: "high"
+}
+```
+
+#### `aggregates.models` — Model Risk Map
+
+Present only when snapshot JSON is generated with `--include-models`.
+
+```typescript
+{
+  models: [{
+    name: "Snapshot",
+    file: "hotspots-core/src/snapshot.rs",
+    line: 219,
+    kind: "struct",
+    score: 52.11,
+    critical: 4,
+    high: 15,
+    moderate: 17,
+    functions: [{
+      function: "Snapshot::populate_callgraph",
+      file: "hotspots-core/src/snapshot.rs",
+      line: 661,
+      lrs: 9.24,
+      quadrant: "debt",
+      association: "same-file"
+    }]
+  }],
+  links: [{
+    source: 0,
+    target: 2,
+    shared_functions: 15,
+    shared_risk: 83.53,
+    functions: [
+      "GoCfgBuilderState::visit_switch",
+      "GoCfgBuilderState::visit_select"
+    ]
+  }]
 }
 ```
 

--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -694,7 +694,8 @@ Hotspots produces versioned JSON output. The `schema_version` field indicates th
 
 | Version | Scope | Added fields |
 |---------|-------|--------------|
-| **v3** (current default snapshot JSON) | Agent-optimized snapshot output | `summary`, `fire`/`debt`/`watch`/`ok` triage buckets, per-function `action` text, `architecture` aggregates |
+| **v4** (current default snapshot JSON) | Agent-optimized snapshot output | `summary`, `fire`/`debt`/`watch`/`ok` triage buckets, per-function `action` text, `architecture` aggregates, optional `architecture.models` |
+| **v3** | Agent-optimized snapshot output | triage buckets and per-function `action` text before architecture aggregates were nested |
 | **v2** | Full snapshot JSON (`--all-functions`) and delta output | `driver`, `driver_detail`, `patterns`, `pattern_details`, enriched `aggregates` (file_risk, co_change, modules) |
 | **v1** | Delta output (legacy constant) | — |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -337,12 +337,12 @@ structure (quadrant buckets).
 hotspots analyze . --mode snapshot --format json --all-functions
 ```
 
-Produces schema v3 output: a flat `functions` array containing every function, regardless
-of quadrant. The default triage-first structure groups functions into `fire`, `debt`,
-`watch`, and `ok` buckets. Use `--all-functions` when consuming output in tooling or AI
-agents that prefer a flat list.
+Produces schema v2 full snapshot output: a flat `functions` array containing every
+function, regardless of quadrant. The default triage-first structure is schema v4 and
+groups functions into `fire`, `debt`, `watch`, and `ok` buckets. Use `--all-functions`
+when consuming output in tooling that needs the complete snapshot shape.
 
-See [JSON Schema Reference](../guide/output-formats.md#schema-versions) for the v3 schema.
+See [JSON Schema Reference](../guide/output-formats.md#schema-versions) for schema details.
 
 ##### `--include-models`
 **Optional.** Include the model risk map in snapshot JSON and HTML reports.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -353,9 +353,9 @@ hotspots analyze . --mode snapshot --format json --include-models
 hotspots analyze . --mode snapshot --format html --include-models
 ```
 
-Adds the top model risk concentrations and shared-reference `links` under `models`
-in agent JSON output, `aggregates.models` in `--all-functions` JSON output, and
-a draggable Model Risk Map graph in HTML reports.
+Adds the top model risk concentrations and shared-reference `links` under
+`architecture.models` in agent JSON output, `aggregates.models` in `--all-functions`
+JSON output, and a Model Risk Map section in HTML reports.
 
 #### Examples
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -83,7 +83,7 @@ hotspots analyze . --mode snapshot --format sarif > results.sarif
 - SARIF format requires `--mode snapshot`. Unlike HTML, SARIF has no default output file — without `--output`, SARIF is written to stdout.
 
 ##### `--mode <mode>`
-**Optional.** Output mode: `snapshot` or `delta`.
+**Optional.** Output mode: `snapshot`, `delta`, or `models`.
 
 ```bash
 # Snapshot mode: capture current state
@@ -91,6 +91,10 @@ hotspots analyze src/ --mode snapshot --format json
 
 # Delta mode: compare against parent commit
 hotspots analyze src/ --mode delta --format json
+
+# Models mode: rank data models by associated hotspot risk
+hotspots analyze src/ --mode models --format text
+hotspots analyze src/ --mode models --format json --top 10
 ```
 
 **Snapshot mode:**
@@ -105,6 +109,12 @@ hotspots analyze src/ --mode delta --format json
 - Shows complexity changes (ΔLRS)
 - PR mode: compares vs merge-base
 - Mainline mode: compares vs direct parent
+
+**Models mode:**
+- Extracts first-party model declarations from supported languages
+- Associates functions in the same file or files that directly import the model file
+- Ranks models by the sum of their top 5 associated function risk scores
+- Supports text and JSON output
 
 ##### `--policy`
 **Optional.** Evaluate policies (only valid with `--mode delta`).
@@ -333,6 +343,19 @@ of quadrant. The default triage-first structure groups functions into `fire`, `d
 agents that prefer a flat list.
 
 See [JSON Schema Reference](../guide/output-formats.md#schema-versions) for the v3 schema.
+
+##### `--include-models`
+**Optional.** Include the model risk map in snapshot JSON and HTML reports.
+**Only valid with:** `--mode snapshot --format json` or `--mode snapshot --format html`
+
+```bash
+hotspots analyze . --mode snapshot --format json --include-models
+hotspots analyze . --mode snapshot --format html --include-models
+```
+
+Adds the top model risk concentrations and shared-reference `links` under `models`
+in agent JSON output, `aggregates.models` in `--all-functions` JSON output, and
+a draggable Model Risk Map graph in HTML reports.
 
 #### Examples
 

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -24,6 +24,7 @@ pub(crate) struct AnalyzeArgs {
     pub level: Option<OutputLevel>,
     pub per_function_touches: bool,
     pub all_functions: bool,
+    pub include_models: bool,
     pub explain_patterns: bool,
     /// URL of the corresponding written analysis post, embedded as a banner in HTML output.
     pub source_url: Option<String>,
@@ -51,6 +52,7 @@ pub(crate) fn validate_analyze_flags(args: &AnalyzeArgs) -> anyhow::Result<()> {
         force,
         level,
         all_functions,
+        include_models,
         explain_patterns,
         ..
     } = args;
@@ -61,10 +63,15 @@ pub(crate) fn validate_analyze_flags(args: &AnalyzeArgs) -> anyhow::Result<()> {
         anyhow::bail!("--explain flag is only valid with --mode snapshot");
     }
     if *per_function_touches && mode.is_none() {
-        anyhow::bail!("--per-function-touches is only valid with --mode snapshot or --mode delta");
+        anyhow::bail!(
+            "--per-function-touches is only valid with --mode snapshot, --mode delta, or --mode models"
+        );
     }
     if *no_persist {
         if mode.is_none() {
+            anyhow::bail!("--no-persist is only valid with --mode snapshot or --mode delta");
+        }
+        if *mode == Some(OutputMode::Models) {
             anyhow::bail!("--no-persist is only valid with --mode snapshot or --mode delta");
         }
         if *force {
@@ -86,6 +93,17 @@ pub(crate) fn validate_analyze_flags(args: &AnalyzeArgs) -> anyhow::Result<()> {
         && (*mode != Some(OutputMode::Snapshot) || !matches!(format, OutputFormat::Json))
     {
         anyhow::bail!("--all-functions is only valid with --mode snapshot --format json");
+    }
+    if *mode == Some(OutputMode::Models)
+        && !matches!(format, OutputFormat::Text | OutputFormat::Json)
+    {
+        anyhow::bail!("--mode models supports --format text or --format json");
+    }
+    if *include_models
+        && (*mode != Some(OutputMode::Snapshot)
+            || !matches!(format, OutputFormat::Json | OutputFormat::Html))
+    {
+        anyhow::bail!("--include-models is only valid with --mode snapshot --format json/html");
     }
     if *explain_patterns && *mode != Some(OutputMode::Snapshot) && mode.is_some() {
         anyhow::bail!("--explain-patterns is only valid with --mode snapshot or without --mode");
@@ -117,6 +135,7 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         skip_touch_metrics,
         hybrid_touches,
         all_functions,
+        include_models,
         explain_patterns,
         source_url,
         jobs,
@@ -182,6 +201,7 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
                 level,
                 touch_mode: effective_touch_mode,
                 all_functions,
+                include_models,
                 explain_patterns,
                 source_url,
                 callgraph_skip_above,
@@ -264,6 +284,7 @@ pub(crate) struct ModeOutputOptions {
     pub level: Option<OutputLevel>,
     pub touch_mode: TouchMode,
     pub all_functions: bool,
+    pub include_models: bool,
     pub explain_patterns: bool,
     pub source_url: Option<String>,
     pub callgraph_skip_above: Option<usize>,
@@ -288,6 +309,7 @@ pub(crate) fn handle_mode_output(
         level,
         touch_mode,
         all_functions,
+        include_models,
         explain_patterns,
         source_url,
         callgraph_skip_above,
@@ -359,6 +381,7 @@ pub(crate) fn handle_mode_output(
                     co_change_window_days: resolved_config.co_change_window_days,
                     co_change_min_count: resolved_config.co_change_min_count,
                     all_functions,
+                    include_models,
                     source_url: source_url.clone(),
                     risk_thresholds: hotspots_core::risk::RiskThresholds {
                         moderate: resolved_config.moderate_threshold,
@@ -367,6 +390,7 @@ pub(crate) fn handle_mode_output(
                     },
                 },
                 &repo_root,
+                path,
             )?;
         }
         OutputMode::Delta => {
@@ -450,6 +474,37 @@ pub(crate) fn handle_mode_output(
                 std::process::exit(1);
             }
         }
+        OutputMode::Models => {
+            let snapshot = build_enriched_snapshot(
+                &repo_root,
+                resolved_config,
+                reports,
+                touch_mode,
+                callgraph_skip_above,
+                skip_touch_metrics,
+            )
+            .context("failed to build enriched snapshot")?;
+            let model_map =
+                hotspots_core::models::compute_model_risk_map(path, &repo_root, &snapshot, top)
+                    .context("failed to compute model risk map")?;
+            match format {
+                OutputFormat::Text => {
+                    print!(
+                        "{}",
+                        hotspots_core::models::render_model_risk_text(&model_map, top)
+                    );
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        hotspots_core::models::render_model_risk_json(&model_map)?
+                    );
+                }
+                OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif => {
+                    unreachable!("validated by validate_analyze_flags")
+                }
+            }
+        }
     }
 
     Ok(())
@@ -465,6 +520,7 @@ struct SnapshotOutputOpts {
     co_change_window_days: u64,
     co_change_min_count: usize,
     all_functions: bool,
+    include_models: bool,
     source_url: Option<String>,
     risk_thresholds: hotspots_core::risk::RiskThresholds,
 }
@@ -473,6 +529,7 @@ fn emit_snapshot_output(
     snapshot: &mut Snapshot,
     opts: SnapshotOutputOpts,
     repo_root: &Path,
+    analysis_path: &Path,
 ) -> anyhow::Result<()> {
     let SnapshotOutputOpts {
         format,
@@ -484,16 +541,18 @@ fn emit_snapshot_output(
         co_change_window_days,
         co_change_min_count,
         all_functions,
+        include_models,
         source_url,
         risk_thresholds,
     } = opts;
     match format {
         OutputFormat::Json => {
-            let aggregates = hotspots_core::aggregates::compute_snapshot_aggregates(
+            let aggregates = hotspots_core::aggregates::compute_snapshot_aggregates_with_models(
                 snapshot,
                 repo_root,
                 co_change_window_days,
                 co_change_min_count,
+                include_models.then_some(analysis_path),
             );
             if all_functions {
                 snapshot.aggregates = Some(aggregates);
@@ -558,11 +617,12 @@ fn emit_snapshot_output(
             }
         }
         OutputFormat::Html => {
-            let aggregates = hotspots_core::aggregates::compute_snapshot_aggregates(
+            let aggregates = hotspots_core::aggregates::compute_snapshot_aggregates_with_models(
                 snapshot,
                 repo_root,
                 co_change_window_days,
                 co_change_min_count,
+                include_models.then_some(analysis_path),
             );
             snapshot.aggregates = Some(aggregates);
             let history: Vec<_> = hotspots_core::trends::load_snapshot_window(repo_root, 30)

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -356,7 +356,10 @@ pub(crate) fn handle_mode_output(
             let total_function_count = snapshot.functions.len();
             let is_aggregate_level =
                 level == Some(OutputLevel::File) || level == Some(OutputLevel::Module);
-            if (explain || top.is_some()) && !is_aggregate_level {
+            if matches!(format, OutputFormat::Text)
+                && (explain || top.is_some())
+                && !is_aggregate_level
+            {
                 snapshot.functions.sort_by(|a, b| {
                     let a_score = a.activity_risk.unwrap_or(a.lrs);
                     let b_score = b.activity_risk.unwrap_or(b.lrs);
@@ -554,7 +557,28 @@ fn emit_snapshot_output(
                 co_change_min_count,
                 include_models.then_some(analysis_path),
             );
-            if all_functions {
+            if let Some(output_path) = output {
+                if all_functions {
+                    snapshot.aggregates = Some(aggregates);
+                    write_snapshot_json_file(&output_path, |out| {
+                        snapshot
+                            .write_json_to(out)
+                            .context("failed to write snapshot JSON")
+                    })?;
+                } else {
+                    let agent_output = hotspots_core::aggregates::compute_agent_snapshot_output(
+                        snapshot,
+                        &aggregates,
+                        repo_root,
+                    );
+                    write_snapshot_json_file(&output_path, |out| {
+                        agent_output
+                            .write_json_to(out)
+                            .context("failed to write agent snapshot JSON")
+                    })?;
+                }
+                eprintln!("JSON report written to: {}", output_path.display());
+            } else if all_functions {
                 snapshot.aggregates = Some(aggregates);
                 let stdout = std::io::stdout();
                 let mut out = std::io::BufWriter::new(stdout.lock());
@@ -658,6 +682,20 @@ fn emit_snapshot_output(
         }
     }
     Ok(())
+}
+
+fn write_snapshot_json_file<F>(output_path: &Path, write: F) -> anyhow::Result<()>
+where
+    F: FnOnce(&mut std::io::BufWriter<std::fs::File>) -> anyhow::Result<()>,
+{
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+    }
+    let file = std::fs::File::create(output_path)
+        .with_context(|| format!("failed to create {}", output_path.display()))?;
+    let mut out = std::io::BufWriter::new(file);
+    write(&mut out)
 }
 
 /// Returns true if there are blocking policy failures (caller should exit non-zero).

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -356,10 +356,7 @@ pub(crate) fn handle_mode_output(
             let total_function_count = snapshot.functions.len();
             let is_aggregate_level =
                 level == Some(OutputLevel::File) || level == Some(OutputLevel::Module);
-            if matches!(format, OutputFormat::Text)
-                && (explain || top.is_some())
-                && !is_aggregate_level
-            {
+            if (explain || top.is_some()) && !is_aggregate_level {
                 snapshot.functions.sort_by(|a, b| {
                     let a_score = a.activity_risk.unwrap_or(a.lrs);
                     let b_score = b.activity_risk.unwrap_or(b.lrs);

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -356,9 +356,8 @@ pub(crate) fn handle_mode_output(
             let total_function_count = snapshot.functions.len();
             let is_aggregate_level =
                 level == Some(OutputLevel::File) || level == Some(OutputLevel::Module);
-            if matches!(format, OutputFormat::Text)
-                && (explain || top.is_some())
-                && !is_aggregate_level
+            if !is_aggregate_level
+                && (top.is_some() || (matches!(format, OutputFormat::Text) && explain))
             {
                 snapshot.functions.sort_by(|a, b| {
                     let a_score = a.activity_risk.unwrap_or(a.lrs);

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -36,7 +36,7 @@ enum Commands {
         #[arg(long, default_value = "text")]
         format: OutputFormat,
 
-        /// Output mode (snapshot or delta)
+        /// Output mode (snapshot, delta, or models)
         #[arg(long)]
         mode: Option<OutputMode>,
 
@@ -98,6 +98,10 @@ enum Commands {
         /// Output all functions as a flat array (only valid with --mode snapshot --format json)
         #[arg(long)]
         all_functions: bool,
+
+        /// Include model risk map data in snapshot JSON/HTML reports.
+        #[arg(long)]
+        include_models: bool,
 
         /// Populate and emit pattern details for --explain-patterns
         #[arg(long)]
@@ -219,6 +223,7 @@ pub(crate) enum OutputFormat {
 pub(crate) enum OutputMode {
     Snapshot,
     Delta,
+    Models,
 }
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
@@ -248,6 +253,7 @@ fn main() -> anyhow::Result<()> {
             no_per_function_touches,
             skip_touch_metrics,
             all_functions,
+            include_models,
             explain_patterns,
             source_url,
             jobs,
@@ -270,6 +276,7 @@ fn main() -> anyhow::Result<()> {
             no_per_function_touches,
             skip_touch_metrics,
             all_functions,
+            include_models,
             explain_patterns,
             source_url,
             jobs,

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -209,7 +209,9 @@ pub struct AgentArchitectureView {
     pub models: Option<crate::models::ModelRiskMap>,
 }
 
-/// Agent-optimized snapshot output (schema version 3)
+pub const AGENT_SNAPSHOT_SCHEMA_VERSION: u32 = 4;
+
+/// Agent-optimized snapshot output (schema version 4)
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct AgentSnapshotOutput {
@@ -283,7 +285,7 @@ fn to_agent_view(
         .collect()
 }
 
-/// Build the agent-optimized v3 JSON output from a fully enriched snapshot and its aggregates.
+/// Build the agent-optimized v4 JSON output from a fully enriched snapshot and its aggregates.
 ///
 /// Groups functions by triage quadrant, sorts each group by `activity_risk` descending,
 /// and returns top-N per quadrant. Co-change is split into hidden pairs only, capped at
@@ -402,7 +404,7 @@ pub fn compute_agent_snapshot_output(
     };
 
     AgentSnapshotOutput {
-        schema_version: 3,
+        schema_version: AGENT_SNAPSHOT_SCHEMA_VERSION,
         commit: snapshot.commit.clone(),
         summary: snapshot.summary.clone(),
         triage,

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -85,6 +85,8 @@ pub struct SnapshotAggregates {
     pub co_change: Vec<crate::git::CoChangePair>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub modules: Vec<ModuleInstability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models: Option<crate::models::ModelRiskMap>,
 }
 
 /// Delta aggregates for a file
@@ -207,6 +209,8 @@ pub struct AgentSnapshotOutput {
     pub file_risk: Vec<FileRiskView>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub modules: Vec<ModuleInstability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models: Option<crate::models::ModelRiskMap>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<crate::snapshot::SnapshotSummary>,
 }
@@ -385,6 +389,7 @@ pub fn compute_agent_snapshot_output(
         },
         file_risk,
         modules: aggregates.modules.clone(),
+        models: aggregates.models.clone(),
         summary: snapshot.summary.clone(),
     }
 }
@@ -762,6 +767,23 @@ pub fn compute_snapshot_aggregates(
     co_change_window_days: u64,
     co_change_min_count: usize,
 ) -> SnapshotAggregates {
+    compute_snapshot_aggregates_with_models(
+        snapshot,
+        repo_root,
+        co_change_window_days,
+        co_change_min_count,
+        None,
+    )
+}
+
+/// Compute snapshot aggregates, optionally including model risk data.
+pub fn compute_snapshot_aggregates_with_models(
+    snapshot: &Snapshot,
+    repo_root: &std::path::Path,
+    co_change_window_days: u64,
+    co_change_min_count: usize,
+    model_source_root: Option<&std::path::Path>,
+) -> SnapshotAggregates {
     let files = compute_file_aggregates(&snapshot.functions);
     let directories = compute_directory_aggregates(&files, repo_root);
     let file_risk = compute_file_risk_views(&snapshot.functions);
@@ -788,6 +810,9 @@ pub fn compute_snapshot_aggregates(
     annotate_static_deps(&mut co_change, &all_edges, repo_root);
 
     let modules = compute_module_instability_from_edges(&snapshot.functions, &all_edges, repo_root);
+    let models = model_source_root.and_then(|source_root| {
+        crate::models::compute_model_risk_map(source_root, repo_root, snapshot, Some(10)).ok()
+    });
 
     SnapshotAggregates {
         files,
@@ -795,6 +820,7 @@ pub fn compute_snapshot_aggregates(
         file_risk,
         co_change,
         modules,
+        models,
     }
 }
 

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -197,22 +197,30 @@ pub struct AgentCoChangeView {
     pub total_pairs: usize,
 }
 
-/// Agent-optimized snapshot output (schema version 3)
+/// Architecture-oriented aggregate views for agent-optimized output.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub struct AgentSnapshotOutput {
-    pub schema_version: u32,
-    pub commit: crate::snapshot::CommitInfo,
-    pub triage: TriageView,
-    pub co_change: AgentCoChangeView,
+pub struct AgentArchitectureView {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub file_risk: Vec<FileRiskView>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub modules: Vec<ModuleInstability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub models: Option<crate::models::ModelRiskMap>,
+}
+
+/// Agent-optimized snapshot output (schema version 3)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentSnapshotOutput {
+    pub schema_version: u32,
+    pub commit: crate::snapshot::CommitInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<crate::snapshot::SnapshotSummary>,
+    pub triage: TriageView,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<AgentArchitectureView>,
+    pub co_change: AgentCoChangeView,
 }
 
 impl AgentSnapshotOutput {
@@ -378,20 +386,73 @@ pub fn compute_agent_snapshot_output(
         })
         .collect();
 
+    let models = aggregates
+        .models
+        .as_ref()
+        .map(|model_map| normalize_model_risk_map(model_map, repo_root));
+    let architecture = if file_risk.is_empty() && aggregates.modules.is_empty() && models.is_none()
+    {
+        None
+    } else {
+        Some(AgentArchitectureView {
+            file_risk,
+            modules: aggregates.modules.clone(),
+            models,
+        })
+    };
+
     AgentSnapshotOutput {
         schema_version: 3,
         commit: snapshot.commit.clone(),
+        summary: snapshot.summary.clone(),
         triage,
+        architecture,
         co_change: AgentCoChangeView {
             hidden_coupling,
             hidden_count,
             total_pairs,
         },
-        file_risk,
-        modules: aggregates.modules.clone(),
-        models: aggregates.models.clone(),
-        summary: snapshot.summary.clone(),
     }
+}
+
+fn normalize_model_risk_map(
+    map: &crate::models::ModelRiskMap,
+    repo_root: &std::path::Path,
+) -> crate::models::ModelRiskMap {
+    crate::models::ModelRiskMap {
+        models: map
+            .models
+            .iter()
+            .map(|model| {
+                let functions = model
+                    .functions
+                    .iter()
+                    .map(|function| crate::models::ModelFunction {
+                        file: normalize_path_relative_to_repo(&function.file, repo_root)
+                            .unwrap_or_else(|| function.file.clone()),
+                        function_id: relativize_function_id(&function.function_id, repo_root),
+                        ..function.clone()
+                    })
+                    .collect();
+                crate::models::ModelRiskEntry {
+                    file: normalize_path_relative_to_repo(&model.file, repo_root)
+                        .unwrap_or_else(|| model.file.clone()),
+                    functions,
+                    ..model.clone()
+                }
+            })
+            .collect(),
+        links: map.links.clone(),
+    }
+}
+
+fn relativize_function_id(function_id: &str, repo_root: &std::path::Path) -> String {
+    let Some((file, function)) = function_id.split_once("::") else {
+        return function_id.to_string();
+    };
+    normalize_path_relative_to_repo(file, repo_root)
+        .map(|rel| format!("{rel}::{function}"))
+        .unwrap_or_else(|| function_id.to_string())
 }
 
 /// Check if a band is High+ (high or critical)

--- a/hotspots-core/src/html.rs
+++ b/hotspots-core/src/html.rs
@@ -31,6 +31,7 @@ pub fn render_html_snapshot(
     let source_banner = render_source_banner(source_url);
     let scatter_json = render_scatter_json(&snapshot.functions);
     let scatter = render_scatter_section(&scatter_json);
+    let overview = render_overview(snapshot, aggregates);
 
     format!(
         r#"<!DOCTYPE html>
@@ -46,6 +47,7 @@ pub fn render_html_snapshot(
         {header}
         {source_banner}
         {summary}
+        {overview}
         {scatter}
         {trends}
         {triage}
@@ -63,6 +65,7 @@ pub fn render_html_snapshot(
         header = render_header(&snapshot.commit),
         source_banner = source_banner,
         summary = render_summary(snapshot, thresholds),
+        overview = overview,
         scatter = scatter,
         trends = trends,
         triage = render_triage_panel(&snapshot.functions),
@@ -360,6 +363,383 @@ tbody tr:hover {
     background: #f3f4f6;
 }
 
+/* Overview */
+.overview-section {
+    padding: 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background: #f9fafb;
+}
+
+.overview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    gap: 0.9rem;
+}
+
+.overview-panel {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background: #ffffff;
+    padding: 0.9rem;
+}
+
+.overview-panel h3 {
+    color: #111827;
+    font-size: 0.95rem;
+    margin-bottom: 0.65rem;
+}
+
+.overview-stacked {
+    display: flex;
+    height: 1rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: #e5e7eb;
+}
+
+.overview-segment {
+    min-width: 2px;
+}
+
+.overview-bars {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.overview-bar-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.6rem;
+    align-items: center;
+}
+
+.overview-bar-label {
+    color: #111827;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.overview-bar-value {
+    color: #6b7280;
+    font-size: 0.78rem;
+}
+
+.overview-mini-bar {
+    grid-column: 1 / -1;
+    height: 0.5rem;
+    border-radius: 999px;
+    background: #e5e7eb;
+    overflow: hidden;
+}
+
+.overview-mini-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: #2563eb;
+}
+
+.overview-mini-fill.band-critical { background: #ef4444; }
+.overview-mini-fill.band-high { background: #f97316; }
+.overview-mini-fill.band-moderate { background: #eab308; }
+.overview-mini-fill.band-low { background: #22c55e; }
+
+.overview-kicker {
+    color: #6b7280;
+    font-size: 0.8rem;
+    margin-top: 0.6rem;
+}
+
+/* Visual report surfaces */
+.visual-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    gap: 0.75rem;
+}
+
+.visual-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background: #ffffff;
+    padding: 0.85rem;
+    min-width: 0;
+}
+
+.visual-card-title {
+    color: #111827;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.visual-card-subtitle {
+    color: #6b7280;
+    font-size: 0.75rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.source-link {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: #9ca3af;
+    text-underline-offset: 2px;
+}
+
+.source-link:hover {
+    color: #2563eb;
+    text-decoration-color: currentColor;
+}
+
+.visual-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.35rem;
+    margin-top: 0.65rem;
+}
+
+.visual-metric {
+    border-radius: 0.375rem;
+    background: #f9fafb;
+    padding: 0.35rem;
+}
+
+.visual-metric span {
+    display: block;
+    color: #6b7280;
+    font-size: 0.68rem;
+}
+
+.visual-metric strong {
+    color: #111827;
+    font-size: 0.9rem;
+}
+
+.visual-bar {
+    height: 0.55rem;
+    border-radius: 999px;
+    background: #e5e7eb;
+    overflow: hidden;
+    margin-top: 0.65rem;
+}
+
+.visual-bar-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: #2563eb;
+}
+
+.visual-bar-fill.band-critical { background: #ef4444; }
+.visual-bar-fill.band-high { background: #f97316; }
+.visual-bar-fill.band-moderate { background: #eab308; }
+.visual-bar-fill.band-low { background: #22c55e; }
+
+.visual-note {
+    color: #6b7280;
+    font-size: 0.82rem;
+    margin-bottom: 0.75rem;
+}
+
+.raw-data-details {
+    margin-top: 0.9rem;
+}
+
+.raw-data-details summary {
+    cursor: pointer;
+    color: #6b7280;
+    font-weight: 600;
+}
+
+.triage-risk-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    gap: 0.75rem;
+}
+
+.triage-risk-card {
+    border: 1px solid #e5e7eb;
+    border-left: 4px solid #f97316;
+    border-radius: 0.5rem;
+    background: #ffffff;
+    padding: 0.85rem;
+}
+
+.triage-risk-card.fire {
+    border-left-color: #ef4444;
+}
+
+.coupling-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    gap: 0.65rem;
+    align-items: center;
+}
+
+.coupling-link {
+    color: #2563eb;
+    font-weight: 700;
+    text-align: center;
+}
+
+/* Model Risk Map */
+.model-risk-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+#hs-model-chart {
+    display: block;
+    width: 100%;
+    border-radius: 0.375rem;
+    background: #f9fafb;
+}
+
+.model-detail-panel {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background: #ffffff;
+    overflow: hidden;
+}
+
+.model-detail-header {
+    padding: 0.75rem 0.9rem;
+    background: #f9fafb;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.model-detail-header strong {
+    display: block;
+    color: #111827;
+    margin-bottom: 0.15rem;
+}
+
+.model-detail-meta {
+    font-size: 0.75rem;
+    color: #6b7280;
+    overflow-wrap: anywhere;
+}
+
+.model-metric-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.4rem;
+    padding: 0.75rem 0.9rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.model-metric {
+    background: #f9fafb;
+    border-radius: 0.375rem;
+    padding: 0.4rem;
+}
+
+.model-metric span {
+    display: block;
+    font-size: 0.7rem;
+    color: #6b7280;
+    margin-bottom: 0.1rem;
+}
+
+.model-metric strong {
+    color: #111827;
+}
+
+.model-function-list {
+    padding: 0.4rem 0.9rem 0.75rem;
+}
+
+.model-connection-bars {
+    padding: 0.75rem 0.9rem 0.9rem;
+}
+
+.model-panel-label {
+    color: #6b7280;
+    font-size: 0.72rem;
+    margin-bottom: 0.45rem;
+}
+
+.model-connection-bar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.model-connection-track {
+    height: 0.45rem;
+    border-radius: 999px;
+    background: #e5e7eb;
+    overflow: hidden;
+    margin-top: 0.18rem;
+}
+
+.model-connection-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: #2563eb;
+}
+
+.model-connection-label {
+    color: #111827;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.model-connection-value {
+    color: #6b7280;
+    font-size: 0.72rem;
+}
+
+.model-empty-note {
+    color: #6b7280;
+    font-size: 0.82rem;
+    line-height: 1.4;
+}
+
+.model-function-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.6rem;
+    align-items: baseline;
+    padding: 0.45rem 0;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.model-function-row:last-child {
+    border-bottom: 0;
+}
+
+.model-function-name {
+    color: #111827;
+    overflow-wrap: anywhere;
+}
+
+.model-function-file {
+    display: block;
+    color: #6b7280;
+    font-size: 0.72rem;
+    margin-top: 0.1rem;
+    overflow-wrap: anywhere;
+}
+
+.model-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.55rem;
+    color: #6b7280;
+    font-size: 0.78rem;
+}
+
 /* Risk Bands */
 .band-low {
     color: #22c55e;
@@ -482,6 +862,14 @@ footer a {
 
     th, td {
         padding: 0.5rem;
+    }
+
+    .model-risk-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .model-function-row {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -863,6 +1251,41 @@ th.sortable.desc::after {
         background: #111827;
     }
 
+    .overview-section,
+    .overview-panel {
+        background: #111827;
+        border-color: #374151;
+    }
+
+    .overview-panel h3,
+    .overview-bar-label {
+        color: #f9fafb;
+    }
+
+    .overview-stacked,
+    .overview-mini-bar {
+        background: #374151;
+    }
+
+    .visual-card,
+    .triage-risk-card {
+        background: #111827;
+        border-color: #374151;
+    }
+
+    .visual-card-title,
+    .visual-metric strong {
+        color: #f9fafb;
+    }
+
+    .visual-metric {
+        background: #1f2937;
+    }
+
+    .visual-bar {
+        background: #374151;
+    }
+
     footer {
         border-top-color: #374151;
     }
@@ -921,6 +1344,17 @@ th.sortable.desc::after {
     .triage-action { color: #9ca3af; }
     .trends-section canvas { background:#1f2937; }
     #hs-scatter-chart { background:#1f2937; }
+    #hs-model-chart { background:#1f2937; }
+    .model-detail-panel { background:#111827; border-color:#374151; }
+    .model-detail-header { background:#1f2937; border-color:#374151; }
+    .model-detail-header strong,
+    .model-metric strong,
+    .model-function-name,
+    .model-connection-label { color:#f9fafb; }
+    .model-metric { background:#1f2937; }
+    .model-connection-track { background:#374151; }
+    .model-metric-row,
+    .model-function-row { border-color:#374151; }
     .scatter-legend { color:#9ca3af; }
     .scatter-legend-label { color:#9ca3af; }
     .scatter-axis-key { color:#e5e7eb; }
@@ -1395,6 +1829,307 @@ fn inline_javascript() -> &'static str {
             window.addEventListener('resize', drawScatter);
         });
     })();
+
+    // Model Risk Map graph — reads window.__hsModelMap
+    ;(function() {
+        var modelMap = window.__hsModelMap || { models: window.__hsModels || [], links: [] };
+        var models = modelMap.models || [];
+        if (!models || models.length === 0) return;
+        var selectedIdx = 0;
+        var hoverIdx = -1;
+        var nodes = [];
+        var links = modelMap.links || [];
+        var raf = null;
+        var simRaf = null;
+        var lastW = 0;
+        var lastH = 0;
+        var dragging = null;
+        var colors = { critical: '#ef4444', high: '#f97316', moderate: '#eab308', low: '#22c55e' };
+
+        function isDarkModel() { return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches); }
+        function esc(s) {
+            return String(s || '').replace(/[&<>"']/g, function(c) {
+                return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c];
+            });
+        }
+        function sourceHref(file, line) {
+            var normalized = String(file || '').replace(/\\/g, '/');
+            var href = normalized.indexOf('/') === 0 ? 'file://' + normalized : normalized;
+            return encodeURI(href) + (line ? '#L' + encodeURIComponent(String(line)) : '');
+        }
+        function modelRiskColor(m) {
+            if ((m.critical || 0) > 0) return colors.critical;
+            if ((m.high || 0) > 0) return colors.high;
+            if ((m.moderate || 0) > 0) return colors.moderate;
+            return colors.low;
+        }
+        function modelConnections(idx) {
+            return links.filter(function(l) {
+                return l.source === idx || l.target === idx;
+            }).map(function(l) {
+                var other = l.source === idx ? l.target : l.source;
+                return {
+                    other: other,
+                    name: (models[other] && models[other].name) || '',
+                    count: l.shared_functions || 0,
+                    risk: l.shared_risk || 0,
+                    strength: linkStrength(l),
+                    shared: l.functions || []
+                };
+            }).sort(function(a, b) {
+                return b.strength - a.strength;
+            });
+        }
+        function buildGraph() {
+            nodes = models.map(function(m, i) {
+                return { model: m, idx: i, x: 0, y: 0, vx: 0, vy: 0, r: 12, fixed: false };
+            });
+        }
+        function linkStrength(l) {
+            return (l.shared_functions || 0) + (l.shared_risk || 0) / 10;
+        }
+        function initializeGraph(W, H) {
+            var maxScore = Math.max.apply(null, models.map(function(m) { return m.score || 0; })) || 1;
+            var cx = W / 2, cy = H / 2, spread = Math.max(70, Math.min(W, H) * 0.34);
+            nodes.forEach(function(n, i) {
+                var angle = (Math.PI * 2 * i / Math.max(1, nodes.length)) - Math.PI / 2;
+                var pull = 1 - Math.min(0.45, (n.model.score || 0) / maxScore * 0.35);
+                n.r = 11 + Math.sqrt(Math.max(0, n.model.score || 0)) * 1.4;
+                n.x = cx + Math.cos(angle) * spread * pull;
+                n.y = cy + Math.sin(angle) * spread * pull;
+                n.vx = 0;
+                n.vy = 0;
+            });
+            for (var tick = 0; tick < 180; tick++) simulateStep(W, H);
+        }
+        function simulateStep(W, H) {
+            var cx = W / 2, cy = H / 2;
+            var maxLink = Math.max.apply(null, links.map(linkStrength)) || 1;
+                for (var a = 0; a < nodes.length; a++) {
+                    for (var b = a + 1; b < nodes.length; b++) {
+                        var na = nodes[a], nb = nodes[b];
+                        var dx = nb.x - na.x, dy = nb.y - na.y;
+                        var d2 = Math.max(64, dx * dx + dy * dy);
+                        var d = Math.sqrt(d2);
+                    var force = 1800 / d2;
+                    if (!na.fixed) {
+                        na.vx -= dx / d * force; na.vy -= dy / d * force;
+                    }
+                    if (!nb.fixed) {
+                        nb.vx += dx / d * force; nb.vy += dy / d * force;
+                    }
+                    }
+                }
+                links.forEach(function(l) {
+                    var a = nodes[l.source], b = nodes[l.target];
+                if (!a || !b) return;
+                    var dx = b.x - a.x, dy = b.y - a.y;
+                    var d = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+                var normalized = linkStrength(l) / maxLink;
+                var target = 190 - normalized * 95;
+                var force = (d - target) * (0.01 + normalized * 0.022);
+                if (!a.fixed) {
+                    a.vx += dx / d * force; a.vy += dy / d * force;
+                }
+                if (!b.fixed) {
+                    b.vx -= dx / d * force; b.vy -= dy / d * force;
+                }
+                });
+                nodes.forEach(function(n) {
+                if (n.fixed) {
+                    n.vx = 0; n.vy = 0;
+                    return;
+                }
+                    n.vx += (cx - n.x) * 0.004;
+                    n.vy += (cy - n.y) * 0.004;
+                n.vx *= 0.82; n.vy *= 0.82;
+                    n.x = Math.min(W - n.r - 16, Math.max(n.r + 16, n.x + n.vx));
+                    n.y = Math.min(H - n.r - 22, Math.max(n.r + 18, n.y + n.vy));
+                });
+        }
+        function tick(el) {
+            if (!el) return;
+            simulateStep(el.width, el.height);
+            drawModels(false);
+            simRaf = requestAnimationFrame(function() { tick(el); });
+        }
+        function updateDetail(idx, pin) {
+            var m = models[idx] || models[0];
+            if (pin) selectedIdx = idx;
+            var name = document.getElementById('hs-model-detail-name');
+            var meta = document.getElementById('hs-model-detail-meta');
+            var metrics = document.getElementById('hs-model-detail-metrics');
+            var funcs = document.getElementById('hs-model-detail-functions');
+            if (!m || !name || !meta || !metrics || !funcs) return;
+            var connections = modelConnections(idx);
+            var maxConnection = Math.max.apply(null, connections.map(function(c) { return c.strength; })) || 1;
+            name.textContent = m.name || '';
+            meta.innerHTML = '<a class="source-link" href="' + sourceHref(m.file, m.line) + '">' + esc((m.file || '') + ':' + (m.line || '')) + '</a> - ' + esc(m.kind || '');
+            metrics.innerHTML =
+                '<div class="model-metric"><span>Score</span><strong>' + Number(m.score || 0).toFixed(2) + '</strong></div>' +
+                '<div class="model-metric"><span>Critical</span><strong class="band-critical">' + (m.critical || 0) + '</strong></div>' +
+                '<div class="model-metric"><span>High</span><strong class="band-high">' + (m.high || 0) + '</strong></div>' +
+                '<div class="model-metric"><span>Moderate</span><strong class="band-moderate">' + (m.moderate || 0) + '</strong></div>';
+            if (connections.length === 0) {
+                funcs.innerHTML = '<div class="model-empty-note">No shared associated references with the other displayed models.</div>';
+                return;
+            }
+            funcs.innerHTML = '<div class="model-panel-label">Strongest shared-reference links</div>' +
+                connections.slice(0, 5).map(function(c) {
+                    var width = Math.max(8, Math.round((c.strength / maxConnection) * 100));
+                    return '<div class="model-connection-bar">' +
+                        '<div><div class="model-connection-label">' + esc(c.name) + '</div>' +
+                        '<div class="model-connection-track"><div class="model-connection-fill" style="width:' + width + '%"></div></div></div>' +
+                        '<div class="model-connection-value">' + c.count + ' shared</div>' +
+                    '</div>';
+                }).join('');
+        }
+        function drawModels() {
+            var el = document.getElementById('hs-model-chart');
+            if (!el) return;
+            el.width = el.offsetWidth || 800;
+            var ctx = el.getContext('2d'), W = el.width, H = el.height;
+            var dark = isDarkModel(), fg = dark ? '#9ca3af' : '#6b7280', text = dark ? '#f9fafb' : '#111827', grid = dark ? '#374151' : '#d1d5db';
+            var maxStrength = Math.max.apply(null, links.map(linkStrength)) || 1;
+            if (W !== lastW || H !== lastH || nodes.some(function(n) { return n.x === 0 && n.y === 0; })) {
+                lastW = W; lastH = H; initializeGraph(W, H);
+            }
+            ctx.clearRect(0, 0, W, H);
+            links.forEach(function(l) {
+                var a = nodes[l.source], b = nodes[l.target];
+                if (!a || !b) return;
+                var active = l.source === selectedIdx || l.target === selectedIdx || l.source === hoverIdx || l.target === hoverIdx;
+                ctx.strokeStyle = active ? (dark ? '#93c5fd' : '#2563eb') : grid;
+                ctx.globalAlpha = active ? 0.85 : 0.42;
+                ctx.lineWidth = 1 + (linkStrength(l) / maxStrength) * 7;
+                ctx.beginPath();
+                ctx.moveTo(a.x, a.y);
+                ctx.lineTo(b.x, b.y);
+                ctx.stroke();
+            });
+            ctx.globalAlpha = 1;
+            nodes.forEach(function(n) {
+                var m = n.model, i = n.idx;
+                var selected = i === selectedIdx, hovered = i === hoverIdx;
+                var r = n.r + (selected || hovered ? 3 : 0);
+                ctx.beginPath();
+                ctx.arc(n.x, n.y, r + 4, 0, Math.PI * 2);
+                ctx.fillStyle = selected ? (dark ? '#111827' : '#eff6ff') : (dark ? '#1f2937' : '#ffffff');
+                ctx.fill();
+                ctx.strokeStyle = selected || hovered ? (dark ? '#93c5fd' : '#2563eb') : (dark ? '#374151' : '#e5e7eb');
+                ctx.lineWidth = selected || hovered ? 3 : 1;
+                ctx.stroke();
+                ctx.beginPath();
+                ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+                ctx.fillStyle = modelRiskColor(m);
+                ctx.globalAlpha = selected || hovered ? 1 : 0.86;
+                ctx.fill();
+                ctx.globalAlpha = 1;
+                ctx.strokeStyle = dark ? '#111827' : '#ffffff';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+                ctx.fillStyle = text;
+                ctx.textAlign = 'center';
+                ctx.font = selected ? 'bold 11px system-ui,sans-serif' : '11px system-ui,sans-serif';
+                var label = m.name || '';
+                if (label.length > 18) label = label.slice(0, 15) + '...';
+                ctx.fillText(label, n.x, n.y + r + 15);
+                ctx.font = 'bold 10px system-ui,sans-serif';
+                ctx.lineWidth = 3;
+                ctx.strokeStyle = 'rgba(17, 24, 39, 0.72)';
+                ctx.strokeText(Number(m.score || 0).toFixed(1), n.x, n.y + 3);
+                ctx.fillStyle = '#ffffff';
+                ctx.fillText(Number(m.score || 0).toFixed(1), n.x, n.y + 3);
+            });
+            if (links.length === 0) {
+                ctx.fillStyle = fg;
+                ctx.textAlign = 'center';
+                ctx.font = '12px system-ui,sans-serif';
+                ctx.fillText('No shared model references in the displayed top models', W / 2, H - 18);
+            }
+            ctx.fillStyle = fg;
+            ctx.font = '10px system-ui,sans-serif';
+            ctx.textAlign = 'left';
+            ctx.fillText('Drag nodes to explore. Stronger shared-reference bonds pull closer and draw thicker.', 14, H - 10);
+        }
+        function hitTest(mx, my, el) {
+            var best = -1, bestD = 900;
+            nodes.forEach(function(n) {
+                var dx = mx - n.x, dy = my - n.y;
+                var d = dx * dx + dy * dy;
+                if (d < bestD && d <= (n.r + 12) * (n.r + 12)) {
+                    bestD = d;
+                    best = n.idx;
+                }
+            });
+            return best;
+        }
+        function pointerPos(e, el) {
+            var r = el.getBoundingClientRect();
+            return {
+                x: (e.clientX - r.left) * (el.width / r.width),
+                y: (e.clientY - r.top) * (el.height / r.height)
+            };
+        }
+        document.addEventListener('DOMContentLoaded', function() {
+            var el = document.getElementById('hs-model-chart');
+            if (!el) return;
+            buildGraph();
+            updateDetail(0, true);
+            drawModels();
+            simRaf = requestAnimationFrame(function() { tick(el); });
+            el.addEventListener('mousemove', function(e) {
+                var p = pointerPos(e, el);
+                if (dragging !== null && nodes[dragging]) {
+                    nodes[dragging].x = Math.min(el.width - nodes[dragging].r - 16, Math.max(nodes[dragging].r + 16, p.x));
+                    nodes[dragging].y = Math.min(el.height - nodes[dragging].r - 22, Math.max(nodes[dragging].r + 18, p.y));
+                    nodes[dragging].vx = 0;
+                    nodes[dragging].vy = 0;
+                    drawModels();
+                    return;
+                }
+                var idx = hitTest(p.x, p.y, el);
+                el.style.cursor = idx >= 0 ? 'grab' : 'default';
+                if (idx !== hoverIdx) {
+                    hoverIdx = idx;
+                    if (idx >= 0) updateDetail(idx, false);
+                    if (raf) cancelAnimationFrame(raf);
+                    raf = requestAnimationFrame(drawModels);
+                }
+            });
+            el.addEventListener('mousedown', function(e) {
+                var p = pointerPos(e, el);
+                var idx = hitTest(p.x, p.y, el);
+                if (idx < 0 || !nodes[idx]) return;
+                dragging = idx;
+                nodes[idx].fixed = true;
+                nodes[idx].vx = 0;
+                nodes[idx].vy = 0;
+                hoverIdx = idx;
+                updateDetail(idx, true);
+                el.style.cursor = 'grabbing';
+                e.preventDefault();
+            });
+            el.addEventListener('click', function() {
+                if (hoverIdx >= 0) updateDetail(hoverIdx, true);
+            });
+            el.addEventListener('mouseleave', function() {
+                if (dragging !== null) return;
+                hoverIdx = -1;
+                updateDetail(selectedIdx, false);
+                if (raf) cancelAnimationFrame(raf);
+                raf = requestAnimationFrame(drawModels);
+            });
+            window.addEventListener('mouseup', function() {
+                if (dragging !== null && nodes[dragging]) {
+                    nodes[dragging].fixed = false;
+                    dragging = null;
+                    el.style.cursor = hoverIdx >= 0 ? 'grab' : 'default';
+                }
+            });
+            window.addEventListener('resize', drawModels);
+        });
+    })();
 })();
 "#
 }
@@ -1531,6 +2266,214 @@ fn render_summary(snapshot: &Snapshot, thresholds: &RiskThresholds) -> String {
     )
 }
 
+fn render_overview(snapshot: &Snapshot, aggregates: Option<&SnapshotAggregates>) -> String {
+    use std::collections::HashMap;
+
+    let total = snapshot.functions.len().max(1);
+    let critical = snapshot
+        .functions
+        .iter()
+        .filter(|f| f.band == RiskBand::Critical)
+        .count();
+    let high = snapshot
+        .functions
+        .iter()
+        .filter(|f| f.band == RiskBand::High)
+        .count();
+    let moderate = snapshot
+        .functions
+        .iter()
+        .filter(|f| f.band == RiskBand::Moderate)
+        .count();
+    let low = snapshot
+        .functions
+        .iter()
+        .filter(|f| f.band == RiskBand::Low)
+        .count();
+    let pct = |count: usize| (count as f64 / total as f64 * 100.0).max(1.0);
+
+    let mut quadrants: HashMap<&str, usize> = HashMap::new();
+    let mut drivers: HashMap<&str, usize> = HashMap::new();
+    for function in &snapshot.functions {
+        if let Some(quadrant) = function.quadrant.as_deref() {
+            *quadrants.entry(quadrant).or_default() += 1;
+        }
+        if let Some(driver) = function.driver.as_deref() {
+            *drivers.entry(driver).or_default() += 1;
+        }
+    }
+
+    let quadrant_total = quadrants.values().sum::<usize>().max(1);
+    let quadrant_rows = [
+        ("fire", "Active risk", "band-critical"),
+        ("debt", "Stable debt", "band-high"),
+        ("watch", "Watch", "band-moderate"),
+        ("ok", "OK", "band-low"),
+    ]
+    .iter()
+    .map(|(key, label, class)| {
+        let count = quadrants.get(key).copied().unwrap_or(0);
+        let width = count as f64 / quadrant_total as f64 * 100.0;
+        overview_bar(label, count, width, class)
+    })
+    .collect::<String>();
+
+    let mut driver_rows = drivers.into_iter().collect::<Vec<_>>();
+    driver_rows.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+    let max_driver = driver_rows.first().map(|(_, count)| *count).unwrap_or(1);
+    let driver_bars = driver_rows
+        .iter()
+        .take(5)
+        .map(|(driver, count)| {
+            let width = *count as f64 / max_driver as f64 * 100.0;
+            overview_bar(driver, *count, width, "overview-mini-fill")
+        })
+        .collect::<String>();
+
+    let file_bars = aggregates
+        .map(|aggregates| {
+            let max_score = aggregates
+                .file_risk
+                .iter()
+                .map(|file| file.file_risk_score)
+                .fold(0.0_f64, f64::max)
+                .max(1.0);
+            aggregates
+                .file_risk
+                .iter()
+                .take(5)
+                .map(|file| {
+                    let width = file.file_risk_score / max_score * 100.0;
+                    overview_bar_html(
+                        &source_link(&file.file, 0, &file.file),
+                        format!("{:.2}", file.file_risk_score),
+                        width,
+                        "band-high",
+                    )
+                })
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+
+    let model_bars = aggregates
+        .and_then(|aggregates| aggregates.models.as_ref())
+        .map(|model_map| {
+            let max_score = model_map
+                .models
+                .iter()
+                .map(|model| model.score)
+                .fold(0.0_f64, f64::max)
+                .max(1.0);
+            model_map
+                .models
+                .iter()
+                .take(5)
+                .map(|model| {
+                    let width = model.score / max_score * 100.0;
+                    overview_bar(
+                        &model.name,
+                        format!("{:.2}", model.score),
+                        width,
+                        "band-critical",
+                    )
+                })
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+
+    let file_panel = if file_bars.is_empty() {
+        String::new()
+    } else {
+        format!(
+            r#"<div class="overview-panel">
+    <h3>Files To Inspect First</h3>
+    <div class="overview-bars">{file_bars}</div>
+</div>"#,
+            file_bars = file_bars,
+        )
+    };
+
+    let model_panel = if model_bars.is_empty() {
+        String::new()
+    } else {
+        format!(
+            r#"<div class="overview-panel">
+    <h3>Model Risk Concentration</h3>
+    <div class="overview-bars">{model_bars}</div>
+</div>"#,
+            model_bars = model_bars,
+        )
+    };
+
+    format!(
+        r#"<section class="section overview-section" id="overview">
+    <h2>Overview</h2>
+    <div class="overview-grid">
+        <div class="overview-panel">
+            <h3>Risk Mix</h3>
+            <div class="overview-stacked">
+                <div class="overview-segment visual-bar-fill band-critical" style="width:{critical_pct:.1}%"></div>
+                <div class="overview-segment visual-bar-fill band-high" style="width:{high_pct:.1}%"></div>
+                <div class="overview-segment visual-bar-fill band-moderate" style="width:{moderate_pct:.1}%"></div>
+                <div class="overview-segment visual-bar-fill band-low" style="width:{low_pct:.1}%"></div>
+            </div>
+            <div class="overview-kicker">{critical} critical · {high} high · {moderate} moderate · {low} low</div>
+        </div>
+        <div class="overview-panel">
+            <h3>Triage Balance</h3>
+            <div class="overview-bars">{quadrant_rows}</div>
+        </div>
+        <div class="overview-panel">
+            <h3>Main Risk Drivers</h3>
+            <div class="overview-bars">{driver_bars}</div>
+        </div>
+        {file_panel}
+        {model_panel}
+    </div>
+</section>"#,
+        critical_pct = pct(critical),
+        high_pct = pct(high),
+        moderate_pct = pct(moderate),
+        low_pct = pct(low),
+        critical = critical,
+        high = high,
+        moderate = moderate,
+        low = low,
+        quadrant_rows = quadrant_rows,
+        driver_bars = driver_bars,
+        file_panel = file_panel,
+        model_panel = model_panel,
+    )
+}
+
+fn overview_bar(
+    label: &str,
+    value: impl std::fmt::Display,
+    width: f64,
+    fill_class: &str,
+) -> String {
+    overview_bar_html(&html_escape(label), value, width, fill_class)
+}
+
+fn overview_bar_html(
+    label_html: &str,
+    value: impl std::fmt::Display,
+    width: f64,
+    fill_class: &str,
+) -> String {
+    format!(
+        r#"<div class="overview-bar-row">
+    <div class="overview-bar-label">{label}</div>
+    <div class="overview-bar-value">{value}</div>
+    <div class="overview-mini-bar"><div class="overview-mini-fill {fill_class}" style="width:{width:.0}%"></div></div>
+</div>"#,
+        label = label_html,
+        value = value,
+        width = width.clamp(2.0, 100.0),
+        fill_class = fill_class,
+    )
+}
+
 /// Render pattern breakdown widget — shows per-pattern counts sorted by frequency.
 /// Returns empty string when no functions have patterns.
 fn render_pattern_breakdown(functions: &[FunctionSnapshot]) -> String {
@@ -1589,6 +2532,66 @@ fn pattern_description(id: &str) -> &'static str {
 }
 
 /// Render functions table
+fn render_function_risk_gallery(functions: &[FunctionSnapshot]) -> String {
+    let max_lrs = functions
+        .iter()
+        .map(|f| f.lrs)
+        .fold(0.0_f64, f64::max)
+        .max(1.0);
+    let mut sorted = functions.iter().collect::<Vec<_>>();
+    sorted.sort_by(|a, b| {
+        b.activity_risk
+            .unwrap_or(b.lrs)
+            .partial_cmp(&a.activity_risk.unwrap_or(a.lrs))
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.lrs
+                    .partial_cmp(&a.lrs)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+    let cards: String = sorted
+        .into_iter()
+        .take(48)
+        .map(|f| {
+            let function_name = f.function_id.split("::").last().unwrap_or(&f.function_id);
+            let width = ((f.lrs / max_lrs) * 100.0).clamp(4.0, 100.0);
+            let activity = f.activity_risk.unwrap_or(f.lrs);
+            let touches = f
+                .touch_count_30d
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "—".to_string());
+            format!(
+                r#"<div class="visual-card" data-band="{band}">
+    <div class="visual-card-title">{function}</div>
+    <div class="visual-card-subtitle monospace">{source}</div>
+    <div class="visual-bar"><div class="visual-bar-fill band-{band}" style="width:{width:.0}%"></div></div>
+    <div class="visual-metrics">
+        <div class="visual-metric"><span>LRS</span><strong>{lrs:.2}</strong></div>
+        <div class="visual-metric"><span>Activity</span><strong>{activity:.2}</strong></div>
+        <div class="visual-metric"><span>Touches</span><strong>{touches}</strong></div>
+        <div class="visual-metric"><span>CC</span><strong>{cc}</strong></div>
+    </div>
+</div>"#,
+                function = html_escape(function_name),
+                source = source_link(&f.file, f.line, &format!("{}:{}", f.file, f.line)),
+                band = f.band.as_str(),
+                width = width,
+                lrs = f.lrs,
+                activity = activity,
+                touches = touches,
+                cc = f.metrics.cc,
+            )
+        })
+        .collect();
+
+    format!(
+        r#"<div class="visual-note">Top function risks rendered as bars. Use the raw table below only for exact rows, sorting, and export-style inspection.</div>
+<div class="visual-grid">{cards}</div>"#,
+        cards = cards,
+    )
+}
+
 fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
     // Only show churn/fanin columns when enough functions actually have data
     let sparse_min = 10usize;
@@ -1733,7 +2736,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
                  {activity_cell}{churn_cell}{touches_cell}{recency_cell}{fanin_cell}{patterns_cell}\
                  </tr>",
                 file = html_escape(&f.file),
-                file_display = html_escape(&f.file),
+                file_display = source_link(&f.file, f.line, &f.file),
                 function = html_escape(function_name),
                 function_display = html_escape(function_name),
                 driver = html_escape(driver_str),
@@ -1800,11 +2803,15 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
     } else {
         ""
     };
+    let gallery = render_function_risk_gallery(functions);
 
     format!(
         r#"<section class="section">
     <h2>Functions (<span id="visible-count">{count}</span> of {count})</h2>
+    {gallery}
 
+    <details class="raw-data-details">
+        <summary>Show raw function table</summary>
     <div class="filters">
         <div class="filter-group">
             <label for="band-filter">Risk Band</label>
@@ -1861,8 +2868,10 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
             {rows}
         </tbody>
     </table>
+    </details>
 </section>"#,
         count = functions.len(),
+        gallery = gallery,
         rows = rows,
         activity_header = activity_header,
         churn_header = churn_header,
@@ -1961,7 +2970,7 @@ fn render_triage_panel(functions: &[FunctionSnapshot]) -> String {
                 None => "—".to_string(),
             };
 
-            let touches_td = if show_touches {
+            let _touches_td = if show_touches {
                 let inner = match f.touch_count_30d {
                     Some(t) if t > 5 => {
                         format!(r#"<span class="recency-hot">{}</span>"#, t)
@@ -1977,7 +2986,7 @@ fn render_triage_panel(functions: &[FunctionSnapshot]) -> String {
                 String::new()
             };
 
-            let last_change_td = if show_last_change {
+            let _last_change_td = if show_last_change {
                 let inner = match f.days_since_last_change {
                     Some(d) if d <= 7 => {
                         format!(r#"<span class="recency-hot">{d}d</span>"#, d = d)
@@ -1996,7 +3005,7 @@ fn render_triage_panel(functions: &[FunctionSnapshot]) -> String {
                 String::new()
             };
 
-            let fanin_td = match &f.callgraph {
+            let _fanin_td = match &f.callgraph {
                 Some(cg) if cg.fan_in <= 2 => format!(
                     r#"<td><span class="refactor-ready">{} (safe)</span></td>"#,
                     cg.fan_in
@@ -2004,32 +3013,50 @@ fn render_triage_panel(functions: &[FunctionSnapshot]) -> String {
                 Some(cg) => format!("<td>{}</td>", cg.fan_in),
                 None => "<td>—</td>".to_string(),
             };
+            let touches_value = f
+                .touch_count_30d
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "—".to_string());
+            let last_change_value = f
+                .days_since_last_change
+                .map(|d| format!("{d}d"))
+                .unwrap_or_else(|| "—".to_string());
+            let fanin_value = f
+                .callgraph
+                .as_ref()
+                .map(|cg| cg.fan_in.to_string())
+                .unwrap_or_else(|| "—".to_string());
+            let risk_width = (risk_val * 8.0).clamp(4.0, 100.0);
 
             let row_class = if f.quadrant.as_deref() == Some("fire") {
-                " class=\"triage-active-row\""
+                "fire"
             } else {
                 ""
             };
 
             format!(
-                "<tr{cls}>\n\
-                 <td class=\"monospace\">{file}</td>\n\
-                 <td>{func}</td>\n\
-                 <td><span class=\"band-{band}\">{band}</span></td>\n\
-                 <td>{risk:.2}</td>\n\
-                 <td>{driver}</td>\n\
-                 {touches_td}{last_change_td}{fanin_td}\
-                 <td class=\"triage-action\">{action}</td>\n\
-                 </tr>",
+                r#"<div class="triage-risk-card {cls}">
+    <div class="visual-card-title">{func}</div>
+    <div class="visual-card-subtitle monospace">{source}</div>
+    <div class="visual-bar"><div class="visual-bar-fill band-{band}" style="width:{risk_width:.0}%"></div></div>
+    <div class="visual-metrics">
+        <div class="visual-metric"><span>Band</span><strong class="band-{band}">{band}</strong></div>
+        <div class="visual-metric"><span>Risk</span><strong>{risk:.2}</strong></div>
+        <div class="visual-metric"><span>Touches</span><strong>{touches}</strong></div>
+        <div class="visual-metric"><span>Fan-in</span><strong>{fanin}</strong></div>
+    </div>
+    <div class="visual-note">{driver} · last change {last_change} · {action}</div>
+</div>"#,
                 cls = row_class,
-                file = html_escape(&f.file),
+                source = source_link(&f.file, f.line, &format!("{}:{}", f.file, f.line)),
                 func = html_escape(function_name),
                 band = f.band.as_str(),
                 risk = risk_val,
+                risk_width = risk_width,
                 driver = driver_cell,
-                touches_td = touches_td,
-                last_change_td = last_change_td,
-                fanin_td = fanin_td,
+                touches = touches_value,
+                last_change = last_change_value,
+                fanin = fanin_value,
                 action = triage_action(f.driver.as_deref(), f.quadrant.as_deref()),
             )
         })
@@ -2081,45 +3108,15 @@ fn render_triage_panel(functions: &[FunctionSnapshot]) -> String {
         String::new()
     };
 
-    let touches_th = if show_touches {
-        "<th>Touches (30d)</th>"
-    } else {
-        ""
-    };
-    let last_change_th = if show_last_change {
-        "<th>Last Change</th>"
-    } else {
-        ""
-    };
-
     format!(
         r#"<section class="section triage-section" id="triage">
     <h2>Triage</h2>
     {chips}
     <h3 class="triage-subtitle">Top Risks ({count})</h3>
-    <table>
-        <thead>
-            <tr>
-                <th>File</th>
-                <th>Function</th>
-                <th>Band</th>
-                <th>Risk</th>
-                <th>Driver</th>
-                {touches_th}
-                {last_change_th}
-                <th>Fan-in</th>
-                <th>Action</th>
-            </tr>
-        </thead>
-        <tbody>
-            {rows}
-        </tbody>
-    </table>
+    <div class="triage-risk-grid">{rows}</div>
 </section>"#,
         chips = chips_html,
         count = count,
-        touches_th = touches_th,
-        last_change_th = last_change_th,
         rows = rows,
     )
 }
@@ -2128,10 +3125,14 @@ fn render_triage_panel(functions: &[FunctionSnapshot]) -> String {
 fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
     let mut sections = Vec::new();
 
+    if let Some(model_map) = &aggregates.models {
+        if !model_map.models.is_empty() {
+            sections.push(render_model_risk_section(model_map));
+        }
+    }
+
     // 4a. File Risk Table (joined with FileAggregates for LRS metrics)
     if !aggregates.file_risk.is_empty() {
-        let show_file_churn = aggregates.file_risk.iter().any(|f| f.file_churn > 0);
-
         // Build a lookup: file -> (sum_lrs, max_lrs, high_plus_count)
         let lrs_lookup: std::collections::HashMap<&str, &crate::aggregates::FileAggregates> =
             aggregates
@@ -2146,73 +3147,40 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
             .take(30)
             .map(|f| {
                 let lrs = lrs_lookup.get(f.file.as_str());
-                let sum_lrs = lrs.map(|l| l.sum_lrs).unwrap_or(0.0);
                 let max_lrs = lrs.map(|l| l.max_lrs).unwrap_or(0.0);
                 let high_plus = lrs.map(|l| l.high_plus_count).unwrap_or(0);
-                let churn_td = if show_file_churn {
-                    format!("<td>{}</td>", f.file_churn)
-                } else {
-                    String::new()
-                };
+                let score_width = (f.file_risk_score * 10.0).clamp(4.0, 100.0);
                 format!(
-                    "<tr>\n\
-                     <td class=\"monospace\">{file}</td>\n\
-                     <td>{fns}</td>\n\
-                     <td>{loc}</td>\n\
-                     <td>{max_cc}</td>\n\
-                     <td>{avg_cc:.1}</td>\n\
-                     <td>{critical}</td>\n\
-                     <td>{high_plus}</td>\n\
-                     <td>{sum_lrs:.2}</td>\n\
-                     <td>{max_lrs:.2}</td>\n\
-                     {churn_td}\
-                     <td>{score:.2}</td>\n\
-                     </tr>",
-                    file = html_escape(&f.file),
+                    r#"<div class="visual-card">
+    <div class="visual-card-title monospace">{file}</div>
+    <div class="visual-card-subtitle">{fns} functions · {loc} LOC · {high_plus} high+</div>
+    <div class="visual-bar"><div class="visual-bar-fill band-high" style="width:{score_width:.0}%"></div></div>
+    <div class="visual-metrics">
+        <div class="visual-metric"><span>Risk</span><strong>{score:.2}</strong></div>
+        <div class="visual-metric"><span>Max LRS</span><strong>{max_lrs:.2}</strong></div>
+        <div class="visual-metric"><span>Max CC</span><strong>{max_cc}</strong></div>
+        <div class="visual-metric"><span>Critical</span><strong>{critical}</strong></div>
+    </div>
+</div>"#,
+                    file = source_link(&f.file, 0, &f.file),
                     fns = f.function_count,
                     loc = f.loc,
                     max_cc = f.max_cc,
-                    avg_cc = f.avg_cc,
                     critical = f.critical_count,
                     high_plus = high_plus,
-                    sum_lrs = sum_lrs,
                     max_lrs = max_lrs,
-                    churn_td = churn_td,
                     score = f.file_risk_score,
+                    score_width = score_width,
                 )
             })
             .collect();
 
-        let churn_th = if show_file_churn {
-            "<th title=\"Total lines added + deleted across all recent commits\">Churn (lines)</th>"
-        } else {
-            ""
-        };
         sections.push(format!(
             r#"<section class="section">
-    <h2>File Risk (Top 30 by Risk Score)</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>File</th>
-                <th title="Number of functions in this file">Fns</th>
-                <th title="Lines of code">LOC</th>
-                <th title="Highest Cyclomatic Complexity of any function in the file">Max CC</th>
-                <th title="Average Cyclomatic Complexity across all functions">Avg CC</th>
-                <th title="Functions in the critical risk band">Critical</th>
-                <th title="Functions in the high or critical risk band">High+</th>
-                <th title="Sum of Local Risk Scores across all functions">Sum LRS</th>
-                <th title="Highest single-function Local Risk Score in the file">Max LRS</th>
-                {churn_th}
-                <th title="Composite file risk: max_cc×0.4 + avg_cc×0.3 + log2(fns+1)×0.2 + churn_factor×0.1">Risk Score</th>
-            </tr>
-        </thead>
-        <tbody>
-            {rows}
-        </tbody>
-    </table>
+    <h2>File Risk</h2>
+    <div class="visual-note">Top files by composite risk. Bar length reflects file risk score.</div>
+    <div class="visual-grid">{rows}</div>
 </section>"#,
-            churn_th = churn_th,
             rows = rows,
         ));
     }
@@ -2224,7 +3192,7 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
             .iter()
             .map(|m| {
                 // Classify into Martin's zones using instability + complexity
-                let (zone_label, zone_class) = if m.instability < 0.3 {
+                let (zone_label, _zone_class) = if m.instability < 0.3 {
                     if m.avg_complexity > 8.0 {
                         ("zone of pain", "zone-pain")
                     } else {
@@ -2239,25 +3207,25 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
                 } else {
                     ("balanced", "zone-balanced")
                 };
+                let instability_width = (m.instability * 100.0).clamp(4.0, 100.0);
                 format!(
-                    "<tr>\n\
-                     <td class=\"monospace\">{module}</td>\n\
-                     <td>{files}</td>\n\
-                     <td>{fns}</td>\n\
-                     <td>{avg_cc:.1}</td>\n\
-                     <td>{afferent}</td>\n\
-                     <td>{efferent}</td>\n\
-                     <td>{instability:.2}</td>\n\
-                     <td class=\"{zone_class}\">{zone_label}</td>\n\
-                     </tr>",
+                    r#"<div class="visual-card">
+    <div class="visual-card-title monospace">{module}</div>
+    <div class="visual-card-subtitle">{zone_label}</div>
+    <div class="visual-bar"><div class="visual-bar-fill" style="width:{instability_width:.0}%"></div></div>
+    <div class="visual-metrics">
+        <div class="visual-metric"><span>Instability</span><strong>{instability:.2}</strong></div>
+        <div class="visual-metric"><span>Avg CC</span><strong>{avg_cc:.1}</strong></div>
+        <div class="visual-metric"><span>Afferent</span><strong>{afferent}</strong></div>
+        <div class="visual-metric"><span>Efferent</span><strong>{efferent}</strong></div>
+    </div>
+</div>"#,
                     module = html_escape(&m.module),
-                    files = m.file_count,
-                    fns = m.function_count,
                     avg_cc = m.avg_complexity,
                     afferent = m.afferent,
                     efferent = m.efferent,
                     instability = m.instability,
-                    zone_class = zone_class,
+                    instability_width = instability_width,
                     zone_label = zone_label,
                 )
             })
@@ -2266,23 +3234,8 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
         sections.push(format!(
             r#"<section class="section">
     <h2>Module Instability</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Module</th>
-                <th>Files</th>
-                <th>Fns</th>
-                <th title="Average Cyclomatic Complexity across all functions in the module">Avg CC</th>
-                <th title="Afferent coupling — modules that depend on this one (higher = more depended upon)">Afferent</th>
-                <th title="Efferent coupling — modules this one depends on (higher = more dependencies)">Efferent</th>
-                <th title="I = Ce / (Ca + Ce). 0 = maximally stable, 1 = maximally unstable">Instability</th>
-                <th title="Zone of Pain: stable but complex (I&lt;0.3, high CC). Volatile: changes often (I&gt;0.7). Balanced: healthy range.">Zone</th>
-            </tr>
-        </thead>
-        <tbody>
-            {rows}
-        </tbody>
-    </table>
+    <div class="visual-note">Instability is Ce / (Ca + Ce). Longer bars are more dependency-volatile.</div>
+    <div class="visual-grid">{rows}</div>
 </section>"#,
             rows = rows,
         ));
@@ -2302,71 +3255,207 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
         .collect();
 
     if !qualifying.is_empty() {
-        let show_static_dep = qualifying.iter().any(|p| p.has_static_dep);
         let rows: String = qualifying
             .iter()
             .map(|p| {
-                let risk_class = match p.risk.as_str() {
-                    "high" => " class=\"co-change-high\"",
-                    "moderate" => " class=\"co-change-moderate\"",
-                    _ => "",
-                };
-                let dep_td = if show_static_dep {
-                    format!("<td>{}</td>", if p.has_static_dep { "yes" } else { "no" })
-                } else {
-                    String::new()
-                };
+                let width = (p.coupling_ratio * 100.0).clamp(4.0, 100.0);
+                let band = if p.risk == "high" { "high" } else { "moderate" };
                 format!(
-                    "<tr>\n\
-                     <td class=\"monospace\">{file_a}</td>\n\
-                     <td class=\"monospace\">{file_b}</td>\n\
-                     <td>{count}</td>\n\
-                     <td>{ratio:.0}%</td>\n\
-                     <td{risk_class}>{risk}</td>\n\
-                     {dep_td}\
-                     </tr>",
-                    file_a = html_escape(&p.file_a),
-                    file_b = html_escape(&p.file_b),
+                    r#"<div class="visual-card coupling-card">
+    <div>
+        <div class="visual-card-title monospace">{file_a}</div>
+        <div class="visual-card-subtitle">source file</div>
+    </div>
+    <div class="coupling-link">{count}x<br>{ratio:.0}%</div>
+    <div>
+        <div class="visual-card-title monospace">{file_b}</div>
+        <div class="visual-card-subtitle">{dep}</div>
+    </div>
+    <div class="visual-bar" style="grid-column:1 / -1"><div class="visual-bar-fill band-{band}" style="width:{width:.0}%"></div></div>
+</div>"#,
+                    file_a = source_link(&p.file_a, 0, &p.file_a),
+                    file_b = source_link(&p.file_b, 0, &p.file_b),
                     count = p.co_change_count,
                     ratio = p.coupling_ratio * 100.0,
-                    risk_class = risk_class,
-                    risk = html_escape(&p.risk),
-                    dep_td = dep_td,
+                    dep = if p.has_static_dep { "static dependency" } else { "implicit coupling" },
+                    band = band,
+                    width = width,
                 )
             })
             .collect();
 
-        let dep_th = if show_static_dep {
-            "<th title=\"Whether a direct import relationship exists between the two files\">Has Static Dep?</th>"
-        } else {
-            ""
-        };
-
         sections.push(format!(
             r#"<section class="section">
     <h2>Co-change Coupling</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>File A</th>
-                <th>File B</th>
-                <th title="Number of commits where both files changed together">Co-changes</th>
-                <th title="co_changes / min(total_changes_A, total_changes_B)">Coupling %</th>
-                <th>Risk</th>
-                {dep_th}
-            </tr>
-        </thead>
-        <tbody>
-            {rows}
-        </tbody>
-    </table>
+    <div class="visual-note">File pairs that repeatedly change together. Bar length reflects coupling ratio.</div>
+    <div class="visual-grid">{rows}</div>
 </section>"#,
-            dep_th = dep_th,
             rows = rows,
         ));
     }
 
     sections.join("\n")
+}
+
+fn render_model_risk_section(model_map: &crate::models::ModelRiskMap) -> String {
+    let json = render_model_risk_json(model_map);
+    let initial = model_map.models.first();
+    let initial_name = initial
+        .map(|m| html_escape(&m.name))
+        .unwrap_or_else(|| "No models".to_string());
+    let initial_meta = initial
+        .map(|m| {
+            format!(
+                "{}:{} - {}",
+                source_link(&m.file, m.line, &m.file),
+                m.line,
+                html_escape(&m.kind)
+            )
+        })
+        .unwrap_or_default();
+    let initial_metrics = initial.map(render_model_metrics).unwrap_or_default();
+    let initial_functions = r#"<div class="model-empty-note">Graph connections load in the browser from shared associated references.</div>"#;
+    let rows: String = model_map
+        .models
+        .iter()
+        .take(10)
+        .enumerate()
+        .map(|(idx, model)| {
+            let functions = model
+                .functions
+                .iter()
+                .map(|function| {
+                    let band_class = format!("band-{}", function.band.as_str());
+                    let quadrant = function.quadrant.as_deref().unwrap_or("-");
+                    format!(
+                        r#"<div class="model-function-row">
+                            <span class="monospace model-function-name">{function}</span>
+                            <span class="monospace model-function-file">{file}</span>
+                            <span class="{band_class}">LRS {lrs:.2}</span>
+                            <span>{quadrant}</span>
+                        </div>"#,
+                        function = html_escape(&function.function),
+                        file = source_link(
+                            &function.file,
+                            function.line,
+                            &format!("{}:{}", function.file, function.line)
+                        ),
+                        band_class = band_class,
+                        lrs = function.lrs,
+                        quadrant = html_escape(quadrant),
+                    )
+                })
+                .collect::<String>();
+            format!(
+                r#"<tr>
+                    <td class="model-rank">#{rank}</td>
+                    <td>
+                        <div class="model-name">{name}</div>
+                        <div class="monospace model-file">{file}</div>
+                    </td>
+                    <td>{kind}</td>
+                    <td>{critical}</td>
+                    <td>{high}</td>
+                    <td>{moderate}</td>
+                    <td>{score:.2}</td>
+                    <td>{functions}</td>
+                </tr>"#,
+                rank = idx + 1,
+                name = html_escape(&model.name),
+                file = source_link(
+                    &model.file,
+                    model.line,
+                    &format!("{}:{}", model.file, model.line)
+                ),
+                kind = html_escape(&model.kind),
+                critical = model.critical,
+                high = model.high,
+                moderate = model.moderate,
+                score = model.score,
+                functions = functions,
+            )
+        })
+        .collect();
+
+    format!(
+        r#"<script>window.__hsModelMap = {json}; window.__hsModels = window.__hsModelMap.models;</script>
+<section class="section model-risk-section">
+    <h2>Model Risk Map</h2>
+    <div class="chart-label">Data and control models as a relationship graph; stronger links share more associated references</div>
+    <div class="model-risk-layout">
+        <div>
+            <canvas id="hs-model-chart" height="420"></canvas>
+            <div class="model-legend">
+                <span><span class="scatter-dot band-critical">●</span> Critical functions</span>
+                <span><span class="scatter-dot band-high">●</span> High functions</span>
+                <span><span class="scatter-dot band-moderate">●</span> Moderate functions</span>
+                <span>Node size = risk concentration</span>
+                <span>Edge width = shared references</span>
+            </div>
+        </div>
+        <aside class="model-detail-panel" id="hs-model-detail">
+            <div class="model-detail-header">
+                <strong id="hs-model-detail-name">{initial_name}</strong>
+                <div class="model-detail-meta" id="hs-model-detail-meta">{initial_meta}</div>
+            </div>
+            <div class="model-metric-row" id="hs-model-detail-metrics">{initial_metrics}</div>
+            <div class="model-function-list" id="hs-model-detail-functions">{initial_functions}</div>
+        </aside>
+    </div>
+    <details class="model-table-details">
+        <summary>Show raw model table</summary>
+        <table>
+        <thead>
+            <tr>
+                <th>Rank</th>
+                <th>Model</th>
+                <th>Kind</th>
+                <th>Critical</th>
+                <th>High</th>
+                <th>Moderate</th>
+                <th title="Sum of the top 5 associated function risk scores">Score</th>
+                <th>Top Associated Functions</th>
+            </tr>
+        </thead>
+        <tbody>{rows}</tbody>
+        </table>
+    </details>
+</section>"#,
+        json = json,
+        initial_name = initial_name,
+        initial_meta = initial_meta,
+        initial_metrics = initial_metrics,
+        initial_functions = initial_functions,
+        rows = rows,
+    )
+}
+
+fn render_model_risk_json(model_map: &crate::models::ModelRiskMap) -> String {
+    let models = model_map.models.iter().take(10).collect::<Vec<_>>();
+    let links = model_map
+        .links
+        .iter()
+        .filter(|link| link.source < 10 && link.target < 10)
+        .collect::<Vec<_>>();
+    let json = serde_json::to_string(&serde_json::json!({
+        "models": models,
+        "links": links,
+    }))
+    .unwrap_or_else(|_| r#"{"models":[],"links":[]}"#.to_string());
+    json.replace("</", "<\\/")
+}
+
+fn render_model_metrics(model: &crate::models::ModelRiskEntry) -> String {
+    format!(
+        r#"<div class="model-metric"><span>Score</span><strong>{score:.2}</strong></div>
+<div class="model-metric"><span>Critical</span><strong class="band-critical">{critical}</strong></div>
+<div class="model-metric"><span>High</span><strong class="band-high">{high}</strong></div>
+<div class="model-metric"><span>Moderate</span><strong class="band-moderate">{moderate}</strong></div>"#,
+        score = model.score,
+        critical = model.critical,
+        high = model.high,
+        moderate = model.moderate,
+    )
 }
 
 /// Render delta header
@@ -2449,11 +3538,11 @@ fn render_policy_section(policy: &PolicyResults, delta: &Delta) -> String {
             .map(|result| {
                 let function_id = result.function_id.as_deref().unwrap_or("N/A");
                 format!(
-                    r#"<tr>
-    <td class="monospace">{function}</td>
-    <td>{policy}</td>
-    <td>{message}</td>
-</tr>"#,
+                    r#"<div class="visual-card">
+    <div class="visual-card-title monospace">{function}</div>
+    <div class="visual-card-subtitle">{policy}</div>
+    <div class="visual-note">{message}</div>
+</div>"#,
                     function = html_escape(function_id),
                     policy = result.id.as_str(),
                     message = html_escape(&result.message),
@@ -2464,18 +3553,7 @@ fn render_policy_section(policy: &PolicyResults, delta: &Delta) -> String {
         sections.push(format!(
             r#"<div class="policy-failures">
     <h3>Blocking Failures ({count})</h3>
-    <table>
-        <thead>
-            <tr>
-                <th>Function</th>
-                <th>Policy</th>
-                <th>Message</th>
-            </tr>
-        </thead>
-        <tbody>
-            {rows}
-        </tbody>
-    </table>
+    <div class="visual-grid">{rows}</div>
 </div>"#,
             count = policy.failed.len(),
             rows = rows,
@@ -2545,14 +3623,19 @@ fn render_warning_group(
                 .map(|a| format!("{:.2}", a.lrs))
                 .unwrap_or_else(|| "N/A".to_string());
 
+            let width = after_lrs.parse::<f64>().unwrap_or(0.0).mul_add(8.0, 0.0).clamp(4.0, 100.0);
             format!(
-                r#"<tr>
-    <td class="monospace">{function}</td>
-    <td>{lrs}</td>
-    <td>{message}</td>
-</tr>"#,
+                r#"<div class="visual-card">
+    <div class="visual-card-title monospace">{function}</div>
+    <div class="visual-bar"><div class="visual-bar-fill band-moderate" style="width:{width:.0}%"></div></div>
+    <div class="visual-metrics">
+        <div class="visual-metric"><span>LRS</span><strong>{lrs}</strong></div>
+    </div>
+    <div class="visual-note">{message}</div>
+</div>"#,
                 function = html_escape(function_id),
                 lrs = after_lrs,
+                width = width,
                 message = html_escape(&result.message),
             )
         })
@@ -2561,18 +3644,7 @@ fn render_warning_group(
     format!(
         r#"<div class="policy-warnings">
     <h3>{title} ({count})</h3>
-    <table>
-        <thead>
-            <tr>
-                <th>Function</th>
-                <th>LRS</th>
-                <th>Message</th>
-            </tr>
-        </thead>
-        <tbody>
-            {rows}
-        </tbody>
-    </table>
+    <div class="visual-grid">{rows}</div>
 </div>"#,
         title = title,
         count = warnings.len(),
@@ -2642,30 +3714,34 @@ fn render_delta_table(deltas: &[FunctionDeltaEntry]) -> String {
             let status_debug = format!("{:?}", entry.status);
             let status_lowercase = status_debug.to_lowercase();
 
+            let after_lrs_num = entry.after.as_ref().map(|a| a.lrs).unwrap_or(0.0);
+            let width = (after_lrs_num * 8.0).clamp(4.0, 100.0);
             format!(
-                r#"<tr class="{status_class}" data-status="{status}" data-lrs="{after_lrs_val}">
-    <td class="monospace">{file}</td>
-    <td class="monospace">{function}</td>
-    <td>{before_lrs}</td>
-    <td>{after_lrs}</td>
-    <td><span class="band-{before_band}">{before_band}</span></td>
-    <td><span class="band-{after_band}">{after_band}</span></td>
-    <td>{delta_lrs}</td>
-    <td>{transition}</td>
-    <td>{status_display}</td>
-</tr>"#,
+                r#"<div class="visual-card {status_class}" data-status="{status}" data-lrs="{after_lrs_val}">
+    <div class="visual-card-title monospace">{function}</div>
+    <div class="visual-card-subtitle monospace">{source}</div>
+    <div class="visual-bar"><div class="visual-bar-fill band-{after_band}" style="width:{width:.0}%"></div></div>
+    <div class="visual-metrics">
+        <div class="visual-metric"><span>Before</span><strong>{before_lrs}</strong></div>
+        <div class="visual-metric"><span>After</span><strong>{after_lrs}</strong></div>
+        <div class="visual-metric"><span>Delta</span><strong>{delta_lrs}</strong></div>
+        <div class="visual-metric"><span>Status</span><strong>{status_display}</strong></div>
+    </div>
+    <div class="visual-note"><span class="band-{before_band}">{before_band}</span> {transition} <span class="band-{after_band}">{after_band}</span></div>
+</div>"#,
                 status_class = status_class,
                 status = status_lowercase,
-                file = html_escape(file_name),
+                source = source_link(file_name, 0, file_name),
                 function = html_escape(function_name),
                 before_lrs = before_lrs,
                 after_lrs = after_lrs,
-                after_lrs_val = entry.after.as_ref().map(|a| a.lrs).unwrap_or(0.0),
+                after_lrs_val = after_lrs_num,
                 before_band = before_band,
                 after_band = after_band,
                 delta_lrs = delta_lrs,
                 transition = transition,
                 status_display = status_debug,
+                width = width,
             )
         })
         .collect();
@@ -2673,24 +3749,8 @@ fn render_delta_table(deltas: &[FunctionDeltaEntry]) -> String {
     format!(
         r#"<section class="section">
     <h2>Function Changes ({count})</h2>
-    <table id="delta-table">
-        <thead>
-            <tr>
-                <th>File</th>
-                <th>Function</th>
-                <th>Before LRS</th>
-                <th>After LRS</th>
-                <th>Before Band</th>
-                <th>After Band</th>
-                <th>Δ LRS</th>
-                <th>Trend</th>
-                <th>Status</th>
-            </tr>
-        </thead>
-        <tbody>
-            {rows}
-        </tbody>
-    </table>
+    <div class="visual-note">Function changes rendered as risk bars. Bar length reflects after-change LRS.</div>
+    <div id="delta-table" class="visual-grid">{rows}</div>
 </section>"#,
         count = deltas.len(),
         rows = rows,
@@ -2819,4 +3879,39 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#39;")
+}
+
+fn source_link(file: &str, line: u32, label: &str) -> String {
+    let href = source_href(file, line);
+    format!(
+        r#"<a class="source-link" href="{href}">{label}</a>"#,
+        href = html_escape(&href),
+        label = html_escape(label),
+    )
+}
+
+fn source_href(file: &str, line: u32) -> String {
+    let normalized = file.replace('\\', "/");
+    let base = if normalized.starts_with('/') {
+        format!("file://{}", normalized)
+    } else {
+        normalized
+    };
+    let encoded = base
+        .chars()
+        .map(|ch| match ch {
+            ' ' => "%20".to_string(),
+            '"' => "%22".to_string(),
+            '<' => "%3C".to_string(),
+            '>' => "%3E".to_string(),
+            '#' => "%23".to_string(),
+            '?' => "%3F".to_string(),
+            _ => ch.to_string(),
+        })
+        .collect::<String>();
+    if line > 0 {
+        format!("{encoded}#L{line}")
+    } else {
+        encoded
+    }
 }

--- a/hotspots-core/src/html.rs
+++ b/hotspots-core/src/html.rs
@@ -18,7 +18,7 @@ pub fn render_html_snapshot(
     snapshot: &Snapshot,
     history: &[(CommitInfo, SnapshotSummary)],
     source_url: Option<&str>,
-    thresholds: &RiskThresholds,
+    _thresholds: &RiskThresholds,
 ) -> String {
     let aggregates = snapshot.aggregates.as_ref();
     let history_json = render_history_json(history);
@@ -31,7 +31,6 @@ pub fn render_html_snapshot(
     let source_banner = render_source_banner(source_url);
     let scatter_json = render_scatter_json(&snapshot.functions);
     let scatter = render_scatter_section(&scatter_json);
-    let overview = render_overview(snapshot, aggregates);
 
     format!(
         r#"<!DOCTYPE html>
@@ -46,14 +45,14 @@ pub fn render_html_snapshot(
     <div class="container">
         {header}
         {source_banner}
-        {summary}
-        {overview}
         {scatter}
-        {trends}
+        {summary}
         {triage}
+        {aggregates_section}
+        {next_actions}
+        {trends}
         {patterns_breakdown}
         {functions_table}
-        {aggregates_section}
         {footer}
     </div>
     <script>{js}</script>
@@ -64,8 +63,8 @@ pub fn render_html_snapshot(
         js = inline_javascript(),
         header = render_header(&snapshot.commit),
         source_banner = source_banner,
-        summary = render_summary(snapshot, thresholds),
-        overview = overview,
+        summary = render_summary(snapshot),
+        next_actions = render_next_actions(&snapshot.functions),
         scatter = scatter,
         trends = trends,
         triage = render_triage_panel(&snapshot.functions),
@@ -155,8 +154,12 @@ fn render_scatter_json(functions: &[FunctionSnapshot]) -> String {
                 "moderate" => "m",
                 _ => "l",
             };
-            let name = f.function_id.replace('\\', "\\\\").replace('"', "\\\"");
-            let file = f.file.replace('\\', "\\\\").replace('"', "\\\"");
+            let name = compact_source_label(&f.function_id)
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"");
+            let file = compact_source_label(&f.file)
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"");
             format!(
                 r#"{{"n":"{name}","f":"{file}","x":{x:.2},"y":{y:.2},"b":"{b}"}}"#,
                 name = name,
@@ -174,10 +177,15 @@ fn render_scatter_json(functions: &[FunctionSnapshot]) -> String {
 fn render_scatter_section(json: &str) -> String {
     format!(
         r#"<script>window.__hsScatter = {json};</script>
-<section class="section" id="landscape">
-    <h2>Risk Landscape</h2>
-    <div class="chart-label">Complexity (LRS) vs Change Frequency — each dot is a function; top-right quadrant are your hotspots</div>
-    <canvas id="hs-scatter-chart" height="340"></canvas>
+<section class="section landscape-section" id="landscape">
+    <div class="landscape-heading">
+        <div>
+            <h2>Risk Landscape</h2>
+            <div class="chart-label">Start here: high and far-right points are the functions most likely to need attention; top-right means active regression risk.</div>
+        </div>
+        <div class="landscape-kicker">Complexity x Recent Change</div>
+    </div>
+    <canvas id="hs-scatter-chart" height="430"></canvas>
     <div class="scatter-legend">
         <div class="scatter-legend-bands">
             <span class="scatter-dot band-critical">●</span><span class="scatter-legend-label">Critical</span>
@@ -325,6 +333,46 @@ header .meta {
     font-size: 1.5rem;
     font-weight: 700;
     margin-bottom: 1rem;
+}
+
+details.section > summary {
+    cursor: pointer;
+    list-style: none;
+    color: #1f2937;
+    font-size: 1.15rem;
+    font-weight: 800;
+}
+
+details.section > summary::-webkit-details-marker {
+    display: none;
+}
+
+details.section > summary::before {
+    content: "Show";
+    display: inline-block;
+    margin-right: 0.65rem;
+    padding: 0.16rem 0.48rem;
+    border-radius: 999px;
+    background: #e5e7eb;
+    color: #4b5563;
+    font-size: 0.72rem;
+    font-weight: 700;
+}
+
+details.section[open] > summary {
+    margin-bottom: 1rem;
+}
+
+details.section[open] > summary::before {
+    content: "Hide";
+}
+
+.section-summary-note {
+    display: block;
+    margin-top: 0.25rem;
+    color: #6b7280;
+    font-size: 0.82rem;
+    font-weight: 400;
 }
 
 /* Table */
@@ -664,6 +712,10 @@ tbody tr:hover {
     margin-bottom: 0.45rem;
 }
 
+.model-connection-label-heading {
+    margin-top: 0.75rem;
+}
+
 .model-connection-bar {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
@@ -729,6 +781,15 @@ tbody tr:hover {
     font-size: 0.72rem;
     margin-top: 0.1rem;
     overflow-wrap: anywhere;
+}
+
+.model-function-score {
+    display: grid;
+    gap: 0.12rem;
+    justify-items: end;
+    color: #6b7280;
+    font-size: 0.72rem;
+    white-space: nowrap;
 }
 
 .model-legend {
@@ -905,6 +966,86 @@ footer a {
 .filter-group input:focus {
     outline: none;
     border-color: #3b82f6;
+}
+
+/* Next actions */
+.next-actions-section {
+    border: 1px solid #bfdbfe;
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+    background: #eff6ff;
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.12);
+}
+
+.next-actions-section h2 {
+    color: #1e3a8a;
+    margin-bottom: 0.35rem;
+}
+
+.next-actions-subtitle {
+    color: #475569;
+    font-size: 0.86rem;
+    margin-bottom: 0.9rem;
+}
+
+.next-actions-list {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.next-action {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: start;
+    border: 1px solid #dbeafe;
+    border-left: 4px solid #2563eb;
+    border-radius: 0.5rem;
+    background: #ffffff;
+    padding: 0.8rem;
+}
+
+.next-action:first-child {
+    border-left-width: 6px;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.next-action-fire { border-left-color: #ef4444; }
+.next-action-debt { border-left-color: #8b5cf6; }
+.next-action-watch { border-left-color: #f59e0b; }
+
+.next-action-rank {
+    color: #1d4ed8;
+    font-weight: 800;
+    font-size: 0.82rem;
+}
+
+.next-action-title {
+    color: #111827;
+    font-weight: 800;
+    overflow-wrap: anywhere;
+}
+
+.next-action-meta {
+    color: #64748b;
+    font-size: 0.76rem;
+    margin-top: 0.15rem;
+    overflow-wrap: anywhere;
+}
+
+.next-action-why {
+    color: #374151;
+    font-size: 0.82rem;
+    margin-top: 0.35rem;
+}
+
+.next-action-score {
+    display: grid;
+    gap: 0.15rem;
+    justify-items: end;
+    color: #64748b;
+    font-size: 0.72rem;
+    white-space: nowrap;
 }
 
 /* Triage section */
@@ -1187,8 +1328,37 @@ th.sortable.desc::after {
 
 /* Trend charts */
 .trends-section canvas { display:block; border-radius:0.375rem; background:#f9fafb; width:100%; }
-#hs-scatter-chart { display:block; border-radius:0.375rem; background:#f9fafb; width:100%; }
-.scatter-legend { display:flex; flex-wrap:wrap; align-items:flex-start; gap:0.75rem 2rem; margin-top:0.75rem; font-size:0.8rem; color:#6b7280; }
+.landscape-section {
+    border: 1px solid #dbeafe;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+    box-shadow: 0 16px 34px rgba(15, 23, 42, 0.08);
+}
+.landscape-heading {
+    display:flex;
+    align-items:flex-start;
+    justify-content:space-between;
+    gap:1rem;
+    margin-bottom:0.65rem;
+}
+.landscape-kicker {
+    flex-shrink:0;
+    border:1px solid #bfdbfe;
+    border-radius:999px;
+    background:#eff6ff;
+    color:#1d4ed8;
+    font-size:0.72rem;
+    font-weight:800;
+    letter-spacing:0;
+    padding:0.28rem 0.65rem;
+}
+#hs-scatter-chart {
+    display:block;
+    border:1px solid #e5e7eb;
+    border-radius:0.5rem;
+    background:#ffffff;
+    width:100%;
+}
+.scatter-legend { display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:0.75rem 2rem; margin-top:0.75rem; font-size:0.8rem; color:#6b7280; }
 .scatter-legend-bands { display:flex; align-items:center; gap:0.5rem; flex-shrink:0; }
 .scatter-dot { font-size:1rem; line-height:1; }
 .scatter-legend-label { color:#6b7280; margin-right:0.25rem; }
@@ -1197,7 +1367,11 @@ th.sortable.desc::after {
 .scatter-axis-key { font-weight:700; color:#374151; white-space:nowrap; min-width:5.5rem; }
 .scatter-axis-desc { color:#9ca3af; }
 .trends-charts { display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin-top:1rem; }
-@media (max-width:768px) { .trends-charts { grid-template-columns:1fr; } }
+@media (max-width:768px) {
+    .trends-charts { grid-template-columns:1fr; }
+    .landscape-heading { display:block; }
+    .landscape-kicker { display:inline-block; margin-top:0.5rem; }
+}
 .chart-label { font-size:0.75rem; font-weight:600; color:#6b7280; margin-bottom:0.25rem; }
 
 /* Dark Mode */
@@ -1330,7 +1504,11 @@ th.sortable.desc::after {
     .page-size-select { background: #1f2937; border-color: #374151; color: #f9fafb; }
 
     .triage-section { border-color: #92400e; background: #1c1500; }
-    .triage-section h2 { color: #fbbf24; }
+    details.section > summary { color: #f9fafb; }
+    details.section > summary::before { background: #374151; color: #d1d5db; }
+    .section-summary-note { color: #9ca3af; }
+    .triage-section h2,
+    .triage-section > summary { color: #fbbf24; }
     .triage-subtitle { color: #d1d5db; }
     .quadrant-fire   { background: #1a0000; }
     .quadrant-debt   { background: #140028; }
@@ -1342,8 +1520,33 @@ th.sortable.desc::after {
     .triage-active-row:hover { background: #2a1a00; }
     .recency-cold { color: #4b5563; }
     .triage-action { color: #9ca3af; }
+    .next-actions-section {
+        background: #0f172a;
+        border-color: #1d4ed8;
+    }
+    .next-actions-section h2 { color: #93c5fd; }
+    .next-actions-subtitle,
+    .next-action-rank,
+    .next-action-meta,
+    .next-action-score { color: #9ca3af; }
+    .next-action {
+        background: #111827;
+        border-color: #374151;
+    }
+    .next-action-title { color: #f9fafb; }
+    .next-action-why { color: #d1d5db; }
+    .landscape-section {
+        background: #0f172a;
+        border-color: #1f2937;
+        box-shadow: none;
+    }
+    .landscape-kicker {
+        background: #172554;
+        border-color: #1d4ed8;
+        color: #bfdbfe;
+    }
     .trends-section canvas { background:#1f2937; }
-    #hs-scatter-chart { background:#1f2937; }
+    #hs-scatter-chart { background:#111827; border-color:#374151; }
     #hs-model-chart { background:#1f2937; }
     .model-detail-panel { background:#111827; border-color:#374151; }
     .model-detail-header { background:#1f2937; border-color:#374151; }
@@ -1702,9 +1905,14 @@ fn inline_javascript() -> &'static str {
             if (!el) return;
             el.width = el.offsetWidth || 800;
             var ctx = el.getContext('2d'), W = el.width, H = el.height;
-            var lP = 56, rP = 16, tP = 16, bP = 36;
+            var lP = 64, rP = 24, tP = 28, bP = 46;
             var cW = W - lP - rP, cH = H - tP - bP;
             var dark = isDarkSc(), fg = dark ? '#9ca3af' : '#6b7280', grd = dark ? '#374151' : '#e5e7eb';
+            var panel = dark ? '#111827' : '#ffffff';
+            var hotFill = dark ? 'rgba(239,68,68,0.16)' : 'rgba(254,226,226,0.72)';
+            var debtFill = dark ? 'rgba(249,115,22,0.12)' : 'rgba(255,237,213,0.58)';
+            var activeFill = dark ? 'rgba(234,179,8,0.10)' : 'rgba(254,249,195,0.45)';
+            var calmFill = dark ? 'rgba(34,197,94,0.08)' : 'rgba(220,252,231,0.38)';
 
             var xs = pts.map(function(p) { return p.x; });
             var ys = pts.map(function(p) { return p.y; });
@@ -1720,6 +1928,17 @@ fn inline_javascript() -> &'static str {
             ctx.clearRect(0, 0, W, H);
             ctx.font = '10px system-ui,sans-serif';
 
+            ctx.fillStyle = panel;
+            ctx.fillRect(0, 0, W, H);
+
+            // quadrant regions
+            var qx = lP + (medX / maxX) * cW;
+            var qy = tP + cH - (medY / maxY) * cH;
+            ctx.fillStyle = calmFill; ctx.fillRect(lP, qy, qx - lP, tP + cH - qy);
+            ctx.fillStyle = activeFill; ctx.fillRect(lP, tP, qx - lP, qy - tP);
+            ctx.fillStyle = debtFill; ctx.fillRect(qx, qy, lP + cW - qx, tP + cH - qy);
+            ctx.fillStyle = hotFill; ctx.fillRect(qx, tP, lP + cW - qx, qy - tP);
+
             // grid lines
             for (var t = 0; t <= 4; t++) {
                 var xv = maxX * t / 4, xp = lP + (t / 4) * cW;
@@ -1734,13 +1953,22 @@ fn inline_javascript() -> &'static str {
             }
 
             // quadrant dividers at median
-            var qx = lP + (medX / maxX) * cW;
-            var qy = tP + cH - (medY / maxY) * cH;
-            ctx.strokeStyle = dark ? '#4b5563' : '#d1d5db'; ctx.lineWidth = 1;
+            ctx.strokeStyle = dark ? '#6b7280' : '#94a3b8'; ctx.lineWidth = 1;
             ctx.setLineDash([4, 4]);
             ctx.beginPath(); ctx.moveTo(qx, tP); ctx.lineTo(qx, tP + cH); ctx.stroke();
             ctx.beginPath(); ctx.moveTo(lP, qy); ctx.lineTo(lP + cW, qy); ctx.stroke();
             ctx.setLineDash([]);
+
+            function quadrantLabel(text, x, y, align) {
+                ctx.font = 'bold 11px system-ui,sans-serif';
+                ctx.fillStyle = dark ? 'rgba(249,250,251,0.72)' : 'rgba(17,24,39,0.62)';
+                ctx.textAlign = align || 'left';
+                ctx.fillText(text, x, y);
+            }
+            quadrantLabel('watch while active', lP + 10, tP + 18, 'left');
+            quadrantLabel('act now', lP + cW - 10, tP + 18, 'right');
+            quadrantLabel('ignore', lP + 10, tP + cH - 10, 'left');
+            quadrantLabel('schedule debt', lP + cW - 10, tP + cH - 10, 'right');
 
             // dots
             var r = Math.max(3, Math.min(7, Math.round(cW / Math.sqrt(pts.length) * 0.18)));
@@ -1749,11 +1977,37 @@ fn inline_javascript() -> &'static str {
                 var cy = tP + cH - (p.y / maxY) * cH;
                 var col = bandColor[p.b] || '#6b7280';
                 ctx.beginPath();
-                ctx.arc(cx, cy, i === hoveredIdx ? r + 2 : r, 0, Math.PI * 2);
+                ctx.arc(cx, cy, i === hoveredIdx ? r + 3 : r, 0, Math.PI * 2);
                 ctx.fillStyle = col;
-                ctx.globalAlpha = i === hoveredIdx ? 1.0 : 0.72;
+                ctx.globalAlpha = i === hoveredIdx ? 1.0 : (p.b === 'c' ? 0.88 : 0.62);
                 ctx.fill();
+                if (p.b === 'c' || i === hoveredIdx) {
+                    ctx.strokeStyle = dark ? '#111827' : '#ffffff';
+                    ctx.lineWidth = i === hoveredIdx ? 3 : 2;
+                    ctx.stroke();
+                }
                 ctx.globalAlpha = 1.0;
+            });
+
+            var callouts = pts.slice().sort(function(a, b) {
+                var ar = (a.x * 1.4) + (a.y * 2.2) + (a.b === 'c' ? 5 : a.b === 'h' ? 2 : 0);
+                var br = (b.x * 1.4) + (b.y * 2.2) + (b.b === 'c' ? 5 : b.b === 'h' ? 2 : 0);
+                return br - ar;
+            }).slice(0, 3);
+            callouts.forEach(function(p, idx) {
+                var cx = lP + (p.x / maxX) * cW;
+                var cy = tP + cH - (p.y / maxY) * cH;
+                var shortName = String(p.n || '').split('::').pop();
+                if (shortName.length > 24) shortName = shortName.slice(0, 21) + '...';
+                var tx = Math.min(Math.max(cx + 12, lP + 72), lP + cW - 72);
+                var ty = Math.max(tP + 18, cy - 16 - (idx * 4));
+                ctx.strokeStyle = dark ? 'rgba(156,163,175,0.45)' : 'rgba(100,116,139,0.45)';
+                ctx.lineWidth = 1;
+                ctx.beginPath(); ctx.moveTo(cx + 5, cy - 5); ctx.lineTo(tx - 5, ty + 3); ctx.stroke();
+                ctx.font = 'bold 10px system-ui,sans-serif';
+                ctx.textAlign = 'left';
+                ctx.fillStyle = dark ? '#f9fafb' : '#111827';
+                ctx.fillText(shortName, tx, ty);
             });
 
             // tooltip
@@ -1802,7 +2056,7 @@ fn inline_javascript() -> &'static str {
                 var r2 = el.getBoundingClientRect();
                 var mx = (e.clientX - r2.left) * (el.width / r2.width);
                 var my = (e.clientY - r2.top) * (el.height / r2.height);
-                var lP2 = 56, rP2 = 16, tP2 = 16, bP2 = 36;
+                var lP2 = 64, rP2 = 24, tP2 = 28, bP2 = 46;
                 var cW2 = el.width - lP2 - rP2, cH2 = el.height - tP2 - bP2;
                 var xs2 = pts.map(function(p) { return p.x; });
                 var ys2 = pts.map(function(p) { return p.y; });
@@ -1826,7 +2080,9 @@ fn inline_javascript() -> &'static str {
                 if (scatterRaf) cancelAnimationFrame(scatterRaf);
                 scatterRaf = requestAnimationFrame(drawScatter);
             });
-            window.addEventListener('resize', drawScatter);
+            window.addEventListener('resize', function() {
+                drawScatter();
+            });
         });
     })();
 
@@ -1971,10 +2227,25 @@ fn inline_javascript() -> &'static str {
                 '<div class="model-metric"><span>High</span><strong class="band-high">' + (m.high || 0) + '</strong></div>' +
                 '<div class="model-metric"><span>Moderate</span><strong class="band-moderate">' + (m.moderate || 0) + '</strong></div>';
             if (connections.length === 0) {
-                funcs.innerHTML = '<div class="model-empty-note">No shared associated references with the other displayed models.</div>';
+                funcs.innerHTML = '<div class="model-panel-label">Top associated functions</div>' + (m.functions || []).map(function(f) {
+                    return '<div class="model-function-row">' +
+                        '<div><div class="monospace model-function-name">' + esc(f.function || '') + '</div>' +
+                        '<div class="monospace model-function-file"><a class="source-link" href="' + sourceHref(f.file, f.line) + '">' + esc((f.file || '') + ':' + (f.line || '')) + '</a></div></div>' +
+                        '<div class="model-function-score"><span class="band-' + esc(f.band || 'low') + '">LRS ' + Number(f.lrs || 0).toFixed(2) + '</span>' +
+                        '<span>' + esc(f.quadrant || '-') + '</span><span>' + esc((f.association || '').replace('-', ' ')) + '</span></div>' +
+                    '</div>';
+                }).join('');
                 return;
             }
-            funcs.innerHTML = '<div class="model-panel-label">Strongest shared-reference links</div>' +
+            var functionRows = '<div class="model-panel-label">Top associated functions</div>' + (m.functions || []).map(function(f) {
+                return '<div class="model-function-row">' +
+                    '<div><div class="monospace model-function-name">' + esc(f.function || '') + '</div>' +
+                    '<div class="monospace model-function-file"><a class="source-link" href="' + sourceHref(f.file, f.line) + '">' + esc((f.file || '') + ':' + (f.line || '')) + '</a></div></div>' +
+                    '<div class="model-function-score"><span class="band-' + esc(f.band || 'low') + '">LRS ' + Number(f.lrs || 0).toFixed(2) + '</span>' +
+                    '<span>' + esc(f.quadrant || '-') + '</span><span>' + esc((f.association || '').replace('-', ' ')) + '</span></div>' +
+                '</div>';
+            }).join('');
+            funcs.innerHTML = functionRows + '<div class="model-panel-label model-connection-label-heading">Strongest shared-reference links</div>' +
                 connections.slice(0, 5).map(function(c) {
                     var width = Math.max(8, Math.round((c.strength / maxConnection) * 100));
                     return '<div class="model-connection-bar">' +
@@ -2154,7 +2425,7 @@ fn render_header(commit: &CommitInfo) -> String {
 }
 
 /// Render summary section
-fn render_summary(snapshot: &Snapshot, thresholds: &RiskThresholds) -> String {
+fn render_summary(snapshot: &Snapshot) -> String {
     let total_functions = snapshot.functions.len();
     let critical_count = snapshot
         .functions
@@ -2166,59 +2437,16 @@ fn render_summary(snapshot: &Snapshot, thresholds: &RiskThresholds) -> String {
         .iter()
         .filter(|f| f.band == RiskBand::High)
         .count();
-    let avg_lrs = if total_functions > 0 {
-        snapshot.functions.iter().map(|f| f.lrs).sum::<f64>() / total_functions as f64
-    } else {
-        0.0
-    };
-
-    let mut extra = String::new();
-    if let Some(summary) = &snapshot.summary {
-        if summary.total_activity_risk > 0.0 {
-            extra.push_str(&format!(
-                r#"
-    <div class="summary-card">
-        <h3>Total Activity Risk</h3>
-        <div class="value">{:.1}</div>
-    </div>"#,
-                summary.total_activity_risk
-            ));
-        }
-        if summary.top_1_pct_share > 0.0 {
-            extra.push_str(&format!(
-                r#"
-    <div class="summary-card">
-        <h3>Top 1% Share</h3>
-        <div class="value">{:.1}%</div>
-    </div>"#,
-                summary.top_1_pct_share * 100.0
-            ));
-        }
-        if let Some(cg) = &summary.call_graph {
-            if cg.total_edges > 0 {
-                extra.push_str(&format!(
-                    r#"
-    <div class="summary-card">
-        <h3>Call Graph Edges</h3>
-        <div class="value">{}</div>
-    </div>"#,
-                    cg.total_edges
-                ));
-            }
-        }
-    }
-
-    // Format threshold values: show as integer when whole, else 1 decimal place.
-    let fmt_t = |v: f64| -> String {
-        if v.fract() == 0.0 {
-            format!("{}", v as i64)
-        } else {
-            format!("{:.1}", v)
-        }
-    };
-    let t_critical = fmt_t(thresholds.critical);
-    let t_high = fmt_t(thresholds.high);
-    let t_moderate = fmt_t(thresholds.moderate);
+    let fire_count = snapshot
+        .functions
+        .iter()
+        .filter(|f| f.quadrant.as_deref() == Some("fire"))
+        .count();
+    let debt_count = snapshot
+        .functions
+        .iter()
+        .filter(|f| f.quadrant.as_deref() == Some("debt"))
+        .count();
 
     format!(
         r#"<div class="summary">
@@ -2227,250 +2455,23 @@ fn render_summary(snapshot: &Snapshot, thresholds: &RiskThresholds) -> String {
         <div class="value">{total}</div>
     </div>
     <div class="summary-card">
-        <h3>Critical Risk</h3>
-        <div class="value band-critical">{critical}</div>
+        <h3>Fire</h3>
+        <div class="value band-critical">{fire}</div>
     </div>
     <div class="summary-card">
-        <h3>High Risk</h3>
-        <div class="value band-high">{high}</div>
+        <h3>Debt</h3>
+        <div class="value band-high">{debt}</div>
     </div>
     <div class="summary-card">
-        <h3>Average LRS</h3>
-        <div class="value">{avg:.2}</div>
-    </div>{extra}
+        <h3>High+ Risk</h3>
+        <div class="value">{high_plus}</div>
+    </div>
 </div>
-<p class="summary-legend">
-    <strong>Risk bands (LRS):</strong>
-    <span class="band-critical">critical</span> ≥ {t_critical} ·
-    <span class="band-high">high</span> {t_high}–&lt;{t_critical} ·
-    <span class="band-moderate">moderate</span> {t_moderate}–&lt;{t_high} ·
-    <span class="band-low">low</span> &lt; {t_moderate}
-</p>
-<div class="metric-legend">
-    <span class="metric-legend-label">Metrics:</span>
-    <span class="metric-pill" title="Cyclomatic Complexity — number of independent execution paths through the function. Each path is a potential bug surface and a required test case."><strong>CC</strong> independent code paths</span>
-    <span class="metric-pill" title="Nesting Depth — maximum level of nested control structures (if / for / while / try). Deeper = harder to reason about."><strong>ND</strong> nesting depth</span>
-    <span class="metric-pill" title="Fan-out — number of distinct functions this function calls. High fan-out = a change here ripples into many call sites."><strong>FO</strong> functions called</span>
-    <span class="metric-pill" title="Non-Structured exits — count of early returns, throws, panics, and other exits that bypass normal control flow. Each one is an additional path a reader must trace."><strong>NS</strong> early exits (returns / throws / panics)</span>
-    <span class="metric-pill" title="Local Risk Score — weighted composite of CC, ND, FO, and NS (non-structured exits — early returns, throws, panics). The structural complexity score for a single function."><strong>LRS</strong> structural complexity (CC + ND + FO + NS combined)</span>
-    <span class="metric-pill" title="Activity Risk = LRS × recent commit frequency, weighted by recency. The primary sort signal: a structurally complex function that is actively being changed is higher priority than one that is merely complex but untouched."><strong>Activity Risk</strong> LRS × how often this function has been committed to recently</span>
-</div>"#,
+"#,
         total = total_functions,
-        critical = critical_count,
-        high = high_count,
-        avg = avg_lrs,
-        extra = extra,
-        t_critical = t_critical,
-        t_high = t_high,
-        t_moderate = t_moderate,
-    )
-}
-
-fn render_overview(snapshot: &Snapshot, aggregates: Option<&SnapshotAggregates>) -> String {
-    use std::collections::HashMap;
-
-    let total = snapshot.functions.len().max(1);
-    let critical = snapshot
-        .functions
-        .iter()
-        .filter(|f| f.band == RiskBand::Critical)
-        .count();
-    let high = snapshot
-        .functions
-        .iter()
-        .filter(|f| f.band == RiskBand::High)
-        .count();
-    let moderate = snapshot
-        .functions
-        .iter()
-        .filter(|f| f.band == RiskBand::Moderate)
-        .count();
-    let low = snapshot
-        .functions
-        .iter()
-        .filter(|f| f.band == RiskBand::Low)
-        .count();
-    let pct = |count: usize| (count as f64 / total as f64 * 100.0).max(1.0);
-
-    let mut quadrants: HashMap<&str, usize> = HashMap::new();
-    let mut drivers: HashMap<&str, usize> = HashMap::new();
-    for function in &snapshot.functions {
-        if let Some(quadrant) = function.quadrant.as_deref() {
-            *quadrants.entry(quadrant).or_default() += 1;
-        }
-        if let Some(driver) = function.driver.as_deref() {
-            *drivers.entry(driver).or_default() += 1;
-        }
-    }
-
-    let quadrant_total = quadrants.values().sum::<usize>().max(1);
-    let quadrant_rows = [
-        ("fire", "Active risk", "band-critical"),
-        ("debt", "Stable debt", "band-high"),
-        ("watch", "Watch", "band-moderate"),
-        ("ok", "OK", "band-low"),
-    ]
-    .iter()
-    .map(|(key, label, class)| {
-        let count = quadrants.get(key).copied().unwrap_or(0);
-        let width = count as f64 / quadrant_total as f64 * 100.0;
-        overview_bar(label, count, width, class)
-    })
-    .collect::<String>();
-
-    let mut driver_rows = drivers.into_iter().collect::<Vec<_>>();
-    driver_rows.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
-    let max_driver = driver_rows.first().map(|(_, count)| *count).unwrap_or(1);
-    let driver_bars = driver_rows
-        .iter()
-        .take(5)
-        .map(|(driver, count)| {
-            let width = *count as f64 / max_driver as f64 * 100.0;
-            overview_bar(driver, *count, width, "overview-mini-fill")
-        })
-        .collect::<String>();
-
-    let file_bars = aggregates
-        .map(|aggregates| {
-            let max_score = aggregates
-                .file_risk
-                .iter()
-                .map(|file| file.file_risk_score)
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
-            aggregates
-                .file_risk
-                .iter()
-                .take(5)
-                .map(|file| {
-                    let width = file.file_risk_score / max_score * 100.0;
-                    overview_bar_html(
-                        &source_link(&file.file, 0, &file.file),
-                        format!("{:.2}", file.file_risk_score),
-                        width,
-                        "band-high",
-                    )
-                })
-                .collect::<String>()
-        })
-        .unwrap_or_default();
-
-    let model_bars = aggregates
-        .and_then(|aggregates| aggregates.models.as_ref())
-        .map(|model_map| {
-            let max_score = model_map
-                .models
-                .iter()
-                .map(|model| model.score)
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
-            model_map
-                .models
-                .iter()
-                .take(5)
-                .map(|model| {
-                    let width = model.score / max_score * 100.0;
-                    overview_bar(
-                        &model.name,
-                        format!("{:.2}", model.score),
-                        width,
-                        "band-critical",
-                    )
-                })
-                .collect::<String>()
-        })
-        .unwrap_or_default();
-
-    let file_panel = if file_bars.is_empty() {
-        String::new()
-    } else {
-        format!(
-            r#"<div class="overview-panel">
-    <h3>Files To Inspect First</h3>
-    <div class="overview-bars">{file_bars}</div>
-</div>"#,
-            file_bars = file_bars,
-        )
-    };
-
-    let model_panel = if model_bars.is_empty() {
-        String::new()
-    } else {
-        format!(
-            r#"<div class="overview-panel">
-    <h3>Model Risk Concentration</h3>
-    <div class="overview-bars">{model_bars}</div>
-</div>"#,
-            model_bars = model_bars,
-        )
-    };
-
-    format!(
-        r#"<section class="section overview-section" id="overview">
-    <h2>Overview</h2>
-    <div class="overview-grid">
-        <div class="overview-panel">
-            <h3>Risk Mix</h3>
-            <div class="overview-stacked">
-                <div class="overview-segment visual-bar-fill band-critical" style="width:{critical_pct:.1}%"></div>
-                <div class="overview-segment visual-bar-fill band-high" style="width:{high_pct:.1}%"></div>
-                <div class="overview-segment visual-bar-fill band-moderate" style="width:{moderate_pct:.1}%"></div>
-                <div class="overview-segment visual-bar-fill band-low" style="width:{low_pct:.1}%"></div>
-            </div>
-            <div class="overview-kicker">{critical} critical · {high} high · {moderate} moderate · {low} low</div>
-        </div>
-        <div class="overview-panel">
-            <h3>Triage Balance</h3>
-            <div class="overview-bars">{quadrant_rows}</div>
-        </div>
-        <div class="overview-panel">
-            <h3>Main Risk Drivers</h3>
-            <div class="overview-bars">{driver_bars}</div>
-        </div>
-        {file_panel}
-        {model_panel}
-    </div>
-</section>"#,
-        critical_pct = pct(critical),
-        high_pct = pct(high),
-        moderate_pct = pct(moderate),
-        low_pct = pct(low),
-        critical = critical,
-        high = high,
-        moderate = moderate,
-        low = low,
-        quadrant_rows = quadrant_rows,
-        driver_bars = driver_bars,
-        file_panel = file_panel,
-        model_panel = model_panel,
-    )
-}
-
-fn overview_bar(
-    label: &str,
-    value: impl std::fmt::Display,
-    width: f64,
-    fill_class: &str,
-) -> String {
-    overview_bar_html(&html_escape(label), value, width, fill_class)
-}
-
-fn overview_bar_html(
-    label_html: &str,
-    value: impl std::fmt::Display,
-    width: f64,
-    fill_class: &str,
-) -> String {
-    format!(
-        r#"<div class="overview-bar-row">
-    <div class="overview-bar-label">{label}</div>
-    <div class="overview-bar-value">{value}</div>
-    <div class="overview-mini-bar"><div class="overview-mini-fill {fill_class}" style="width:{width:.0}%"></div></div>
-</div>"#,
-        label = label_html,
-        value = value,
-        width = width.clamp(2.0, 100.0),
-        fill_class = fill_class,
+        fire = fire_count,
+        debt = debt_count,
+        high_plus = critical_count + high_count,
     )
 }
 
@@ -2505,7 +2506,10 @@ fn render_pattern_breakdown(functions: &[FunctionSnapshot]) -> String {
 
     let affected = functions.iter().filter(|f| !f.patterns.is_empty()).count();
     format!(
-        r#"<div class="pattern-breakdown"><h2>Pattern Breakdown</h2><p class="pattern-breakdown-subtitle">Detected across {affected} function{s}</p><div class="pattern-chips">{chips}</div></div>"#,
+        r#"<details class="section pattern-breakdown">
+    <summary>Pattern Breakdown<span class="section-summary-note">Detected across {affected} function{s}</span></summary>
+    <div class="pattern-chips">{chips}</div>
+</details>"#,
         affected = affected,
         s = if affected == 1 { "" } else { "s" },
         chips = chips,
@@ -2574,7 +2578,11 @@ fn render_function_risk_gallery(functions: &[FunctionSnapshot]) -> String {
     </div>
 </div>"#,
                 function = html_escape(function_name),
-                source = source_link(&f.file, f.line, &format!("{}:{}", f.file, f.line)),
+                source = source_link(
+                    &f.file,
+                    f.line,
+                    &format!("{}:{}", compact_source_label(&f.file), f.line)
+                ),
                 band = f.band.as_str(),
                 width = width,
                 lrs = f.lrs,
@@ -2736,7 +2744,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
                  {activity_cell}{churn_cell}{touches_cell}{recency_cell}{fanin_cell}{patterns_cell}\
                  </tr>",
                 file = html_escape(&f.file),
-                file_display = source_link(&f.file, f.line, &f.file),
+                file_display = source_link(&f.file, f.line, &compact_source_label(&f.file)),
                 function = html_escape(function_name),
                 function_display = html_escape(function_name),
                 driver = html_escape(driver_str),
@@ -2806,8 +2814,8 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
     let gallery = render_function_risk_gallery(functions);
 
     format!(
-        r#"<section class="section">
-    <h2>Functions (<span id="visible-count">{count}</span> of {count})</h2>
+        r#"<details class="section">
+    <summary>Function Inventory (<span id="visible-count">{count}</span> of {count})<span class="section-summary-note">Full searchable table and function cards</span></summary>
     {gallery}
 
     <details class="raw-data-details">
@@ -2869,7 +2877,7 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
         </tbody>
     </table>
     </details>
-</section>"#,
+</details>"#,
         count = functions.len(),
         gallery = gallery,
         rows = rows,
@@ -2885,6 +2893,148 @@ fn render_functions_table(functions: &[FunctionSnapshot]) -> String {
 /// Map (driver, quadrant) to a one-line recommended action for the triage table.
 fn triage_action(driver: Option<&str>, quadrant: Option<&str>) -> &'static str {
     crate::snapshot::driver_action_for_quadrant(driver.unwrap_or(""), quadrant.unwrap_or(""))
+}
+
+fn render_next_actions(functions: &[FunctionSnapshot]) -> String {
+    let mut candidates: Vec<&FunctionSnapshot> = functions
+        .iter()
+        .filter(|f| {
+            matches!(
+                f.quadrant.as_deref(),
+                Some("fire") | Some("debt") | Some("watch")
+            )
+        })
+        .collect();
+    candidates.sort_by(|a, b| {
+        next_action_rank(a)
+            .cmp(&next_action_rank(b))
+            .then_with(|| {
+                b.activity_risk
+                    .unwrap_or(b.lrs)
+                    .partial_cmp(&a.activity_risk.unwrap_or(a.lrs))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                b.touch_count_30d
+                    .unwrap_or(0)
+                    .cmp(&a.touch_count_30d.unwrap_or(0))
+            })
+            .then_with(|| {
+                b.lrs
+                    .partial_cmp(&a.lrs)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+    candidates.truncate(3);
+    if candidates.is_empty() {
+        return String::new();
+    }
+
+    let rows = candidates
+        .into_iter()
+        .enumerate()
+        .map(|(idx, function)| render_next_action(idx + 1, function))
+        .collect::<String>();
+
+    format!(
+        r#"<section class="section next-actions-section" id="next-actions">
+    <h2>3 Targeted Next Moves</h2>
+    <div class="next-actions-subtitle">A short action list from the highest-priority fire, debt, and watch candidates.</div>
+    <div class="next-actions-list">{rows}</div>
+</section>"#,
+        rows = rows,
+    )
+}
+
+fn next_action_rank(function: &FunctionSnapshot) -> u8 {
+    match function.quadrant.as_deref() {
+        Some("fire") => 0,
+        Some("debt") => 1,
+        Some("watch") => 2,
+        _ => 3,
+    }
+}
+
+fn render_next_action(rank: usize, function: &FunctionSnapshot) -> String {
+    let function_name = function
+        .function_id
+        .split("::")
+        .last()
+        .unwrap_or(&function.function_id);
+    let quadrant = function.quadrant.as_deref().unwrap_or("ok");
+    let driver = function.driver.as_deref().unwrap_or("composite");
+    let touches = function.touch_count_30d.unwrap_or(0);
+    let fan_in = function.callgraph.as_ref().map(|cg| cg.fan_in).unwrap_or(0);
+    let activity = function.activity_risk.unwrap_or(function.lrs);
+    let last_change = function
+        .days_since_last_change
+        .map(|d| format!("{d}d ago"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let why = next_action_reason(function, quadrant, driver, touches, fan_in);
+
+    format!(
+        r#"<div class="next-action next-action-{quadrant}">
+    <div class="next-action-rank">#{rank}</div>
+    <div>
+        <div class="next-action-title">{function}</div>
+        <div class="next-action-meta monospace">{source}</div>
+        <div class="next-action-why">{why}</div>
+    </div>
+    <div class="next-action-score">
+        <span class="band-{band}">{band}</span>
+        <span>{quadrant}</span>
+        <span>{touches} touches</span>
+        <span>{last_change}</span>
+        <span>risk {activity:.2}</span>
+    </div>
+</div>"#,
+        rank = rank,
+        function = html_escape(function_name),
+        source = source_link(
+            &function.file,
+            function.line,
+            &format!("{}:{}", compact_source_label(&function.file), function.line)
+        ),
+        why = why,
+        quadrant = html_escape(quadrant),
+        band = function.band.as_str(),
+        touches = touches,
+        last_change = last_change,
+        activity = activity,
+    )
+}
+
+fn next_action_reason(
+    function: &FunctionSnapshot,
+    quadrant: &str,
+    driver: &str,
+    touches: usize,
+    fan_in: usize,
+) -> String {
+    let urgency = match quadrant {
+        "fire" => "Act this week",
+        "debt" => "Schedule deliberately",
+        "watch" => "Watch while active",
+        _ => "Track",
+    };
+    let driver_reason = match driver {
+        "high_complexity" => "complexity is the main driver",
+        "deep_nesting" => "nested control flow is the main driver",
+        "high_fanin_complex" => "wide fan-in raises blast radius",
+        "high_fanout_churning" => "fan-out plus activity raises integration risk",
+        "high_churn_low_cc" => "recent churn is the main signal",
+        "cyclic_dep" => "dependency cycles raise change risk",
+        _ => "multiple factors contribute",
+    };
+    let fan_in_note = if fan_in <= 2 {
+        "low fan-in makes this a smaller first move"
+    } else {
+        "higher fan-in means plan tests before changing it"
+    };
+    format!(
+        "{urgency}: {driver_reason}; {touches} touch(es) in 30 days; {fan_in_note}. {}.",
+        triage_action(function.driver.as_deref(), function.quadrant.as_deref())
+    )
 }
 
 /// Render triage panel: quadrant summary + top risks table
@@ -3109,19 +3259,19 @@ fn render_triage_panel(functions: &[FunctionSnapshot]) -> String {
     };
 
     format!(
-        r#"<section class="section triage-section" id="triage">
-    <h2>Triage</h2>
+        r#"<details class="section triage-section" id="triage">
+    <summary>Triage Details<span class="section-summary-note">Quadrant counts and the next tier of risky functions</span></summary>
     {chips}
     <h3 class="triage-subtitle">Top Risks ({count})</h3>
     <div class="triage-risk-grid">{rows}</div>
-</section>"#,
+</details>"#,
         chips = chips_html,
         count = count,
         rows = rows,
     )
 }
 
-/// Render aggregates section (File Risk, Module Instability, Co-change Coupling)
+/// Render architecture/concentration sections.
 fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
     let mut sections = Vec::new();
 
@@ -3176,11 +3326,11 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
             .collect();
 
         sections.push(format!(
-            r#"<section class="section">
-    <h2>File Risk</h2>
-    <div class="visual-note">Top files by composite risk. Bar length reflects file risk score.</div>
+            r#"<details class="section" open>
+    <summary>Risk Concentration: Files<span class="section-summary-note">Top files by composite risk</span></summary>
+    <div class="visual-note">Use this to choose where to inspect first after the start-here actions.</div>
     <div class="visual-grid">{rows}</div>
-</section>"#,
+</details>"#,
             rows = rows,
         ));
     }
@@ -3232,11 +3382,11 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
             .collect();
 
         sections.push(format!(
-            r#"<section class="section">
-    <h2>Module Instability</h2>
+            r#"<details class="section">
+    <summary>Risk Concentration: Modules<span class="section-summary-note">Dependency volatility by directory</span></summary>
     <div class="visual-note">Instability is Ce / (Ca + Ce). Longer bars are more dependency-volatile.</div>
     <div class="visual-grid">{rows}</div>
-</section>"#,
+</details>"#,
             rows = rows,
         ));
     }
@@ -3285,11 +3435,11 @@ fn render_aggregates(aggregates: &SnapshotAggregates) -> String {
             .collect();
 
         sections.push(format!(
-            r#"<section class="section">
-    <h2>Co-change Coupling</h2>
-    <div class="visual-note">File pairs that repeatedly change together. Bar length reflects coupling ratio.</div>
+            r#"<details class="section">
+    <summary>Risk Concentration: Co-change<span class="section-summary-note">Files that repeatedly change together</span></summary>
+    <div class="visual-note">Bar length reflects coupling ratio.</div>
     <div class="visual-grid">{rows}</div>
-</section>"#,
+</details>"#,
             rows = rows,
         ));
     }
@@ -3314,7 +3464,9 @@ fn render_model_risk_section(model_map: &crate::models::ModelRiskMap) -> String 
         })
         .unwrap_or_default();
     let initial_metrics = initial.map(render_model_metrics).unwrap_or_default();
-    let initial_functions = r#"<div class="model-empty-note">Graph connections load in the browser from shared associated references.</div>"#;
+    let initial_functions = initial.map(render_model_function_list).unwrap_or_else(|| {
+        r#"<div class="model-empty-note">No associated functions.</div>"#.to_string()
+    });
     let rows: String = model_map
         .models
         .iter()
@@ -3324,27 +3476,7 @@ fn render_model_risk_section(model_map: &crate::models::ModelRiskMap) -> String 
             let functions = model
                 .functions
                 .iter()
-                .map(|function| {
-                    let band_class = format!("band-{}", function.band.as_str());
-                    let quadrant = function.quadrant.as_deref().unwrap_or("-");
-                    format!(
-                        r#"<div class="model-function-row">
-                            <span class="monospace model-function-name">{function}</span>
-                            <span class="monospace model-function-file">{file}</span>
-                            <span class="{band_class}">LRS {lrs:.2}</span>
-                            <span>{quadrant}</span>
-                        </div>"#,
-                        function = html_escape(&function.function),
-                        file = source_link(
-                            &function.file,
-                            function.line,
-                            &format!("{}:{}", function.file, function.line)
-                        ),
-                        band_class = band_class,
-                        lrs = function.lrs,
-                        quadrant = html_escape(quadrant),
-                    )
-                })
+                .map(render_model_function_row)
                 .collect::<String>();
             format!(
                 r#"<tr>
@@ -3379,9 +3511,9 @@ fn render_model_risk_section(model_map: &crate::models::ModelRiskMap) -> String 
 
     format!(
         r#"<script>window.__hsModelMap = {json}; window.__hsModels = window.__hsModelMap.models;</script>
-<section class="section model-risk-section">
-    <h2>Model Risk Map</h2>
-    <div class="chart-label">Data and control models as a relationship graph; stronger links share more associated references</div>
+<details class="section model-risk-section" open>
+    <summary>Risk Concentration: Models<span class="section-summary-note">Data and control models ranked by associated function risk</span></summary>
+    <div class="chart-label">Stronger links share more associated references.</div>
     <div class="model-risk-layout">
         <div>
             <canvas id="hs-model-chart" height="420"></canvas>
@@ -3420,7 +3552,7 @@ fn render_model_risk_section(model_map: &crate::models::ModelRiskMap) -> String 
         <tbody>{rows}</tbody>
         </table>
     </details>
-</section>"#,
+</details>"#,
         json = json,
         initial_name = initial_name,
         initial_meta = initial_meta,
@@ -3455,6 +3587,50 @@ fn render_model_metrics(model: &crate::models::ModelRiskEntry) -> String {
         critical = model.critical,
         high = model.high,
         moderate = model.moderate,
+    )
+}
+
+fn render_model_function_list(model: &crate::models::ModelRiskEntry) -> String {
+    let functions = model
+        .functions
+        .iter()
+        .map(render_model_function_row)
+        .collect::<String>();
+    format!(
+        r#"<div class="model-panel-label">Top associated functions</div>{functions}"#,
+        functions = functions,
+    )
+}
+
+fn render_model_function_row(function: &crate::models::ModelFunction) -> String {
+    let band_class = format!("band-{}", function.band.as_str());
+    let quadrant = function.quadrant.as_deref().unwrap_or("-");
+    let association = match function.association {
+        crate::models::AssociationKind::SameFile => "same file",
+        crate::models::AssociationKind::DirectImport => "direct import",
+    };
+    format!(
+        r#"<div class="model-function-row">
+    <div>
+        <div class="monospace model-function-name">{function}</div>
+        <div class="monospace model-function-file">{file}</div>
+    </div>
+    <div class="model-function-score">
+        <span class="{band_class}">LRS {lrs:.2}</span>
+        <span>{quadrant}</span>
+        <span>{association}</span>
+    </div>
+</div>"#,
+        function = html_escape(&function.function),
+        file = source_link(
+            &function.file,
+            function.line,
+            &format!("{}:{}", function.file, function.line)
+        ),
+        band_class = band_class,
+        lrs = function.lrs,
+        quadrant = html_escape(quadrant),
+        association = association,
     )
 }
 
@@ -3883,11 +4059,33 @@ fn html_escape(s: &str) -> String {
 
 fn source_link(file: &str, line: u32, label: &str) -> String {
     let href = source_href(file, line);
+    let display_label = compact_source_label(label);
     format!(
         r#"<a class="source-link" href="{href}">{label}</a>"#,
         href = html_escape(&href),
-        label = html_escape(label),
+        label = html_escape(&display_label),
     )
+}
+
+fn compact_source_label(label: &str) -> String {
+    let normalized = label.replace('\\', "/");
+    if let Some((path, suffix)) = normalized.rsplit_once(':') {
+        if suffix.chars().all(|ch| ch.is_ascii_digit()) {
+            return format!("{}:{suffix}", compact_source_label(path));
+        }
+    }
+    if let Some(idx) = normalized.find("/hotspots/") {
+        return normalized[idx + "/hotspots/".len()..].to_string();
+    }
+    if normalized.starts_with('/') {
+        let parts: Vec<&str> = normalized
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .collect();
+        let keep = parts.len().saturating_sub(4);
+        return parts[keep..].join("/");
+    }
+    normalized
 }
 
 fn source_href(file: &str, line: u32) -> String {

--- a/hotspots-core/src/html.rs
+++ b/hotspots-core/src/html.rs
@@ -2101,6 +2101,7 @@ fn inline_javascript() -> &'static str {
         var lastH = 0;
         var dragging = null;
         var colors = { critical: '#ef4444', high: '#f97316', moderate: '#eab308', low: '#22c55e' };
+        var bandWeights = { critical: 1.5, high: 1.25, moderate: 1.0, low: 0.5 };
 
         function isDarkModel() { return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches); }
         function esc(s) {
@@ -2113,11 +2114,25 @@ fn inline_javascript() -> &'static str {
             var href = normalized.indexOf('/') === 0 ? 'file://' + normalized : normalized;
             return encodeURI(href) + (line ? '#L' + encodeURIComponent(String(line)) : '');
         }
-        function modelRiskColor(m) {
-            if ((m.critical || 0) > 0) return colors.critical;
-            if ((m.high || 0) > 0) return colors.high;
-            if ((m.moderate || 0) > 0) return colors.moderate;
-            return colors.low;
+        function weightedScore(m) {
+            var fns = m.functions || [];
+            if (!fns.length) return m.score || 0;
+            var s = 0;
+            fns.forEach(function(f) {
+                var base = (f.activity_risk != null ? f.activity_risk : f.lrs) || 0;
+                s += base * (bandWeights[f.band] || 1.0);
+            });
+            return s;
+        }
+        var wScores = models.map(weightedScore);
+        var maxWScore = Math.max.apply(null, wScores.concat([1]));
+        function modelRiskColor(m, idx) {
+            var ratio = (typeof idx === 'number' ? wScores[idx] : weightedScore(m)) / maxWScore;
+            if (ratio >= 0.75) return '#b91c1c';
+            if (ratio >= 0.50) return '#ef4444';
+            if (ratio >= 0.30) return '#f97316';
+            if (ratio >= 0.15) return '#eab308';
+            return '#22c55e';
         }
         function modelConnections(idx) {
             return links.filter(function(l) {
@@ -2145,12 +2160,12 @@ fn inline_javascript() -> &'static str {
             return (l.shared_functions || 0) + (l.shared_risk || 0) / 10;
         }
         function initializeGraph(W, H) {
-            var maxScore = Math.max.apply(null, models.map(function(m) { return m.score || 0; })) || 1;
             var cx = W / 2, cy = H / 2, spread = Math.max(70, Math.min(W, H) * 0.34);
             nodes.forEach(function(n, i) {
                 var angle = (Math.PI * 2 * i / Math.max(1, nodes.length)) - Math.PI / 2;
-                var pull = 1 - Math.min(0.45, (n.model.score || 0) / maxScore * 0.35);
-                n.r = 11 + Math.sqrt(Math.max(0, n.model.score || 0)) * 1.4;
+                var ws = wScores[i] || 0;
+                var pull = 1 - Math.min(0.45, ws / maxWScore * 0.35);
+                n.r = 11 + Math.sqrt(Math.max(0, ws)) * 1.4;
                 n.x = cx + Math.cos(angle) * spread * pull;
                 n.y = cy + Math.sin(angle) * spread * pull;
                 n.vx = 0;
@@ -2222,7 +2237,8 @@ fn inline_javascript() -> &'static str {
             name.textContent = m.name || '';
             meta.innerHTML = '<a class="source-link" href="' + sourceHref(m.file, m.line) + '">' + esc((m.file || '') + ':' + (m.line || '')) + '</a> - ' + esc(m.kind || '');
             metrics.innerHTML =
-                '<div class="model-metric"><span>Score</span><strong>' + Number(m.score || 0).toFixed(2) + '</strong></div>' +
+                '<div class="model-metric"><span>Risk Score</span><strong style="color:' + modelRiskColor(m, idx) + '">' + (wScores[idx] || 0).toFixed(2) + '</strong></div>' +
+                '<div class="model-metric"><span>Raw Score</span><strong>' + Number(m.score || 0).toFixed(2) + '</strong></div>' +
                 '<div class="model-metric"><span>Critical</span><strong class="band-critical">' + (m.critical || 0) + '</strong></div>' +
                 '<div class="model-metric"><span>High</span><strong class="band-high">' + (m.high || 0) + '</strong></div>' +
                 '<div class="model-metric"><span>Moderate</span><strong class="band-moderate">' + (m.moderate || 0) + '</strong></div>';
@@ -2292,7 +2308,7 @@ fn inline_javascript() -> &'static str {
                 ctx.stroke();
                 ctx.beginPath();
                 ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
-                ctx.fillStyle = modelRiskColor(m);
+                ctx.fillStyle = modelRiskColor(m, i);
                 ctx.globalAlpha = selected || hovered ? 1 : 0.86;
                 ctx.fill();
                 ctx.globalAlpha = 1;
@@ -2308,9 +2324,10 @@ fn inline_javascript() -> &'static str {
                 ctx.font = 'bold 10px system-ui,sans-serif';
                 ctx.lineWidth = 3;
                 ctx.strokeStyle = 'rgba(17, 24, 39, 0.72)';
-                ctx.strokeText(Number(m.score || 0).toFixed(1), n.x, n.y + 3);
+                var wsLabel = (wScores[i] || 0).toFixed(1);
+                ctx.strokeText(wsLabel, n.x, n.y + 3);
                 ctx.fillStyle = '#ffffff';
-                ctx.fillText(Number(m.score || 0).toFixed(1), n.x, n.y + 3);
+                ctx.fillText(wsLabel, n.x, n.y + 3);
             });
             if (links.length === 0) {
                 ctx.fillStyle = fg;

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod html;
 pub mod imports;
 pub mod language;
 pub mod metrics;
+pub mod models;
 pub mod parser;
 pub mod patterns;
 pub mod policy;
@@ -243,7 +244,7 @@ fn is_supported_source_file(filename: &str) -> bool {
 /// - Java: .java
 /// - Python: .py, .pyw
 /// - Rust: .rs
-fn collect_source_files(path: &std::path::Path) -> Result<Vec<std::path::PathBuf>> {
+pub(crate) fn collect_source_files(path: &std::path::Path) -> Result<Vec<std::path::PathBuf>> {
     let mut files = Vec::new();
 
     if path.is_file() {

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -637,6 +637,72 @@ fn truncate_middle(value: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::report::MetricsReport;
+    use crate::snapshot::{AnalysisInfo, CommitInfo};
+
+    fn test_function(
+        file: &str,
+        name: &str,
+        lrs: f64,
+        activity_risk: Option<f64>,
+    ) -> FunctionSnapshot {
+        FunctionSnapshot {
+            function_id: format!("{file}::{name}"),
+            file: file.to_string(),
+            line: 10,
+            language: Language::TypeScript,
+            metrics: MetricsReport {
+                cc: 1,
+                nd: 0,
+                fo: 0,
+                ns: 0,
+                loc: 10,
+            },
+            lrs,
+            band: if lrs >= 8.0 {
+                RiskBand::High
+            } else {
+                RiskBand::Moderate
+            },
+            suppression_reason: None,
+            churn: None,
+            touch_count_30d: None,
+            days_since_last_change: None,
+            callgraph: None,
+            activity_risk,
+            risk_factors: None,
+            percentile: None,
+            driver: None,
+            driver_detail: None,
+            quadrant: Some("fire".to_string()),
+            patterns: vec![],
+            pattern_details: None,
+        }
+    }
+
+    fn test_snapshot(functions: Vec<FunctionSnapshot>) -> Snapshot {
+        Snapshot {
+            schema_version: crate::snapshot::SNAPSHOT_SCHEMA_VERSION,
+            commit: CommitInfo {
+                sha: "test".to_string(),
+                parents: vec![],
+                timestamp: 0,
+                branch: None,
+                message: None,
+                author: None,
+                is_fix_commit: None,
+                is_revert_commit: None,
+                ticket_ids: vec![],
+            },
+            analysis: AnalysisInfo {
+                scope: ".".to_string(),
+                tool_version: "test".to_string(),
+            },
+            functions,
+            summary: None,
+            aggregates: None,
+        }
+    }
 
     #[test]
     fn extracts_model_declarations_from_supported_languages() {
@@ -652,5 +718,62 @@ mod tests {
         assert_eq!(models.len(), 2);
         assert_eq!(models[0].kind, "struct");
         assert_eq!(models[1].kind, "enum");
+    }
+
+    #[test]
+    fn associates_single_model_file_functions_and_prefers_activity_risk_for_ranking() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("order.ts"),
+            "export interface Order { id: string }\n",
+        )
+        .unwrap();
+        let snapshot = test_snapshot(vec![
+            test_function("order.ts", "validateOrder", 2.0, Some(20.0)),
+            test_function("order.ts", "saveOrder", 9.0, None),
+        ]);
+
+        let map = compute_model_risk_map(dir.path(), dir.path(), &snapshot, None).unwrap();
+
+        assert_eq!(map.models.len(), 1);
+        let order = &map.models[0];
+        assert_eq!(order.name, "Order");
+        assert_eq!(order.functions.len(), 2);
+        assert_eq!(order.functions[0].function, "validateOrder");
+        assert_eq!(order.score, 29.0);
+        assert_eq!(order.high, 1);
+        assert_eq!(order.moderate, 1);
+    }
+
+    #[test]
+    fn does_not_fallback_associate_every_function_when_file_has_multiple_models() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("models.ts"),
+            "export interface Order { id: string }\nexport interface User { id: string }\n",
+        )
+        .unwrap();
+        let snapshot = test_snapshot(vec![
+            test_function("models.ts", "validateOrder", 8.0, None),
+            test_function("models.ts", "saveOrder", 6.0, None),
+            test_function("models.ts", "validateUser", 7.0, None),
+            test_function("models.ts", "saveUser", 5.0, None),
+            test_function("models.ts", "unrelated", 9.0, None),
+        ]);
+
+        let map = compute_model_risk_map(dir.path(), dir.path(), &snapshot, None).unwrap();
+
+        assert_eq!(map.models.len(), 2);
+        assert!(map.models.iter().all(|model| model.functions.len() == 2));
+        assert!(map.models.iter().any(|model| model.name == "Order"
+            && model
+                .functions
+                .iter()
+                .all(|function| function.function.contains("Order"))));
+        assert!(map.models.iter().any(|model| model.name == "User"
+            && model
+                .functions
+                .iter()
+                .all(|function| function.function.contains("User"))));
     }
 }

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -1,0 +1,600 @@
+//! Model risk map extraction and aggregation.
+//!
+//! This module keeps the first model-map implementation structural: it extracts
+//! first-party model declarations, associates functions by same-file and direct
+//! import edges, then ranks models by concentrated risk.
+
+use crate::language::Language;
+use crate::risk::RiskBand;
+use crate::snapshot::{FunctionSnapshot, Snapshot};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::Path;
+
+const DEFAULT_FUNCTIONS_PER_MODEL: usize = 5;
+const MIN_ASSOCIATED_FUNCTIONS: usize = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct ModelDecl {
+    pub name: String,
+    pub file: String,
+    pub line: u32,
+    pub language: Language,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct ModelRiskMap {
+    pub models: Vec<ModelRiskEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<ModelRiskLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct ModelRiskEntry {
+    pub name: String,
+    pub file: String,
+    pub line: u32,
+    pub language: Language,
+    pub kind: String,
+    pub score: f64,
+    pub critical: usize,
+    pub high: usize,
+    pub moderate: usize,
+    pub low: usize,
+    pub functions: Vec<ModelFunction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct ModelFunction {
+    pub function_id: String,
+    pub function: String,
+    pub file: String,
+    pub line: u32,
+    pub lrs: f64,
+    pub activity_risk: Option<f64>,
+    pub band: RiskBand,
+    pub quadrant: Option<String>,
+    pub association: AssociationKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct ModelRiskLink {
+    pub source: usize,
+    pub target: usize,
+    pub shared_functions: usize,
+    pub shared_risk: f64,
+    pub functions: Vec<String>,
+}
+
+struct ModelRiskBuildEntry {
+    entry: ModelRiskEntry,
+    associated: Vec<ModelFunction>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum AssociationKind {
+    SameFile,
+    DirectImport,
+}
+
+pub fn compute_model_risk_map(
+    source_root: &Path,
+    repo_root: &Path,
+    snapshot: &Snapshot,
+    top_models: Option<usize>,
+) -> Result<ModelRiskMap> {
+    let models = extract_models(source_root, repo_root)?;
+    let model_files: BTreeSet<String> = models.iter().map(|m| m.file.clone()).collect();
+    let mut model_counts_by_file: HashMap<String, usize> = HashMap::new();
+    for model in &models {
+        *model_counts_by_file.entry(model.file.clone()).or_default() += 1;
+    }
+    if models.is_empty() {
+        return Ok(ModelRiskMap {
+            models: Vec::new(),
+            links: Vec::new(),
+        });
+    }
+
+    let mut files: Vec<String> = snapshot.functions.iter().map(|f| f.file.clone()).collect();
+    files.extend(model_files.iter().cloned());
+    files.sort();
+    files.dedup();
+    let file_refs: Vec<&str> = files.iter().map(String::as_str).collect();
+    let import_edges = crate::imports::resolve_file_deps(&file_refs, repo_root);
+
+    let mut import_map: HashMap<String, HashSet<String>> = HashMap::new();
+    for (from, to) in import_edges {
+        import_map.entry(from).or_default().insert(to);
+    }
+    let tokens_by_file = load_source_tokens(&files, repo_root);
+
+    let mut functions_by_file: BTreeMap<&str, Vec<&FunctionSnapshot>> = BTreeMap::new();
+    for function in &snapshot.functions {
+        functions_by_file
+            .entry(function.file.as_str())
+            .or_default()
+            .push(function);
+    }
+
+    let mut entries = Vec::new();
+    for model in models {
+        let mut associated = Vec::new();
+        let mut seen = HashSet::new();
+
+        if let Some(functions) = functions_by_file.get(model.file.as_str()) {
+            let model_count = model_counts_by_file
+                .get(&model.file)
+                .copied()
+                .unwrap_or_default();
+            add_same_file_functions(&mut associated, &mut seen, functions, &model, model_count);
+        }
+
+        for (file, imports) in &import_map {
+            if imports.contains(&model.file)
+                && tokens_by_file
+                    .get(file)
+                    .is_some_and(|tokens| tokens.contains(&model.name))
+            {
+                add_associated_functions(
+                    &mut associated,
+                    &mut seen,
+                    direct_import_functions(
+                        functions_by_file
+                            .get(file.as_str())
+                            .map(Vec::as_slice)
+                            .unwrap_or(&[]),
+                        &model.name,
+                    )
+                    .iter(),
+                    AssociationKind::DirectImport,
+                );
+            }
+        }
+
+        if associated.len() < MIN_ASSOCIATED_FUNCTIONS {
+            continue;
+        }
+
+        associated.sort_by(compare_model_functions);
+        let score = associated
+            .iter()
+            .take(DEFAULT_FUNCTIONS_PER_MODEL)
+            .map(function_score)
+            .sum();
+        let (critical, high, moderate, low) = band_counts(&associated);
+        let mut top_functions = associated.clone();
+        top_functions.truncate(DEFAULT_FUNCTIONS_PER_MODEL);
+
+        entries.push(ModelRiskBuildEntry {
+            entry: ModelRiskEntry {
+                name: model.name,
+                file: model.file,
+                line: model.line,
+                language: model.language,
+                kind: model.kind,
+                score,
+                critical,
+                high,
+                moderate,
+                low,
+                functions: top_functions,
+            },
+            associated,
+        });
+    }
+
+    entries.sort_by(|a, b| {
+        b.entry
+            .score
+            .partial_cmp(&a.entry.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.entry.file.cmp(&b.entry.file))
+            .then_with(|| a.entry.line.cmp(&b.entry.line))
+            .then_with(|| a.entry.name.cmp(&b.entry.name))
+    });
+    if let Some(limit) = top_models {
+        entries.truncate(limit);
+    }
+
+    let links = build_model_links(&entries);
+    let models = entries.into_iter().map(|entry| entry.entry).collect();
+
+    Ok(ModelRiskMap { models, links })
+}
+
+fn build_model_links(entries: &[ModelRiskBuildEntry]) -> Vec<ModelRiskLink> {
+    let mut links = Vec::new();
+    for source_idx in 0..entries.len() {
+        let source_functions: HashMap<&str, &ModelFunction> = entries[source_idx]
+            .associated
+            .iter()
+            .map(|function| (function.function_id.as_str(), function))
+            .collect();
+        for (target_idx, target_entry) in entries.iter().enumerate().skip(source_idx + 1) {
+            let mut shared = Vec::new();
+            let mut shared_risk = 0.0;
+            for function in &target_entry.associated {
+                if let Some(source_function) = source_functions.get(function.function_id.as_str()) {
+                    shared_risk += function_score(function).max(function_score(source_function));
+                    shared.push(function.function.clone());
+                }
+            }
+            if !shared.is_empty() {
+                let shared_functions = shared.len();
+                shared.sort();
+                shared.truncate(5);
+                links.push(ModelRiskLink {
+                    source: source_idx,
+                    target: target_idx,
+                    shared_functions,
+                    shared_risk,
+                    functions: shared,
+                });
+            }
+        }
+    }
+    links.sort_by(|a, b| {
+        b.shared_functions
+            .cmp(&a.shared_functions)
+            .then_with(|| {
+                b.shared_risk
+                    .partial_cmp(&a.shared_risk)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.source.cmp(&b.source))
+            .then_with(|| a.target.cmp(&b.target))
+    });
+    links
+}
+
+fn load_source_tokens(files: &[String], repo_root: &Path) -> HashMap<String, HashSet<String>> {
+    let mut tokens_by_file = HashMap::new();
+    for file in files {
+        let path = if Path::new(file).is_absolute() {
+            std::path::PathBuf::from(file)
+        } else {
+            repo_root.join(file)
+        };
+        if let Ok(source) = std::fs::read_to_string(path) {
+            tokens_by_file.insert(file.clone(), source_tokens(&source));
+        }
+    }
+    tokens_by_file
+}
+
+pub fn extract_models(source_root: &Path, repo_root: &Path) -> Result<Vec<ModelDecl>> {
+    let source_files = crate::collect_source_files(source_root)?;
+    let mut models = Vec::new();
+    for path in source_files {
+        let language = match Language::from_path(&path) {
+            Some(language) => language,
+            None => continue,
+        };
+        let source = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let file = normalize_file(&path, repo_root);
+        models.extend(extract_models_from_source(&source, language, file));
+    }
+    models.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.line.cmp(&b.line))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Ok(models)
+}
+
+fn add_associated_functions<'a>(
+    out: &mut Vec<ModelFunction>,
+    seen: &mut HashSet<String>,
+    functions: impl Iterator<Item = &'a &'a FunctionSnapshot>,
+    association: AssociationKind,
+) {
+    for function in functions {
+        if seen.insert(function.function_id.clone()) {
+            out.push(ModelFunction {
+                function_id: function.function_id.clone(),
+                function: function_name(function),
+                file: function.file.clone(),
+                line: function.line,
+                lrs: function.lrs,
+                activity_risk: function.activity_risk,
+                band: function.band,
+                quadrant: function.quadrant.clone(),
+                association,
+            });
+        }
+    }
+}
+
+fn add_same_file_functions(
+    out: &mut Vec<ModelFunction>,
+    seen: &mut HashSet<String>,
+    functions: &[&FunctionSnapshot],
+    model: &ModelDecl,
+    model_count_in_file: usize,
+) {
+    let method_prefix = format!("{}::", model.name);
+    let methods: Vec<&FunctionSnapshot> = functions
+        .iter()
+        .copied()
+        .filter(|function| function_name(function).starts_with(&method_prefix))
+        .collect();
+    if !methods.is_empty() {
+        add_associated_functions(out, seen, methods.iter(), AssociationKind::SameFile);
+        return;
+    }
+
+    let mentioned: Vec<&FunctionSnapshot> = functions
+        .iter()
+        .copied()
+        .filter(|function| function_name_mentions_model(&function_name(function), &model.name))
+        .collect();
+    if !mentioned.is_empty() {
+        add_associated_functions(out, seen, mentioned.iter(), AssociationKind::SameFile);
+        return;
+    }
+
+    if model_count_in_file <= 1 {
+        add_associated_functions(out, seen, functions.iter(), AssociationKind::SameFile);
+    }
+}
+
+fn direct_import_functions<'a>(
+    functions: &'a [&'a FunctionSnapshot],
+    model_name: &str,
+) -> Vec<&'a FunctionSnapshot> {
+    let mentioned: Vec<&FunctionSnapshot> = functions
+        .iter()
+        .copied()
+        .filter(|function| function_name_mentions_model(&function_name(function), model_name))
+        .collect();
+    if !mentioned.is_empty() || functions.len() > 1 {
+        return mentioned;
+    }
+    functions.to_vec()
+}
+
+fn source_tokens(source: &str) -> HashSet<String> {
+    source
+        .split(|c: char| !(c == '_' || c == '$' || c.is_ascii_alphanumeric()))
+        .filter(|token| !token.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn function_name_mentions_model(name: &str, model_name: &str) -> bool {
+    name.to_lowercase().contains(&model_name.to_lowercase())
+}
+
+fn compare_model_functions(a: &ModelFunction, b: &ModelFunction) -> std::cmp::Ordering {
+    function_score(b)
+        .partial_cmp(&function_score(a))
+        .unwrap_or(std::cmp::Ordering::Equal)
+        .then_with(|| a.file.cmp(&b.file))
+        .then_with(|| a.line.cmp(&b.line))
+        .then_with(|| a.function.cmp(&b.function))
+}
+
+fn function_score(function: &ModelFunction) -> f64 {
+    function.activity_risk.unwrap_or(function.lrs)
+}
+
+fn band_counts(functions: &[ModelFunction]) -> (usize, usize, usize, usize) {
+    let mut critical = 0;
+    let mut high = 0;
+    let mut moderate = 0;
+    let mut low = 0;
+    for function in functions {
+        match function.band {
+            RiskBand::Critical => critical += 1,
+            RiskBand::High => high += 1,
+            RiskBand::Moderate => moderate += 1,
+            RiskBand::Low => low += 1,
+        }
+    }
+    (critical, high, moderate, low)
+}
+
+fn function_name(function: &FunctionSnapshot) -> String {
+    function
+        .function_id
+        .strip_prefix(&format!("{}::", function.file))
+        .unwrap_or(function.function_id.as_str())
+        .to_string()
+}
+
+fn normalize_file(path: &Path, repo_root: &Path) -> String {
+    if path.is_absolute() {
+        path.to_string_lossy().replace('\\', "/")
+    } else {
+        repo_root.join(path).to_string_lossy().replace('\\', "/")
+    }
+}
+
+fn extract_models_from_source(source: &str, language: Language, file: String) -> Vec<ModelDecl> {
+    match language {
+        Language::Rust => extract_regex_models(source, language, file, RUST_MODEL_PATTERNS),
+        Language::Go => extract_regex_models(source, language, file, GO_MODEL_PATTERNS),
+        Language::Python => extract_regex_models(source, language, file, PYTHON_MODEL_PATTERNS),
+        Language::Java => extract_regex_models(source, language, file, JAVA_MODEL_PATTERNS),
+        Language::TypeScript
+        | Language::TypeScriptReact
+        | Language::JavaScript
+        | Language::JavaScriptReact
+        | Language::Vue => extract_regex_models(source, language, file, ECMASCRIPT_MODEL_PATTERNS),
+    }
+}
+
+struct PatternSpec {
+    pattern: &'static str,
+    kind: &'static str,
+}
+
+const ECMASCRIPT_MODEL_PATTERNS: &[PatternSpec] = &[
+    PatternSpec {
+        pattern: r"\b(?:export\s+)?interface\s+([A-Za-z_$][\w$]*)",
+        kind: "interface",
+    },
+    PatternSpec {
+        pattern: r"\b(?:export\s+)?class\s+([A-Za-z_$][\w$]*)",
+        kind: "class",
+    },
+    PatternSpec {
+        pattern: r"\b(?:export\s+)?type\s+([A-Za-z_$][\w$]*)\s*=",
+        kind: "type",
+    },
+];
+
+const GO_MODEL_PATTERNS: &[PatternSpec] = &[PatternSpec {
+    pattern: r"\btype\s+([A-Za-z_]\w*)\s+struct\b",
+    kind: "struct",
+}];
+
+const RUST_MODEL_PATTERNS: &[PatternSpec] = &[
+    PatternSpec {
+        pattern: r"\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Za-z_]\w*)\b",
+        kind: "struct",
+    },
+    PatternSpec {
+        pattern: r"\b(?:pub(?:\([^)]*\))?\s+)?enum\s+([A-Za-z_]\w*)\b",
+        kind: "enum",
+    },
+];
+
+const PYTHON_MODEL_PATTERNS: &[PatternSpec] = &[PatternSpec {
+    pattern: r"(?m)^\s*class\s+([A-Za-z_]\w*)\b",
+    kind: "class",
+}];
+
+const JAVA_MODEL_PATTERNS: &[PatternSpec] = &[
+    PatternSpec {
+        pattern: r"(?m)^\s*(?:(?:public|private|protected|abstract|final|static)\s+)*class\s+([A-Za-z_]\w*)\b",
+        kind: "class",
+    },
+    PatternSpec {
+        pattern: r"(?m)^\s*(?:(?:public|private|protected|abstract|static)\s+)*interface\s+([A-Za-z_]\w*)\b",
+        kind: "interface",
+    },
+    PatternSpec {
+        pattern: r"(?m)^\s*(?:(?:public|private|protected|final|static)\s+)*record\s+([A-Za-z_]\w*)\b",
+        kind: "record",
+    },
+];
+
+fn extract_regex_models(
+    source: &str,
+    language: Language,
+    file: String,
+    specs: &[PatternSpec],
+) -> Vec<ModelDecl> {
+    let mut models = Vec::new();
+    let mut seen = HashSet::new();
+    for spec in specs {
+        let regex = match regex::Regex::new(spec.pattern) {
+            Ok(regex) => regex,
+            Err(_) => continue,
+        };
+        for captures in regex.captures_iter(source) {
+            let Some(name_match) = captures.get(1) else {
+                continue;
+            };
+            let name = name_match.as_str().to_string();
+            let line = line_number(source, name_match.start());
+            if seen.insert((name.clone(), line, spec.kind)) {
+                models.push(ModelDecl {
+                    name,
+                    file: file.clone(),
+                    line,
+                    language,
+                    kind: spec.kind.to_string(),
+                });
+            }
+        }
+    }
+    models.sort_by(|a, b| a.line.cmp(&b.line).then_with(|| a.name.cmp(&b.name)));
+    models
+}
+
+fn line_number(source: &str, offset: usize) -> u32 {
+    source[..offset].bytes().filter(|b| *b == b'\n').count() as u32 + 1
+}
+
+pub fn render_model_risk_text(map: &ModelRiskMap, top: Option<usize>) -> String {
+    let mut output = String::new();
+    output.push_str("Model Risk Map\n");
+    output.push_str(&"=".repeat(80));
+    output.push('\n');
+    output.push('\n');
+
+    let limit = top.unwrap_or(map.models.len());
+    for (idx, model) in map.models.iter().take(limit).enumerate() {
+        output.push_str(&format!(
+            "#{:<3} {:<24} {:<32} criticalx{} highx{} moderatex{}\n",
+            idx + 1,
+            model.name,
+            truncate_middle(&model.file, 32),
+            model.critical,
+            model.high,
+            model.moderate
+        ));
+        for function in &model.functions {
+            let quadrant = function.quadrant.as_deref().unwrap_or("-");
+            output.push_str(&format!(
+                "     {:<28} {:<32} LRS {:>6.2} [{}]\n",
+                truncate_middle(&function.function, 28),
+                format!("{}:{}", truncate_middle(&function.file, 24), function.line),
+                function.lrs,
+                quadrant
+            ));
+        }
+        output.push('\n');
+    }
+
+    output.push_str("Models ranked by: sum of top-5 associated function risk scores\n");
+    output
+}
+
+pub fn render_model_risk_json(map: &ModelRiskMap) -> Result<String> {
+    serde_json::to_string_pretty(map).context("failed to render model risk JSON")
+}
+
+fn truncate_middle(value: &str, width: usize) -> String {
+    if value.len() <= width {
+        return format!("{value:<width$}");
+    }
+    if width <= 3 {
+        return ".".repeat(width);
+    }
+    format!("{}...", &value[..width - 3])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_model_declarations_from_supported_languages() {
+        let ts = "export interface Order {}\ntype User = { id: string }\nclass Cart {}";
+        let models = extract_models_from_source(ts, Language::TypeScript, "a.ts".to_string());
+        assert_eq!(models.len(), 3);
+        assert_eq!(models[0].name, "Order");
+        assert_eq!(models[1].name, "User");
+        assert_eq!(models[2].name, "Cart");
+
+        let rust = "struct Order { id: u64 }\nenum State { Ready(String), Done }";
+        let models = extract_models_from_source(rust, Language::Rust, "a.rs".to_string());
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].kind, "struct");
+        assert_eq!(models[1].kind, "enum");
+    }
+}

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -164,7 +164,6 @@ pub fn compute_model_risk_map(
                             .get(file)
                             .map(Vec::as_slice)
                             .unwrap_or(&[]),
-                        &model.name,
                     )
                     .iter(),
                     AssociationKind::DirectImport,
@@ -384,18 +383,7 @@ fn add_same_file_functions(
     }
 }
 
-fn direct_import_functions<'a>(
-    functions: &'a [&'a FunctionSnapshot],
-    model_name: &str,
-) -> Vec<&'a FunctionSnapshot> {
-    let mentioned: Vec<&FunctionSnapshot> = functions
-        .iter()
-        .copied()
-        .filter(|function| function_name_mentions_model(&function_name(function), model_name))
-        .collect();
-    if !mentioned.is_empty() || functions.len() > 1 {
-        return mentioned;
-    }
+fn direct_import_functions<'a>(functions: &'a [&'a FunctionSnapshot]) -> Vec<&'a FunctionSnapshot> {
     functions.to_vec()
 }
 
@@ -516,16 +504,10 @@ const GO_MODEL_PATTERNS: &[PatternSpec] = &[PatternSpec {
     kind: "struct",
 }];
 
-const RUST_MODEL_PATTERNS: &[PatternSpec] = &[
-    PatternSpec {
-        pattern: r"\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Za-z_]\w*)\b",
-        kind: "struct",
-    },
-    PatternSpec {
-        pattern: r"\b(?:pub(?:\([^)]*\))?\s+)?enum\s+([A-Za-z_]\w*)\b",
-        kind: "enum",
-    },
-];
+const RUST_MODEL_PATTERNS: &[PatternSpec] = &[PatternSpec {
+    pattern: r"\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Za-z_]\w*)\b",
+    kind: "struct",
+}];
 
 const PYTHON_MODEL_PATTERNS: &[PatternSpec] = &[PatternSpec {
     pattern: r"(?m)^\s*class\s+([A-Za-z_]\w*)\b",
@@ -716,9 +698,9 @@ mod tests {
 
         let rust = "struct Order { id: u64 }\nenum State { Ready(String), Done }";
         let models = extract_models_from_source(rust, Language::Rust, "a.rs".to_string());
-        assert_eq!(models.len(), 2);
+        // Enums are excluded until data-carrying variants can be reliably distinguished.
+        assert_eq!(models.len(), 1);
         assert_eq!(models[0].kind, "struct");
-        assert_eq!(models[1].kind, "enum");
     }
 
     #[test]

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -164,7 +164,6 @@ pub fn compute_model_risk_map(
                             .get(file)
                             .map(Vec::as_slice)
                             .unwrap_or(&[]),
-                        &model.name,
                     )
                     .iter(),
                     AssociationKind::DirectImport,
@@ -384,18 +383,7 @@ fn add_same_file_functions(
     }
 }
 
-fn direct_import_functions<'a>(
-    functions: &'a [&'a FunctionSnapshot],
-    model_name: &str,
-) -> Vec<&'a FunctionSnapshot> {
-    let mentioned: Vec<&FunctionSnapshot> = functions
-        .iter()
-        .copied()
-        .filter(|function| function_name_mentions_model(&function_name(function), model_name))
-        .collect();
-    if !mentioned.is_empty() || functions.len() > 1 {
-        return mentioned;
-    }
+fn direct_import_functions<'a>(functions: &'a [&'a FunctionSnapshot]) -> Vec<&'a FunctionSnapshot> {
     functions.to_vec()
 }
 

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -10,7 +10,7 @@ use crate::snapshot::{FunctionSnapshot, Snapshot};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 const DEFAULT_FUNCTIONS_PER_MODEL: usize = 5;
 const MIN_ASSOCIATED_FUNCTIONS: usize = 2;
@@ -28,6 +28,7 @@ pub struct ModelDecl {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct ModelRiskMap {
+    #[serde(rename = "items")]
     pub models: Vec<ModelRiskEntry>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<ModelRiskLink>,
@@ -104,7 +105,11 @@ pub fn compute_model_risk_map(
         });
     }
 
-    let mut files: Vec<String> = snapshot.functions.iter().map(|f| f.file.clone()).collect();
+    let mut files: Vec<String> = snapshot
+        .functions
+        .iter()
+        .map(|f| normalize_file(Path::new(&f.file), repo_root))
+        .collect();
     files.extend(model_files.iter().cloned());
     files.sort();
     files.dedup();
@@ -117,10 +122,10 @@ pub fn compute_model_risk_map(
     }
     let tokens_by_file = load_source_tokens(&files, repo_root);
 
-    let mut functions_by_file: BTreeMap<&str, Vec<&FunctionSnapshot>> = BTreeMap::new();
+    let mut functions_by_file: BTreeMap<String, Vec<&FunctionSnapshot>> = BTreeMap::new();
     for function in &snapshot.functions {
         functions_by_file
-            .entry(function.file.as_str())
+            .entry(normalize_file(Path::new(&function.file), repo_root))
             .or_default()
             .push(function);
     }
@@ -130,12 +135,19 @@ pub fn compute_model_risk_map(
         let mut associated = Vec::new();
         let mut seen = HashSet::new();
 
-        if let Some(functions) = functions_by_file.get(model.file.as_str()) {
+        if let Some(functions) = functions_by_file.get(&model.file) {
             let model_count = model_counts_by_file
                 .get(&model.file)
                 .copied()
                 .unwrap_or_default();
-            add_same_file_functions(&mut associated, &mut seen, functions, &model, model_count);
+            add_same_file_functions(
+                &mut associated,
+                &mut seen,
+                functions,
+                &model,
+                model_count,
+                repo_root,
+            );
         }
 
         for (file, imports) in &import_map {
@@ -149,13 +161,14 @@ pub fn compute_model_risk_map(
                     &mut seen,
                     direct_import_functions(
                         functions_by_file
-                            .get(file.as_str())
+                            .get(file)
                             .map(Vec::as_slice)
                             .unwrap_or(&[]),
                         &model.name,
                     )
                     .iter(),
                     AssociationKind::DirectImport,
+                    repo_root,
                 );
             }
         }
@@ -298,13 +311,16 @@ fn add_associated_functions<'a>(
     seen: &mut HashSet<String>,
     functions: impl Iterator<Item = &'a &'a FunctionSnapshot>,
     association: AssociationKind,
+    repo_root: &Path,
 ) {
     for function in functions {
         if seen.insert(function.function_id.clone()) {
+            let file = normalize_file(Path::new(&function.file), repo_root);
+            let function_name = function_name(function);
             out.push(ModelFunction {
-                function_id: function.function_id.clone(),
-                function: function_name(function),
-                file: function.file.clone(),
+                function_id: format!("{file}::{function_name}"),
+                function: function_name,
+                file,
                 line: function.line,
                 lrs: function.lrs,
                 activity_risk: function.activity_risk,
@@ -322,6 +338,7 @@ fn add_same_file_functions(
     functions: &[&FunctionSnapshot],
     model: &ModelDecl,
     model_count_in_file: usize,
+    repo_root: &Path,
 ) {
     let method_prefix = format!("{}::", model.name);
     let methods: Vec<&FunctionSnapshot> = functions
@@ -330,7 +347,13 @@ fn add_same_file_functions(
         .filter(|function| function_name(function).starts_with(&method_prefix))
         .collect();
     if !methods.is_empty() {
-        add_associated_functions(out, seen, methods.iter(), AssociationKind::SameFile);
+        add_associated_functions(
+            out,
+            seen,
+            methods.iter(),
+            AssociationKind::SameFile,
+            repo_root,
+        );
         return;
     }
 
@@ -340,12 +363,24 @@ fn add_same_file_functions(
         .filter(|function| function_name_mentions_model(&function_name(function), &model.name))
         .collect();
     if !mentioned.is_empty() {
-        add_associated_functions(out, seen, mentioned.iter(), AssociationKind::SameFile);
+        add_associated_functions(
+            out,
+            seen,
+            mentioned.iter(),
+            AssociationKind::SameFile,
+            repo_root,
+        );
         return;
     }
 
     if model_count_in_file <= 1 {
-        add_associated_functions(out, seen, functions.iter(), AssociationKind::SameFile);
+        add_associated_functions(
+            out,
+            seen,
+            functions.iter(),
+            AssociationKind::SameFile,
+            repo_root,
+        );
     }
 }
 
@@ -414,11 +449,32 @@ fn function_name(function: &FunctionSnapshot) -> String {
 }
 
 fn normalize_file(path: &Path, repo_root: &Path) -> String {
-    if path.is_absolute() {
-        path.to_string_lossy().replace('\\', "/")
+    let normalized = if path.is_absolute() {
+        path.to_path_buf()
     } else {
-        repo_root.join(path).to_string_lossy().replace('\\', "/")
+        repo_root.join(path)
+    };
+    let normalized = normalize_path_lexically(&normalized);
+    let repo_root = normalize_path_lexically(repo_root);
+    normalized
+        .strip_prefix(&repo_root)
+        .unwrap_or(normalized.as_path())
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            _ => out.push(component.as_os_str()),
+        }
     }
+    out
 }
 
 fn extract_models_from_source(source: &str, language: Language, file: String) -> Vec<ModelDecl> {

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -677,6 +677,7 @@ mod tests {
             quadrant: Some("fire".to_string()),
             patterns: vec![],
             pattern_details: None,
+            subsystem: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `hotspots analyze --mode models` for text and JSON model risk maps.
- Extracts model declarations across supported languages and associates functions by same-file or direct import relationships.
- Ranks models by the sum of the top 5 associated function risk scores and documents the new mode.

Closes #67.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo run --package hotspots-cli -- analyze hotspots-core/src --mode models --format text --top 5 --skip-touch-metrics`