### PR TITLE
feat: add C# language support (.cs files)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "syn",
  "tempfile",
  "tree-sitter",
+ "tree-sitter-c-sharp",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-python",
@@ -1292,6 +1293,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/hotspots-core/Cargo.toml
+++ b/hotspots-core/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 categories = { workspace = true }
-description = "Core library for static analysis and Local Risk Score (LRS) computation across TypeScript, JavaScript, Go, Python, Rust, and Java"
+description = "Core library for static analysis and Local Risk Score (LRS) computation across TypeScript, JavaScript, Go, Python, Rust, Java, and C#"
 readme = "../README.md"
 
 [lib]
@@ -37,6 +37,7 @@ tree-sitter = "0.25"
 tree-sitter-go = "0.25"
 tree-sitter-java = "0.23"
 tree-sitter-python = "0.23"
+tree-sitter-c-sharp = "0.23"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/hotspots-core/src/analysis.rs
+++ b/hotspots-core/src/analysis.rs
@@ -140,6 +140,9 @@ fn create_parser(
         }
         Language::Rust => Box::new(language::RustParser),
         Language::Vue => Box::new(language::VueParser::new(source_map.clone())),
+        Language::CSharp => {
+            Box::new(language::CSharpParser::new().context("Failed to create C# parser")?)
+        }
     };
     Ok(parser)
 }

--- a/hotspots-core/src/imports.rs
+++ b/hotspots-core/src/imports.rs
@@ -26,6 +26,7 @@ pub fn extract_raw_imports(source: &str, language: Language) -> Vec<String> {
         | Language::JavaScript
         | Language::JavaScriptReact
         | Language::Vue => extract_ecmascript_imports(source),
+        Language::CSharp => extract_csharp_imports(source),
     }
 }
 
@@ -168,6 +169,21 @@ fn extract_java_imports(source: &str) -> Vec<String> {
     dedup(imports)
 }
 
+fn extract_csharp_imports(source: &str) -> Vec<String> {
+    use regex::Regex;
+
+    static USING_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    // Matches: using Foo.Bar; and using static Foo.Bar; but not using var x = ...
+    let using_re =
+        USING_RE.get_or_init(|| Regex::new(r"(?m)^\s*using\s+(?:static\s+)?([\w.]+)\s*;").unwrap());
+
+    let imports: Vec<_> = using_re
+        .captures_iter(source)
+        .map(|c| c[1].to_string())
+        .collect();
+    dedup(imports)
+}
+
 fn extract_ecmascript_imports(source: &str) -> Vec<String> {
     use regex::Regex;
 
@@ -276,6 +292,7 @@ fn resolve_import(
         Language::Go => resolve_go(raw, all_files_set),
         Language::Python => resolve_python(raw, importing_file, all_files_set, repo_root),
         Language::Java => resolve_java(raw, all_files_set),
+        Language::CSharp => resolve_java(raw, all_files_set), // namespace-style, same strategy
     }
 }
 

--- a/hotspots-core/src/language/cfg_builder.rs
+++ b/hotspots-core/src/language/cfg_builder.rs
@@ -32,6 +32,7 @@ pub fn get_builder_for_function(function: &FunctionNode) -> Box<dyn CfgBuilder> 
         FunctionBody::Java { .. } => Box::new(super::java::JavaCfgBuilder),
         FunctionBody::Python { .. } => Box::new(super::python::PythonCfgBuilder),
         FunctionBody::Rust { .. } => Box::new(super::rust::RustCfgBuilder),
+        FunctionBody::CSharp { .. } => Box::new(super::csharp::CSharpCfgBuilder),
     }
 }
 

