### PR TITLE
feat: add version check and update prompt to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,13 +30,60 @@ esac
 
 ASSET="hotspots-${os}-${arch}.tar.gz"
 
+# ── Resolve latest version (HEAD request only — no body, no API key) ─────────
+#
+# GitHub redirects /releases/latest to /releases/tag/<version>.
+# A HEAD request reveals the tag in the Location header without downloading
+# anything or sending any identifying information.
+
+latest_version() {
+  curl --silent --head --location \
+    "https://github.com/${REPO}/releases/latest" \
+    | grep -i "^location:" \
+    | grep -o 'tag/[^[:space:]]*' \
+    | sed 's|tag/||' \
+    | tr -d '\r'
+}
+
+# ── Check for existing install ────────────────────────────────────────────────
+
+INSTALLED_VERSION=""
+if command -v "$BIN_NAME" >/dev/null 2>&1; then
+  INSTALLED_VERSION="$("$BIN_NAME" --version 2>/dev/null | grep -o 'v[0-9][^ ]*' || true)"
+fi
+
 # ── Resolve download URL ──────────────────────────────────────────────────────
 
 if [ -n "$HOTSPOTS_VERSION" ]; then
-  URL="https://github.com/${REPO}/releases/download/${HOTSPOTS_VERSION}/${ASSET}"
+  TARGET_VERSION="$HOTSPOTS_VERSION"
 else
-  URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+  echo "Checking latest version..."
+  TARGET_VERSION="$(latest_version)"
+  if [ -z "$TARGET_VERSION" ]; then
+    echo "error: could not determine latest version" >&2
+    exit 1
+  fi
 fi
+
+# ── Version comparison ────────────────────────────────────────────────────────
+
+if [ -n "$INSTALLED_VERSION" ]; then
+  if [ "$INSTALLED_VERSION" = "$TARGET_VERSION" ]; then
+    echo "hotspots $INSTALLED_VERSION is already up to date."
+    exit 0
+  fi
+  echo "Update available: $INSTALLED_VERSION → $TARGET_VERSION"
+  printf "Install update? [y/N] "
+  read -r answer
+  case "$answer" in
+    [yY]*) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
+else
+  echo "Installing hotspots $TARGET_VERSION..."
+fi
+
+URL="https://github.com/${REPO}/releases/download/${TARGET_VERSION}/${ASSET}"
 
 # ── Download and install ──────────────────────────────────────────────────────
 
@@ -50,7 +97,7 @@ mkdir -p "$INSTALL_DIR"
 mv "$TMP/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
 chmod +x "$INSTALL_DIR/$BIN_NAME"
 
-echo "Installed to $INSTALL_DIR/$BIN_NAME"
+echo "Installed $TARGET_VERSION to $INSTALL_DIR/$BIN_NAME"
 
 # ── PATH check ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Checks if `hotspots` is already installed before downloading anything
- Fetches latest version via a HEAD request to GitHub's `/releases/latest` redirect — the tag is read from the `Location` header, so no body is downloaded, no JSON API is hit, and no identifying information is sent
- If already up to date, exits immediately with no download
- If an update is available, shows `v1.18.x → v1.19.0` and prompts `[y/N]` before proceeding
- Fresh installs behave exactly as before

## Test plan

- [ ] Fresh install: downloads and installs without prompting
- [ ] Run again when already current: prints "already up to date" and exits
- [ ] Run when update is available: shows version diff and prompts y/N
- [ ] `N` response: exits without downloading
- [ ] `HOTSPOTS_VERSION=vX.Y.Z` pin still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)