--- a/hotspots-core/src/language/csharp/cfg_builder.rs
+++ b/hotspots-core/src/language/csharp/cfg_builder.rs
@@ -1,0 +1,540 @@
+//! C# CFG builder implementation
+
+use crate::ast::FunctionNode;
+use crate::cfg::{Cfg, NodeId, NodeKind};
+use crate::language::cfg_builder::CfgBuilder;
+use crate::language::tree_sitter_utils::{
+    find_child_by_kind, find_function_by_start, with_cached_csharp_tree,
+};
+use tree_sitter::Node;
+
+pub struct CSharpCfgBuilder;
+
+impl CfgBuilder for CSharpCfgBuilder {
+    fn build(&self, function: &FunctionNode) -> Cfg {
+        let (_body_node_id, source) = function.body.as_csharp();
+
+        let result = with_cached_csharp_tree(source, |root| {
+            let func_node = find_function_by_start(
+                root,
+                function.span.start,
+                &[
+                    "method_declaration",
+                    "constructor_declaration",
+                    "local_function_statement",
+                    "operator_declaration",
+                    "conversion_operator_declaration",
+                ],
+            )?;
+            let body_node = find_child_by_kind(func_node, "block")?;
+            let mut builder = CSharpCfgBuilderState::new();
+            builder.build_from_block(&body_node, source);
+            Some(builder.cfg)
+        });
+
+        result.unwrap_or_else(|| {
+            let mut cfg = Cfg::new();
+            cfg.add_edge(cfg.entry, cfg.exit);
+            cfg
+        })
+    }
+}
+
+struct CSharpCfgBuilderState {
+    cfg: Cfg,
+    current_node: Option<NodeId>,
+    loop_stack: Vec<LoopContext>,
+}
+
+struct LoopContext {
+    break_target: NodeId,
+    continue_target: NodeId,
+}
+
+impl CSharpCfgBuilderState {
+    fn new() -> Self {
+        let cfg = Cfg::new();
+        let entry = cfg.entry;
+        CSharpCfgBuilderState {
+            cfg,
+            current_node: Some(entry),
+            loop_stack: Vec::new(),
+        }
+    }
+
+    fn build_from_block(&mut self, block: &Node, source: &str) {
+        let mut cursor = block.walk();
+        for child in block.children(&mut cursor) {
+            if child.is_named() {
+                self.visit_node(&child, source);
+            }
+        }
+
+        if let Some(last_node) = self.current_node {
+            if last_node != self.cfg.exit {
+                let has_exit_edge = self
+                    .cfg
+                    .edges
+                    .iter()
+                    .any(|e| e.from == last_node && e.to == self.cfg.exit);
+                if !has_exit_edge {
+                    self.cfg.add_edge(last_node, self.cfg.exit);
+                }
+            }
+        }
+    }
+
+    fn visit_node(&mut self, node: &Node, source: &str) {
+        match node.kind() {
+            "if_statement" => self.visit_if(node, source),
+            "while_statement" => self.visit_while(node, source),
+            "do_statement" => self.visit_do_while(node, source),
+            "for_statement" => self.visit_for(node, source),
+            "foreach_statement" => self.visit_foreach(node, source),
+            "switch_statement" => self.visit_switch(node, source),
+            "try_statement" => self.visit_try(node, source),
+            "return_statement" => self.visit_return(),
+            "throw_statement" => self.visit_throw(),
+            "break_statement" => self.visit_break(),
+            "continue_statement" => self.visit_continue(),
+            "local_function_statement" => {
+                // Local functions are discovered separately; skip the body here
+            }
+            _ => self.visit_simple_statement(),
+        }
+    }
+
+    fn visit_if(&mut self, node: &Node, source: &str) {
+        let Some(current) = self.current_node else {
+            return;
+        };
+
+        let condition = self.cfg.add_node(NodeKind::Condition);
+        self.cfg.add_edge(current, condition);
+
+        let join = self.cfg.add_node(NodeKind::Statement);
+
+        // Then branch: first "block" child
+        let then_block = find_child_by_kind(*node, "block");
+        if let Some(block) = then_block {
+            self.current_node = Some(condition);
+            self.visit_block(&block, source);
+            if let Some(last) = self.current_node {
+                if last != self.cfg.exit {
+                    self.cfg.add_edge(last, join);
+                }
+            }
+        } else {
+            self.cfg.add_edge(condition, join);
+        }
+
+        // Else branch: "else_clause" child
+        let else_clause = find_child_by_kind(*node, "else_clause");
+        if let Some(else_node) = else_clause {
+            self.current_node = Some(condition);
+            let mut cursor = else_node.walk();
+            for child in else_node.children(&mut cursor) {
+                if child.is_named() {
+                    if child.kind() == "if_statement" {
+                        self.visit_if(&child, source);
+                    } else if child.kind() == "block" {
+                        self.visit_block(&child, source);
+                    }
+                }
+            }
+            if let Some(last) = self.current_node {
+                if last != self.cfg.exit {
+                    self.cfg.add_edge(last, join);
+                }
+            }
+        } else {
+            self.cfg.add_edge(condition, join);
+        }
+
+        self.current_node = Some(join);
+    }
+
+    fn visit_while(&mut self, node: &Node, source: &str) {
+        let Some(current) = self.current_node else {
+            return;
+        };
+
+        let condition = self.cfg.add_node(NodeKind::Condition);
+        self.cfg.add_edge(current, condition);
+
+        let after_loop = self.cfg.add_node(NodeKind::Statement);
+
+        self.loop_stack.push(LoopContext {
+            break_target: after_loop,
+            continue_target: condition,
+        });
+
+        if let Some(body) = find_child_by_kind(*node, "block") {
+            self.current_node = Some(condition);
+            self.visit_block(&body, source);
+            if let Some(last) = self.current_node {
+                if last != self.cfg.exit {
+                    self.cfg.add_edge(last, condition);
+                }
+            }
+        }
+
+        self.cfg.add_edge(condition, after_loop);
+        self.loop_stack.pop();
+        self.current_node = Some(after_loop);
+    }
+
+    fn visit_do_while(&mut self, node: &Node, source: &str) {
+        let Some(current) = self.current_node else {
+            return;
+        };
+
+        let body_entry = self.cfg.add_node(NodeKind::Statement);
+        self.cfg.add_edge(current, body_entry);
+
+        let condition = self.cfg.add_node(NodeKind::Condition);
+        let after_loop = self.cfg.add_node(NodeKind::Statement);
+
+        self.loop_stack.push(LoopContext {
+            break_target: after_loop,
+            continue_target: condition,
+        });
+
+        if let Some(body) = find_child_by_kind(*node, "block") {
+            self.current_node = Some(body_entry);
+            self.visit_block(&body, source);
+            if let Some(last) = self.current_node {
+                if last != self.cfg.exit {
+                    self.cfg.add_edge(last, condition);
+                }
+            }
+        } else {
+            self.cfg.add_edge(body_entry, condition);
+        }
+
+        self.cfg.add_edge(condition, body_entry);
+        self.cfg.add_edge(condition, after_loop);
+        self.loop_stack.pop();
+        self.current_node = Some(after_loop);
+    }
+
+    fn visit_for(&mut self, node: &Node, source: &str) {
+        let Some(current) = self.current_node else {
+            return;
+        };
+
+        let condition = self.cfg.add_node(NodeKind::Condition);
+        self.cfg.add_edge(current, condition);
+
+        let after_loop = self.cfg.add_node(NodeKind::Statement);
+
+        self.loop_stack.push(LoopContext {
+            break_target: after_loop,
+            continue_target: condition,
+        });
+
+        if let Some(body) = find_child_by_kind(*node, "block") {
+            self.current_node = Some(condition);
+            self.visit_block(&body, source);
+            if let Some(last) = self.current_node {
+                if last != self.cfg.exit {
+                    self.cfg.add_edge(last, condition);
+                }
+            }
+        }
+
+        self.cfg.add_edge(condition, after_loop);
+        self.loop_stack.pop();
+        self.current_node = Some(after_loop);
+    }
+
+    fn visit_foreach(&mut self, node: &Node, source: &str) {
+        // foreach is structurally identical to for from a CFG perspective
+        self.visit_for(node, source);
+    }
+
+    fn visit_switch(&mut self, node: &Node, source: &str) {
+        let Some(current) = self.current_node else {
+            return;
+        };
+
+        let switch_node = self.cfg.add_node(NodeKind::Condition);
+        self.cfg.add_edge(current, switch_node);
+
+        let join = self.cfg.add_node(NodeKind::Statement);
+
+        self.loop_stack.push(LoopContext {
+            break_target: join,
+            continue_target: join,
+        });
+
+        // C# switch_statement contains a switch_body with switch_section children
+        if let Some(body) = find_child_by_kind(*node, "switch_body") {
+            let mut cursor = body.walk();
+            let mut has_default = false;
+
+            for child in body.children(&mut cursor) {
+                if child.kind() == "switch_section" {
+                    let case_node = self.cfg.add_node(NodeKind::Statement);
+                    self.cfg.add_edge(switch_node, case_node);
+
+                    // Check for default label
+                    let mut inner = child.walk();
+                    for label in child.children(&mut inner) {
+                        if label.kind() == "default_switch_label" {
+                            has_default = true;
+                        }
+                    }
+
+                    self.current_node = Some(case_node);
+                    let mut stmt_cursor = child.walk();
+                    for stmt in child.children(&mut stmt_cursor) {
+                        if stmt.is_named()
+                            && stmt.kind() != "case_switch_label"
+                            && stmt.kind() != "default_switch_label"
+                        {
+                            self.visit_node(&stmt, source);
+                        }
+                    }
+
+                    if let Some(last) = self.current_node {
+                        if last != self.cfg.exit {
+                            self.cfg.add_edge(last, join);
+                        }
+                    }
+                }
+            }
+
+            if !has_default {
+                self.cfg.add_edge(switch_node, join);
+            }
+        } else {
+            self.cfg.add_edge(switch_node, join);
+        }
+
+        self.loop_stack.pop();
+        self.current_node = Some(join);
+    }
+
+    fn visit_try(&mut self, node: &Node, source: &str) {
+        let Some(current) = self.current_node else {
+            return;
+        };
+
+        let try_entry = self.cfg.add_node(NodeKind::Statement);
+        self.cfg.add_edge(current, try_entry);
+
+        let mut branch_ends = Vec::new();
+
+        if let Some(try_body) = find_child_by_kind(*node, "block") {
+            self.current_node = Some(try_entry);
+            self.visit_block(&try_body, source);
+            if let Some(last) = self.current_node {
+                branch_ends.push(last);
+            }
+        } else {
+            branch_ends.push(try_entry);
+        }
+
+        // catch_clause children
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "catch_clause" {
+                let catch_node = self.cfg.add_node(NodeKind::Condition);
+                self.cfg.add_edge(try_entry, catch_node);
+
+                if let Some(catch_body) = find_child_by_kind(child, "block") {
+                    self.current_node = Some(catch_node);
+                    self.visit_block(&catch_body, source);
+                    if let Some(last) = self.current_node {
+                        branch_ends.push(last);
+                    }
+                } else {
+                    branch_ends.push(catch_node);
+                }
+            }
+        }
+
+        let non_exit: Vec<_> = branch_ends
+            .into_iter()
+            .filter(|&end| end != self.cfg.exit)
+            .collect();
+
+        if !non_exit.is_empty() {
+            let join = self.cfg.add_node(NodeKind::Statement);
+            for end in non_exit {
+                self.cfg.add_edge(end, join);
+            }
+            self.current_node = Some(join);
+        } else {
+            self.current_node = Some(self.cfg.exit);
+        }
+    }
+
+    fn visit_return(&mut self) {
+        if let Some(current) = self.current_node {
+            self.cfg.add_edge(current, self.cfg.exit);
+            self.current_node = None;
+        }
+    }
+
+    fn visit_throw(&mut self) {
+        if let Some(current) = self.current_node {
+            self.cfg.add_edge(current, self.cfg.exit);
+            self.current_node = None;
+        }
+    }
+
+    fn visit_break(&mut self) {
+        if let Some(current) = self.current_node {
+            if let Some(ctx) = self.loop_stack.last() {
+                self.cfg.add_edge(current, ctx.break_target);
+            } else {
+                self.cfg.add_edge(current, self.cfg.exit);
+            }
+            self.current_node = None;
+        }
+    }
+
+    fn visit_continue(&mut self) {
+        if let Some(current) = self.current_node {
+            if let Some(ctx) = self.loop_stack.last() {
+                self.cfg.add_edge(current, ctx.continue_target);
+            } else {
+                self.cfg.add_edge(current, self.cfg.exit);
+            }
+            self.current_node = None;
+        }
+    }
+
+    fn visit_simple_statement(&mut self) {
+        if let Some(current) = self.current_node {
+            let node = self.cfg.add_node(NodeKind::Statement);
+            self.cfg.add_edge(current, node);
+            self.current_node = Some(node);
+        }
+    }
+
+    fn visit_block(&mut self, block: &Node, source: &str) {
+        let mut cursor = block.walk();
+        for child in block.children(&mut cursor) {
+            if child.is_named() {
+                self.visit_node(&child, source);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::FunctionId;
+    use crate::language::{FunctionBody, SourceSpan};
+
+    fn make_test_function(source: &str, start_byte: usize, end_byte: usize) -> FunctionNode {
+        FunctionNode {
+            id: FunctionId {
+                file_index: 0,
+                local_index: 0,
+            },
+            name: Some("test".to_string()),
+            span: SourceSpan::new(start_byte, end_byte, 1, 1, 0),
+            body: FunctionBody::CSharp {
+                body_node: 0,
+                source: source.to_string(),
+            },
+            suppression_reason: None,
+        }
+    }
+
+    #[test]
+    fn test_simple_method() {
+        let source = r#"
+public class Test {
+    public void Foo() {
+        int x = 1;
+    }
+}
+"#;
+        let start = source.find("public void Foo").unwrap();
+        let function = make_test_function(source, start, source.len());
+        let cfg = CSharpCfgBuilder.build(&function);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 2);
+    }
+
+    #[test]
+    fn test_if_statement() {
+        let source = r#"
+public class Test {
+    public void Foo(int x) {
+        if (x > 0) {
+            return;
+        }
+    }
+}
+"#;
+        let start = source.find("public void Foo").unwrap();
+        let function = make_test_function(source, start, source.len());
+        let cfg = CSharpCfgBuilder.build(&function);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 3);
+    }
+
+    #[test]
+    fn test_while_loop() {
+        let source = r#"
+public class Test {
+    public void Foo(int n) {
+        int i = 0;
+        while (i < n) {
+            i++;
+        }
+    }
+}
+"#;
+        let start = source.find("public void Foo").unwrap();
+        let function = make_test_function(source, start, source.len());
+        let cfg = CSharpCfgBuilder.build(&function);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 3);
+    }
+
+    #[test]
+    fn test_foreach_loop() {
+        let source = r#"
+public class Test {
+    public void Foo(int[] items) {
+        foreach (var item in items) {
+            Console.WriteLine(item);
+        }
+    }
+}
+"#;
+        let start = source.find("public void Foo").unwrap();
+        let function = make_test_function(source, start, source.len());
+        let cfg = CSharpCfgBuilder.build(&function);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 3);
+    }
+
+    #[test]
+    fn test_try_catch() {
+        let source = r#"
+public class Test {
+    public void Foo(int x) {
+        try {
+            int result = 10 / x;
+        } catch (DivideByZeroException e) {
+            Console.WriteLine("error");
+        }
+    }
+}
+"#;
+        let start = source.find("public void Foo").unwrap();
+        let function = make_test_function(source, start, source.len());
+        let cfg = CSharpCfgBuilder.build(&function);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 4);
+    }
+}

--- a/hotspots-core/src/language/csharp/mod.rs
+++ b/hotspots-core/src/language/csharp/mod.rs
@@ -1,0 +1,7 @@
+//! C# language support
+
+mod cfg_builder;
+mod parser;
+
+pub use cfg_builder::CSharpCfgBuilder;
+pub use parser::CSharpParser;

--- a/hotspots-core/src/language/csharp/parser.rs
+++ b/hotspots-core/src/language/csharp/parser.rs
@@ -1,0 +1,235 @@
+//! C# language parser using tree-sitter
+
+use crate::ast::FunctionNode;
+use crate::language::parser::{LanguageParser, ParsedModule};
+use crate::language::tree_sitter_utils::find_child_by_kind;
+use anyhow::{Context, Result};
+use tree_sitter::{Node, Parser, Tree};
+
+pub struct CSharpParser;
+
+impl CSharpParser {
+    pub fn new() -> Result<Self> {
+        let mut parser = Parser::new();
+        let language = tree_sitter_c_sharp::LANGUAGE;
+        parser
+            .set_language(&language.into())
+            .context("Failed to set C# language for parser")?;
+        Ok(CSharpParser)
+    }
+}
+
+impl Default for CSharpParser {
+    fn default() -> Self {
+        Self::new().expect("Failed to create C# parser")
+    }
+}
+
+impl LanguageParser for CSharpParser {
+    fn parse(&self, source: &str, filename: &str) -> Result<Box<dyn ParsedModule>> {
+        let mut parser = Parser::new();
+        let language = tree_sitter_c_sharp::LANGUAGE;
+        parser
+            .set_language(&language.into())
+            .context("Failed to set C# language")?;
+
+        let tree = parser
+            .parse(source, None)
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse C# file: {}", filename))?;
+
+        Ok(Box::new(CSharpModule {
+            tree,
+            source: source.to_string(),
+        }))
+    }
+}
+
+struct CSharpModule {
+    tree: Tree,
+    source: String,
+}
+
+impl ParsedModule for CSharpModule {
+    fn discover_functions(&self, file_index: usize, _source: &str) -> Vec<FunctionNode> {
+        let root = self.tree.root_node();
+        let mut functions = Vec::new();
+        discover_functions_recursive(root, &self.source, file_index, &mut functions);
+        functions.sort_by_key(|f| f.span.start);
+        functions
+    }
+}
+
+fn discover_functions_recursive(
+    node: Node,
+    source: &str,
+    file_index: usize,
+    functions: &mut Vec<FunctionNode>,
+) {
+    match node.kind() {
+        "method_declaration"
+        | "constructor_declaration"
+        | "local_function_statement"
+        | "operator_declaration"
+        | "conversion_operator_declaration" => {
+            if let Some(function_node) = extract_function(node, source, file_index, functions.len())
+            {
+                functions.push(function_node);
+            }
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        discover_functions_recursive(child, source, file_index, functions);
+    }
+}
+
+fn extract_function(
+    node: Node,
+    source: &str,
+    file_index: usize,
+    local_index: usize,
+) -> Option<FunctionNode> {
+    use crate::ast::FunctionId;
+    use crate::language::{FunctionBody, SourceSpan};
+
+    let name = extract_function_name(node, source);
+
+    let body_node = find_child_by_kind(node, "block")?;
+
+    let span = SourceSpan::new(
+        node.start_byte(),
+        node.end_byte(),
+        node.start_position().row as u32 + 1,
+        node.end_position().row as u32 + 1,
+        node.start_position().column as u32,
+    );
+
+    let body = FunctionBody::CSharp {
+        body_node: body_node.id(),
+        source: source.to_string(),
+    };
+
+    Some(FunctionNode {
+        id: FunctionId {
+            file_index,
+            local_index,
+        },
+        name,
+        span,
+        body,
+        suppression_reason: None,
+    })
+}
+
+fn extract_function_name(node: Node, source: &str) -> Option<String> {
+    // method_declaration and local_function_statement use "identifier"
+    // constructor_declaration uses "identifier"
+    // operator_declaration uses "operator" keyword child — fall back to raw text slice
+    if let Some(name_node) = find_child_by_kind(node, "identifier") {
+        let name = &source[name_node.start_byte()..name_node.end_byte()];
+        return Some(name.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_parser() {
+        assert!(CSharpParser::new().is_ok());
+    }
+
+    #[test]
+    fn test_parse_simple_method() {
+        let parser = CSharpParser::new().unwrap();
+        let source = r#"
+public class Simple {
+    public int Add(int x, int y) {
+        return x + y;
+    }
+}
+"#;
+        let module = parser.parse(source, "test.cs").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name, Some("Add".to_string()));
+    }
+
+    #[test]
+    fn test_parse_constructor() {
+        let parser = CSharpParser::new().unwrap();
+        let source = r#"
+public class MyClass {
+    private int value;
+    public MyClass(int value) {
+        this.value = value;
+    }
+}
+"#;
+        let module = parser.parse(source, "test.cs").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name, Some("MyClass".to_string()));
+    }
+
+    #[test]
+    fn test_parse_multiple_methods() {
+        let parser = CSharpParser::new().unwrap();
+        let source = r#"
+public class Calc {
+    public int Add(int a, int b) { return a + b; }
+    public int Sub(int a, int b) { return a - b; }
+    public int Mul(int a, int b) { return a * b; }
+}
+"#;
+        let module = parser.parse(source, "test.cs").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 3);
+        assert_eq!(functions[0].name, Some("Add".to_string()));
+        assert_eq!(functions[1].name, Some("Sub".to_string()));
+        assert_eq!(functions[2].name, Some("Mul".to_string()));
+    }
+
+    #[test]
+    fn test_parse_empty_file() {
+        let parser = CSharpParser::new().unwrap();
+        let module = parser.parse("", "test.cs").unwrap();
+        assert_eq!(module.discover_functions(0, "").len(), 0);
+    }
+
+    #[test]
+    fn test_parse_static_method() {
+        let parser = CSharpParser::new().unwrap();
+        let source = r#"
+public class Utils {
+    public static string Format(int n) {
+        return n.ToString();
+    }
+}
+"#;
+        let module = parser.parse(source, "test.cs").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name, Some("Format".to_string()));
+    }
+
+    #[test]
+    fn test_parse_nested_class_methods() {
+        let parser = CSharpParser::new().unwrap();
+        let source = r#"
+public class Outer {
+    public void OuterMethod() { }
+    private class Inner {
+        public void InnerMethod() { }
+    }
+}
+"#;
+        let module = parser.parse(source, "test.cs").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 2);
+    }
+}

--- a/hotspots-core/src/language/function_body.rs
+++ b/hotspots-core/src/language/function_body.rs
@@ -55,6 +55,16 @@ pub enum FunctionBody {
         /// The source code for the entire function (signature + body)
         source: String,
     },
+
+    /// C# function body
+    ///
+    /// Contains the tree-sitter node ID for the block and the source code.
+    CSharp {
+        /// The tree-sitter node ID for the function body block
+        body_node: usize,
+        /// The source code (needed to reconstruct the tree)
+        source: String,
+    },
 }
 
 impl FunctionBody {
@@ -86,6 +96,11 @@ impl FunctionBody {
     /// Check if this is a Rust function body
     pub fn is_rust(&self) -> bool {
         matches!(self, FunctionBody::Rust { .. })
+    }
+
+    /// Check if this is a C# function body
+    pub fn is_csharp(&self) -> bool {
+        matches!(self, FunctionBody::CSharp { .. })
     }
 
     /// Get the ECMAScript body, if this is one
@@ -158,6 +173,18 @@ impl FunctionBody {
         match self {
             FunctionBody::Rust { source } => source.as_str(),
             _ => panic!("FunctionBody is not Rust"),
+        }
+    }
+
+    /// Get the C# body node ID and source, if this is a C# function
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is not a C# body. Use `is_csharp()` to check first.
+    pub fn as_csharp(&self) -> (usize, &str) {
+        match self {
+            FunctionBody::CSharp { body_node, source } => (*body_node, source.as_str()),
+            _ => panic!("FunctionBody is not CSharp"),
         }
     }
 }

--- a/hotspots-core/src/language/mod.rs
+++ b/hotspots-core/src/language/mod.rs
@@ -4,6 +4,7 @@
 //! source code across multiple programming languages.
 
 pub mod cfg_builder;
+pub mod csharp;
 pub mod ecmascript;
 pub mod function_body;
 pub mod go;
@@ -19,6 +20,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 pub use cfg_builder::{get_builder_for_function, CfgBuilder};
+pub use csharp::{CSharpCfgBuilder, CSharpParser};
 pub use ecmascript::{ECMAScriptCfgBuilder, ECMAScriptParser, VueParser};
 pub use function_body::FunctionBody;
 pub use go::{GoCfgBuilder, GoParser};
@@ -49,6 +51,8 @@ pub enum Language {
     Rust,
     /// Vue Single File Component (.vue)
     Vue,
+    /// C# (.cs)
+    CSharp,
 }
 
 impl Language {
@@ -84,6 +88,8 @@ impl Language {
             "rs" => Some(Language::Rust),
             // Vue Single File Component
             "vue" => Some(Language::Vue),
+            // C#
+            "cs" => Some(Language::CSharp),
             // Unknown
             _ => None,
         }
@@ -141,6 +147,7 @@ impl Language {
             Language::Python => "Python",
             Language::Rust => "Rust",
             Language::Vue => "Vue",
+            Language::CSharp => "C#",
         }
     }
 
@@ -173,6 +180,7 @@ impl Language {
             Language::Python => &["py", "pyw"],
             Language::Rust => &["rs"],
             Language::Vue => &["vue"],
+            Language::CSharp => &["cs"],
         }
     }
 
@@ -188,6 +196,7 @@ impl Language {
             "Python" => Some(Language::Python),
             "Rust" => Some(Language::Rust),
             "Vue" => Some(Language::Vue),
+            "C#" => Some(Language::CSharp),
             _ => None,
         }
     }

--- a/hotspots-core/src/language/tree_sitter_utils.rs
+++ b/hotspots-core/src/language/tree_sitter_utils.rs
@@ -96,3 +96,9 @@ make_parse_cache!(
     with_cached_python_tree,
     tree_sitter_python::LANGUAGE
 );
+
+make_parse_cache!(
+    CSHARP_TREE_CACHE,
+    with_cached_csharp_tree,
+    tree_sitter_c_sharp::LANGUAGE
+);

--- a/hotspots-core/src/metrics.rs
+++ b/hotspots-core/src/metrics.rs
@@ -79,6 +79,7 @@ pub fn extract_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
             // Extract Rust-specific metrics from syn AST
             extract_rust_metrics(function, cfg)
         }
+        FunctionBody::CSharp { .. } => extract_csharp_metrics(function, cfg),
     }
 }
 
@@ -888,6 +889,119 @@ fn python_count_cc_extras(body_node: &tree_sitter::Node, _source: &str) -> usize
 }
 
 // Note: Python metrics tests are integrated with cfg_builder tests
+
+// ============================================================================
+// C# Metrics Implementation
+// ============================================================================
+
+/// Extract metrics for C# functions using tree-sitter
+fn extract_csharp_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
+    let (_body_node_id, source) = function.body.as_csharp();
+    ts_with_function_body(
+        source,
+        tree_sitter_c_sharp::LANGUAGE.into(),
+        function.span.start,
+        &[
+            "method_declaration",
+            "constructor_declaration",
+            "local_function_statement",
+            "operator_declaration",
+            "conversion_operator_declaration",
+        ],
+        &["block"],
+        |func_node, body_node| {
+            let callee_names = csharp_extract_callees(&body_node, source);
+            RawMetrics {
+                cc: calculate_cc_from_cfg(cfg) + csharp_count_cc_extras(&body_node, source),
+                nd: ts_nesting_depth(
+                    &body_node,
+                    &[
+                        "if_statement",
+                        "while_statement",
+                        "do_statement",
+                        "for_statement",
+                        "foreach_statement",
+                        "switch_statement",
+                        "try_statement",
+                    ],
+                ),
+                fo: callee_names.len(),
+                ns: ts_non_structured_exits(
+                    &body_node,
+                    &[
+                        "return_statement",
+                        "throw_statement",
+                        "break_statement",
+                        "continue_statement",
+                    ],
+                ),
+                loc: calculate_loc_from_node(&func_node),
+                callee_names,
+            }
+        },
+    )
+    .unwrap_or(RawMetrics {
+        cc: 1,
+        nd: 0,
+        fo: 0,
+        ns: 0,
+        loc: 0,
+        callee_names: vec![],
+    })
+}
+
+/// Extract callee names from a C# function body.
+fn csharp_extract_callees(body_node: &tree_sitter::Node, source: &str) -> Vec<String> {
+    fn collect(
+        node: tree_sitter::Node,
+        source: &str,
+        calls: &mut std::collections::HashSet<String>,
+    ) {
+        if node.kind() == "invocation_expression" {
+            let call_text = &source[node.start_byte()..node.end_byte()];
+            calls.insert(call_text.to_string());
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            collect(child, source, calls);
+        }
+    }
+
+    let mut calls = std::collections::HashSet::new();
+    collect(*body_node, source, &mut calls);
+    let mut result: Vec<String> = calls.into_iter().collect();
+    result.sort();
+    result
+}
+
+/// Count additional CC contributors in C# (ternary, boolean operators, null-coalescing)
+fn csharp_count_cc_extras(body_node: &tree_sitter::Node, _source: &str) -> usize {
+    fn count_extras(node: tree_sitter::Node, count: &mut usize) {
+        match node.kind() {
+            "conditional_expression" => {
+                *count += 1;
+            }
+            "binary_expression" => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if child.kind() == "&&" || child.kind() == "||" || child.kind() == "??" {
+                        *count += 1;
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            count_extras(child, count);
+        }
+    }
+
+    let mut count = 0;
+    count_extras(*body_node, &mut count);
+    count
+}
 
 // ========================================
 // Rust Metrics Extraction

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -476,6 +476,7 @@ fn extract_models_from_source(source: &str, language: Language, file: String) ->
         | Language::JavaScript
         | Language::JavaScriptReact
         | Language::Vue => extract_regex_models(source, language, file, ECMASCRIPT_MODEL_PATTERNS),
+        Language::CSharp => extract_regex_models(source, language, file, CSHARP_MODEL_PATTERNS),
     }
 }
 
@@ -526,6 +527,25 @@ const JAVA_MODEL_PATTERNS: &[PatternSpec] = &[
     PatternSpec {
         pattern: r"(?m)^\s*(?:(?:public|private|protected|final|static)\s+)*record\s+([A-Za-z_]\w*)\b",
         kind: "record",
+    },
+];
+
+const CSHARP_MODEL_PATTERNS: &[PatternSpec] = &[
+    PatternSpec {
+        pattern: r"(?m)^\s*(?:(?:public|private|protected|internal|abstract|sealed|static|partial)\s+)*class\s+([A-Za-z_]\w*)\b",
+        kind: "class",
+    },
+    PatternSpec {
+        pattern: r"(?m)^\s*(?:(?:public|private|protected|internal)\s+)*interface\s+([A-Za-z_]\w*)\b",
+        kind: "interface",
+    },
+    PatternSpec {
+        pattern: r"(?m)^\s*(?:(?:public|private|protected|internal)\s+)*record\s+([A-Za-z_]\w*)\b",
+        kind: "record",
+    },
+    PatternSpec {
+        pattern: r"(?m)^\s*(?:(?:public|private|protected|internal)\s+)*enum\s+([A-Za-z_]\w*)\b",
+        kind: "enum",
     },
 ];
 

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -998,3 +998,8 @@ fn test_csharp_golden_determinism() {
     let json2 = render_json(&reports2);
     assert_eq!(json1, json2, "C# analysis is not deterministic");
 }
+
+#[test]
+fn test_csharp_golden_switches() {
+    test_csharp_golden("Switches");
+}

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -919,3 +919,82 @@ function add(a: number, b: number): number {
         );
     }
 }
+
+fn test_csharp_golden(fixture_name: &str) {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("csharp")
+        .join(format!("{}.cs", fixture_name));
+    let golden_name = fixture_name.to_lowercase();
+    let golden = golden_path(&format!("csharp-{}.json", golden_name));
+    let project_root = project_root();
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&fixture, options)
+        .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
+
+    let output = render_json(&reports);
+    let expected = read_golden(&format!("csharp-{}.json", golden_name));
+
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
+
+    normalize_paths(&mut output_json, &project_root);
+    normalize_paths(&mut expected_json, &project_root);
+
+    assert_eq!(
+        output_json, expected_json,
+        "Golden file mismatch for C# fixture: {}",
+        fixture_name
+    );
+}
+
+#[test]
+fn test_csharp_golden_simple() {
+    test_csharp_golden("Simple");
+}
+
+#[test]
+fn test_csharp_golden_loops() {
+    test_csharp_golden("Loops");
+}
+
+#[test]
+fn test_csharp_golden_exceptions() {
+    test_csharp_golden("Exceptions");
+}
+
+#[test]
+fn test_csharp_golden_determinism() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("csharp")
+        .join("Simple.cs");
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    let reports1 = analyze(&fixture, options).unwrap();
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    let reports2 = analyze(&fixture, options).unwrap();
+
+    let json1 = render_json(&reports1);
+    let json2 = render_json(&reports2);
+    assert_eq!(json1, json2, "C# analysis is not deterministic");
+}

--- a/tests/fixtures/csharp/Exceptions.cs
+++ b/tests/fixtures/csharp/Exceptions.cs
@@ -1,0 +1,40 @@
+public class Exceptions
+{
+    public int TryCatch(int x)
+    {
+        try
+        {
+            return 10 / x;
+        }
+        catch (DivideByZeroException)
+        {
+            return -1;
+        }
+    }
+
+    public int TryCatchFinally(int x)
+    {
+        int result = 0;
+        try
+        {
+            result = 10 / x;
+        }
+        catch (Exception)
+        {
+            result = -1;
+        }
+        finally
+        {
+            Console.WriteLine("done");
+        }
+        return result;
+    }
+
+    public void ThrowOnNegative(int x)
+    {
+        if (x < 0)
+        {
+            throw new ArgumentException("x must be non-negative");
+        }
+    }
+}

--- a/tests/fixtures/csharp/Loops.cs
+++ b/tests/fixtures/csharp/Loops.cs
@@ -1,0 +1,42 @@
+public class Loops
+{
+    public int ForLoop(int n)
+    {
+        int sum = 0;
+        for (int i = 0; i < n; i++)
+        {
+            sum += i;
+        }
+        return sum;
+    }
+
+    public int WhileLoop(int n)
+    {
+        int i = 0;
+        while (i < n)
+        {
+            i++;
+        }
+        return i;
+    }
+
+    public int DoWhileLoop(int n)
+    {
+        int i = 0;
+        do
+        {
+            i++;
+        } while (i < n);
+        return i;
+    }
+
+    public int ForeachLoop(int[] items)
+    {
+        int sum = 0;
+        foreach (var item in items)
+        {
+            sum += item;
+        }
+        return sum;
+    }
+}

--- a/tests/fixtures/csharp/Simple.cs
+++ b/tests/fixtures/csharp/Simple.cs
@@ -1,0 +1,16 @@
+public class Simple
+{
+    public int SimpleMethod(int x)
+    {
+        return x + 1;
+    }
+
+    public int WithEarlyReturn(int x)
+    {
+        if (x < 0)
+        {
+            return 0;
+        }
+        return x;
+    }
+}

--- a/tests/fixtures/csharp/Switches.cs
+++ b/tests/fixtures/csharp/Switches.cs
@@ -1,0 +1,61 @@
+public class Switches
+{
+    public string DayName(int day)
+    {
+        switch (day)
+        {
+            case 1:
+                return "Monday";
+            case 2:
+                return "Tuesday";
+            case 3:
+                return "Wednesday";
+            default:
+                return "Other";
+        }
+    }
+
+    public int Classify(int x)
+    {
+        switch (x)
+        {
+            case 0:
+                return 0;
+            case 1:
+            case 2:
+                return 1;
+            default:
+                return -1;
+        }
+    }
+
+    public string NoDefault(int x)
+    {
+        switch (x)
+        {
+            case 1:
+                return "one";
+            case 2:
+                return "two";
+        }
+        return "other";
+    }
+
+    public int WithBreak(int x)
+    {
+        int result = 0;
+        switch (x)
+        {
+            case 1:
+                result = 10;
+                break;
+            case 2:
+                result = 20;
+                break;
+            default:
+                result = -1;
+                break;
+        }
+        return result;
+    }
+}

--- a/tests/golden/csharp-exceptions.json
+++ b/tests/golden/csharp-exceptions.json
@@ -1,0 +1,65 @@
+[
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Exceptions.cs",
+    "function": "TryCatch",
+    "language": "C#",
+    "line": 3,
+    "lrs": 4.521928094887363,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 11,
+      "nd": 1,
+      "ns": 2
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 2.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Exceptions.cs",
+    "function": "TryCatchFinally",
+    "language": "C#",
+    "line": 15,
+    "lrs": 4.421928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 1,
+      "loc": 17,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 1.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Exceptions.cs",
+    "function": "ThrowOnNegative",
+    "language": "C#",
+    "line": 33,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 7,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  }
+]

--- a/tests/golden/csharp-loops.json
+++ b/tests/golden/csharp-loops.json
@@ -1,0 +1,86 @@
+[
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Loops.cs",
+    "function": "ForLoop",
+    "language": "C#",
+    "line": 3,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 9,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Loops.cs",
+    "function": "WhileLoop",
+    "language": "C#",
+    "line": 13,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 9,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Loops.cs",
+    "function": "DoWhileLoop",
+    "language": "C#",
+    "line": 23,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 9,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Loops.cs",
+    "function": "ForeachLoop",
+    "language": "C#",
+    "line": 33,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 9,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  }
+]

--- a/tests/golden/csharp-simple.json
+++ b/tests/golden/csharp-simple.json
@@ -1,0 +1,44 @@
+[
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/csharp/Simple.cs",
+    "function": "WithEarlyReturn",
+    "language": "C#",
+    "line": 8,
+    "lrs": 4.521928094887363,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 8,
+      "nd": 1,
+      "ns": 2
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 2.0
+    }
+  },
+  {
+    "band": "low",
+    "file": "tests/fixtures/csharp/Simple.cs",
+    "function": "SimpleMethod",
+    "language": "C#",
+    "line": 3,
+    "lrs": 1.7,
+    "metrics": {
+      "cc": 1,
+      "fo": 0,
+      "loc": 4,
+      "nd": 0,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 1.0,
+      "r_fo": 0.0,
+      "r_nd": 0.0,
+      "r_ns": 1.0
+    }
+  }
+]

--- a/tests/golden/csharp-switches.json
+++ b/tests/golden/csharp-switches.json
@@ -1,0 +1,86 @@
+[
+  {
+    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/csharp/Switches.cs",
+    "function": "DayName",
+    "line": 3,
+    "language": "C#",
+    "metrics": {
+      "cc": 7,
+      "nd": 1,
+      "fo": 0,
+      "ns": 4,
+      "loc": 14
+    },
+    "risk": {
+      "r_cc": 3.0,
+      "r_nd": 1.0,
+      "r_fo": 0.0,
+      "r_ns": 4.0
+    },
+    "lrs": 6.6,
+    "band": "high"
+  },
+  {
+    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/csharp/Switches.cs",
+    "function": "WithBreak",
+    "line": 44,
+    "language": "C#",
+    "metrics": {
+      "cc": 6,
+      "nd": 1,
+      "fo": 0,
+      "ns": 4,
+      "loc": 17
+    },
+    "risk": {
+      "r_cc": 2.807354922057604,
+      "r_nd": 1.0,
+      "r_fo": 0.0,
+      "r_ns": 4.0
+    },
+    "lrs": 6.407354922057604,
+    "band": "high"
+  },
+  {
+    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/csharp/Switches.cs",
+    "function": "Classify",
+    "line": 18,
+    "language": "C#",
+    "metrics": {
+      "cc": 7,
+      "nd": 1,
+      "fo": 0,
+      "ns": 3,
+      "loc": 13
+    },
+    "risk": {
+      "r_cc": 3.0,
+      "r_nd": 1.0,
+      "r_fo": 0.0,
+      "r_ns": 3.0
+    },
+    "lrs": 5.8999999999999995,
+    "band": "moderate"
+  },
+  {
+    "file": "/Users/stephencollins/projects/stephencollins.tech-repos/hotspots/tests/fixtures/csharp/Switches.cs",
+    "function": "NoDefault",
+    "line": 32,
+    "language": "C#",
+    "metrics": {
+      "cc": 5,
+      "nd": 1,
+      "fo": 0,
+      "ns": 3,
+      "loc": 11
+    },
+    "risk": {
+      "r_cc": 2.584962500721156,
+      "r_nd": 1.0,
+      "r_fo": 0.0,
+      "r_ns": 3.0
+    },
+    "lrs": 5.4849625007211555,
+    "band": "moderate"
+  }
+]


### PR DESCRIPTION
## Summary

- Adds full C# (`.cs`) language support via `tree-sitter-c-sharp v0.23.5`
- Discovers `method_declaration`, `constructor_declaration`, `local_function_statement`, `operator_declaration`, and `conversion_operator_declaration`
- CFG builder handles `if`, `while`, `do/while`, `for`, `foreach`, `switch`, `try/catch`, `return`, `throw`, `break`, `continue`
- Metrics extraction: CC (from CFG + ternary/`&&`/`||`/`??` extras), nesting depth, fan-out (invocation_expression), non-structured exits, LOC
- `using` directive import extraction (including `using static`)
- Model detection: `class`, `interface`, `record`, `enum`
- 4 new golden tests (Simple, Loops, Exceptions, determinism) + unit tests for parser and CFG builder
- Closes #54 (partial — C# done; Kotlin and Ruby remain as backlog)

## Test plan

- [x] All 328 unit tests pass
- [x] All 49 golden tests pass (4 new C# ones added)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)