### PR TITLE
feat: hotspots train — RandomForest ranker from fix-commit history (v3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file contains conventions and rules for Claude Code when working on this project.
 
+## Research sync
+
+This CLI is the promotion target for `../hotspots-research`. Before implementing any ranker change,
+new snapshot field, or formula modification, check
+[`../hotspots-research/docs/promotion-tracker.md`](../hotspots-research/docs/promotion-tracker.md)
+to confirm the finding is validated and see whether a cross-repo task is already tracked.
+
+When a CLI change completes a promotion, update the tracker row to `promoted` and link the commit or PR.
+
 ## General Principles
 
 - **Keep changes minimal and focused.** Do not refactor, rename, or restructure code beyond what is required for the task at hand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,21 @@ to confirm the finding is validated and see whether a cross-repo task is already
 
 When a CLI change completes a promotion, update the tracker row to `promoted` and link the commit or PR.
 
+### Reading a promotion brief
+
+Each finding that is ready to implement has a brief in
+[`../hotspots-research/docs/promotion-briefs/`](../hotspots-research/docs/promotion-briefs/).
+**Before writing any code for a promoted finding, read its brief.** The brief is the
+authoritative spec — it overrides any general intuition about what "seems right."
+
+Rules for consuming a brief:
+
+- **Files to change** is exhaustive. Do not modify files not listed there.
+- **Exact names** are mandatory. Use the struct fields, flag names, enum variants, and constants exactly as spelled in the brief table.
+- **Do not** is a hard constraint. If the brief says "do not add a flag", do not add it even if it seems useful.
+- **Acceptance criteria** is the definition of done. Mark the brief `done` and update the tracker only when every numbered item passes.
+- If the brief is ambiguous or a criterion cannot be met, note the blocker in the tracker row and ask — do not silently work around it.
+
 ## General Principles
 
 - **Keep changes minimal and focused.** Do not refactor, rename, or restructure code beyond what is required for the task at hand.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +353,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -415,8 +435,13 @@ version = "1.20.2"
 dependencies = [
  "anyhow",
  "globset",
+ "linfa",
+ "linfa-ensemble",
+ "linfa-trees",
+ "ndarray",
  "proc-macro2",
  "quote",
+ "rand",
  "rayon",
  "regex",
  "rusqlite",
@@ -606,7 +631,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -627,6 +652,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +666,44 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linfa"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b84e47ca7a9d63f5be24c104e216c8263bfada38080cbdfe1082e611a81fd3"
+dependencies = [
+ "approx",
+ "ndarray",
+ "num-traits",
+ "rand",
+ "sprs",
+ "thiserror",
+]
+
+[[package]]
+name = "linfa-ensemble"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e48cb23c1b19c12ab2e376e26d904730aabdd6db971be959a056ee0129ba28"
+dependencies = [
+ "linfa",
+ "linfa-trees",
+ "ndarray",
+ "ndarray-rand",
+ "rand",
+]
+
+[[package]]
+name = "linfa-trees"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a11824d0811f8a2d3ae95a6498babc49fc63240d33b8753358e8be105ee2c38"
+dependencies = [
+ "linfa",
+ "ndarray",
+ "ndarray-rand",
 ]
 
 [[package]]
@@ -656,10 +725,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+ "rayon",
+]
+
+[[package]]
+name = "ndarray-rand"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f093b3db6fd194718dcdeea6bd8c829417deae904e3fcc7732dabcd4416d25d8"
+dependencies = [
+ "ndarray",
+ "rand",
+ "rand_distr",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -679,6 +786,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -790,12 +907,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -838,6 +973,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -846,6 +993,25 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -1033,6 +1199,18 @@ dependencies = [
  "autocfg",
  "static_assertions",
  "version_check",
+]
+
+[[package]]
+name = "sprs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704ef26d974e8a452313ed629828cd9d4e4fa34667ca1ad9d6b1fffa43c6e166"
+dependencies = [
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -1235,10 +1413,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1415,6 +1613,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ Your CI fails if someone introduces high-risk code. No manual review needed.
 
 > **GitHub Action coming soon.** A native `hotspots-action` for GitHub Actions is not yet available. Use the CLI directly in your workflows in the meantime.
 
+### ✅ Fine-Tune Rankings with Repo-Specific ML
+
+The default heuristic ranker works out of the box, but every codebase is different. Train a local RandomForest ranker from your own fix-commit history to score functions based on patterns that actually predict bugs in your repo:
+
+```bash
+# Fit a ranker from the last year of fix commits (precise blame-based labels)
+hotspots train . --blame
+
+# Next analyze picks up the trained ranker automatically
+hotspots analyze .
+```
+
+The trained model learns which structural features (complexity, churn, call graph) correlate with real bug fixes in your history — not a generic heuristic. Scores are saved to `.hotspots/ranker.json` and reused on every subsequent `analyze`.
+
 ### ✅ Ship with Confidence, Not Crossed Fingers
 
 Know which files are landmines before you touch them. See complexity trends over time. Make informed decisions about refactoring vs rewriting vs leaving it alone.
@@ -410,6 +424,9 @@ hotspots diff main HEAD --top 10 --policy
 # See complexity trends
 hotspots trends .
 
+# Train a repo-specific ranker from fix-commit history
+hotspots train . --blame
+
 # Prune unreachable snapshots (after force-push or branch deletion)
 hotspots prune --unreachable --older-than 30
 
@@ -441,7 +458,7 @@ hotspots config validate
 
 - 🚀 [Quick Start](docs/getting-started/quick-start.md) - Get started in 5 minutes
 - 📖 [CLI Reference](docs/reference/cli.md) - All commands and options
-- 🎯 GitHub Action - CI/CD integration *(coming soon)*
+- 🎯 [CI Integration](docs/guide/ci-integration.md) - GitHub Actions, GitLab CI
 - 🤖 [AI Integration](docs/integrations/ai-agents.md) - Claude, Cursor, Copilot
 - 🏗️ [Architecture](docs/architecture/overview.md) - How it works
 - 🤝 [Contributing](docs/contributing/index.md) - Add languages, fix bugs, improve docs
@@ -550,7 +567,8 @@ MIT License - see [LICENSE-MIT](LICENSE-MIT) for details.
 2. 🔍 Run your first analysis: `hotspots analyze src/`
 3. 🎯 Identify your top 10 hotspots
 4. 🛠️ Refactor the worst offender
-5. 📊 Add to CI/CD: `hotspots analyze src/ --mode delta --policy` (GitHub Action coming soon)
+5. 📊 Add to CI/CD: `hotspots analyze src/ --mode delta --policy`
+6. 🧠 Train a repo-specific ranker: `hotspots train . --blame`
 6. 🤖 Integrate with AI: [AI Integration Guide](docs/integrations/ai-agents.md)
 
 **Questions?** Open a [GitHub Discussion](https://github.com/Stephen-Collins-tech/hotspots/discussions).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -425,6 +425,113 @@ hotspots analyze src/ --mode snapshot --format json --explain-patterns
 
 ---
 
+### `hotspots train`
+
+Fit a local RandomForest ranker from the repo's own fix-commit git history.
+
+The trained model scores functions based on which structural features (complexity, churn, call graph) correlate with real bugs in your codebase — not a generic heuristic. Once trained, `hotspots analyze` picks up the ranker automatically and uses it to recompute triage quadrants.
+
+#### Usage
+
+```bash
+# Train with file-level labels (fast)
+hotspots train .
+
+# Train with blame-based function-level labels (more precise, slower)
+hotspots train . --blame
+
+# Custom label window and output path
+hotspots train . --blame --label-window 180 --output .hotspots/ranker.json
+```
+
+#### Arguments
+
+##### `[PATH]`
+**Optional.** Path to repository root.
+**Default:** `.` (current directory)
+
+```bash
+hotspots train /path/to/repo --blame
+```
+
+#### Options
+
+##### `--blame`
+**Optional.** Use blame-based function-level labelling instead of file-level labelling.
+
+Without `--blame`, every function in a file touched by a fix commit is marked positive. With `--blame`, `git diff-tree` hunk headers are parsed to identify the exact function that owned the changed lines — only that function is marked positive.
+
+**Trade-off:** More precise signal but one `git diff-tree` subprocess per fix commit. Recommended for repos with many large files.
+
+```bash
+# File-level labels (default): fast, noisy
+hotspots train .
+
+# Blame-based function labels: slower, more precise
+hotspots train . --blame
+```
+
+##### `--label-window <DAYS>`
+**Optional.** Days of git history to scan for fix-commit labels.
+**Default:** `365`
+
+```bash
+# Use 6 months of history
+hotspots train . --blame --label-window 180
+```
+
+##### `--n-estimators <N>`
+**Optional.** Number of trees in the RandomForest.
+**Default:** `200`
+
+##### `--max-depth <N>`
+**Optional.** Maximum tree depth.
+**Default:** `6`
+
+##### `--output <PATH>`
+**Optional.** Output path for the trained model JSON.
+**Default:** `.hotspots/ranker.json`
+
+#### Training signal requirements
+
+Training returns an error if the snapshot has fewer than 50 functions, or if the fix scan yields fewer than 5 positive or 10 negative labels. If this happens:
+
+- Try a larger `--label-window` (e.g. `--label-window 730` for 2 years)
+- Run `hotspots analyze . --mode snapshot --force` to regenerate a fresh snapshot
+- Check that your fix commits use conventional keywords (`fix:`, `bug`, `patch`, `hotfix`, `regression`, `defect`)
+
+#### How it integrates with `hotspots analyze`
+
+Once `.hotspots/ranker.json` exists, `hotspots analyze` automatically:
+
+1. Loads the ranker and scores every function
+2. Uses RF scores in place of the activity heuristic to determine triage quadrants
+3. Promotes high-RF functions from `debt` → `fire` where warranted
+
+The suppression gate runs on every `analyze` to verify the heuristic ranker is working. If it detects poor P@10, it recommends running `hotspots train`.
+
+#### Feature set
+
+The v3 model trains on 8 structural features: `lrs`, `cc`, `nd`, `loc`, `fo`, `fan_in`, `total_churn`, `authors_90d`. Windowed activity signals (`touch_count_30d`, `days_since_last_change`, `activity_risk`) are deliberately excluded to prevent temporal leakage from the label scan window.
+
+#### Examples
+
+```bash
+# Basic training (fast, file-level labels)
+hotspots train .
+
+# Precise blame-based training
+hotspots train . --blame
+
+# Train on a specific repo with 2-year history
+hotspots train /path/to/repo --blame --label-window 730
+
+# Re-train after new commits land
+hotspots train . --blame && hotspots analyze .
+```
+
+---
+
 ### `hotspots prune`
 
 Prune unreachable snapshots to reduce storage.
@@ -1069,3 +1176,4 @@ hotspots analyze . --mode snapshot --force         # overwrite existing snapshot
 - [Output Formats](../guide/output-formats.md) - JSON schema, HTML reports
 - [LRS Specification](./lrs-spec.md) - How LRS is calculated
 - [Policy Engine](../guide/usage.md#policy-engine) - Policy rules and enforcement
+- [`hotspots train`](#hotspots-train) - Repo-specific ML ranker from fix-commit history

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -452,6 +452,13 @@ fn handle_snapshot_mode(
 
     let ranker_applied = apply_trained_ranker(repo_root, &mut snapshot);
 
+    // Re-run quadrant assignment now that activity_risk reflects trained RF scores.
+    // This promotes debt→fire for functions with high predicted fix probability (≥0.7)
+    // even if they haven't been touched in the last 30 days.
+    if ranker_applied {
+        snapshot.compute_quadrants(resolved_config.driver_threshold_percentile, true);
+    }
+
     let total_function_count = snapshot.functions.len();
 
     // Suppression gate: check if the activity ranker is working on this repo.

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -412,27 +412,30 @@ fn handle_snapshot_mode(
         snapshot::append_to_index(repo_root, &snapshot).context("failed to update index")?;
     }
 
-    apply_trained_ranker(repo_root, &mut snapshot);
+    let ranker_applied = apply_trained_ranker(repo_root, &mut snapshot);
 
     let total_function_count = snapshot.functions.len();
 
     // Suppression gate: check if the activity ranker is working on this repo.
     // Run on the full sorted snapshot (before top-N truncation) so calibration
     // sees a representative top-50.
+    // Inconclusive is silent — it fires on greenfield repos or non-conventional
+    // commit histories and is not actionable.
     let gate_verdict = check_gate(repo_root, &snapshot.functions, &GateConfig::default());
-    match &gate_verdict {
-        GateVerdict::Suppressed {
-            p_at_10, threshold, ..
-        } => {
+    if let GateVerdict::Suppressed {
+        p_at_10, threshold, ..
+    } = &gate_verdict
+    {
+        if ranker_applied {
             eprintln!(
-                "warning: suppression gate fired — activity ranker P@10={p_at_10:.2} < {threshold:.2} on this repo."
+                "hotspots: activity ranker P@10={p_at_10:.2} (< {threshold:.2}); using trained ranker instead."
             );
-            eprintln!("         Rankings may be misleading. Consider running: hotspots classify");
+        } else {
+            eprintln!(
+                "hotspots: warning: activity ranker P@10={p_at_10:.2} < {threshold:.2} — rankings may be misleading."
+            );
+            eprintln!("          Run `hotspots train` to fit a local ranker from this repo's fix history.");
         }
-        GateVerdict::Inconclusive { reason } => {
-            eprintln!("info: suppression gate inconclusive — {reason}");
-        }
-        GateVerdict::Pass { .. } => {}
     }
 
     apply_top_n(&mut snapshot, format, explain, level, top);
@@ -806,23 +809,24 @@ fn apply_top_n(
 }
 
 /// If `.hotspots/ranker.json` exists, overwrite each function's `activity_risk`
-/// with the trained model's vote score.  Silent no-op if the model is absent or
-/// fails to load — the formula score is the fallback.
-fn apply_trained_ranker(repo_root: &Path, snapshot: &mut Snapshot) {
+/// with the trained model's vote score.  Returns true if the ranker was applied.
+/// Silent no-op (returns false) if the model is absent or fails to load.
+fn apply_trained_ranker(repo_root: &Path, snapshot: &mut Snapshot) -> bool {
     let model_path = snapshot::hotspots_dir(repo_root).join("ranker.json");
     if !model_path.exists() {
-        return;
+        return false;
     }
     let model = match hotspots_core::trainer::RankerModel::load(&model_path) {
         Ok(m) => m,
         Err(e) => {
             eprintln!("hotspots: warning: failed to load ranker.json: {e}");
-            return;
+            return false;
         }
     };
     for func in &mut snapshot.functions {
         func.activity_risk = Some(hotspots_core::trainer::score(&model, func));
     }
+    true
 }
 
 fn write_snapshot_json_file<F>(output_path: &Path, write: F) -> anyhow::Result<()>

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -218,6 +218,44 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         return result;
     }
 
+    // If a trained ranker exists, promote to snapshot mode so activity_risk
+    // fields are populated and the ranker can be applied. The ranker has no
+    // effect in the default LRS-only path.
+    let repo_root_for_ranker =
+        find_repo_root(&normalized_path).unwrap_or_else(|_| normalized_path.clone());
+    let ranker_path = snapshot::hotspots_dir(&repo_root_for_ranker).join("ranker.json");
+    if ranker_path.exists() {
+        let result = handle_mode_output(
+            &normalized_path,
+            OutputMode::Snapshot,
+            &resolved_config,
+            ModeOutputOptions {
+                format,
+                policy: false,
+                top: effective_top,
+                min_lrs: effective_min_lrs,
+                output,
+                explain: matches!(format, OutputFormat::Text),
+                force,
+                no_persist: true, // default analyze doesn't persist snapshots
+                level,
+                touch_mode: effective_touch_mode,
+                all_functions: false,
+                include_models: false,
+                explain_patterns,
+                source_url,
+                callgraph_skip_above,
+                skip_touch_metrics: touch_args.skip,
+            },
+        );
+        if touch_args.is_default(&resolved_config) {
+            eprintln!(
+                "tip: ran with hybrid touch mode (default). For full per-function precision, rerun with --per-function-touches."
+            );
+        }
+        return result;
+    }
+
     // Default behavior (no --mode): simple text/JSON output
     handle_default_output(
         &normalized_path,

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -411,6 +411,8 @@ fn handle_snapshot_mode(
         snapshot::append_to_index(repo_root, &snapshot).context("failed to update index")?;
     }
 
+    apply_trained_ranker(repo_root, &mut snapshot);
+
     let total_function_count = snapshot.functions.len();
     apply_top_n(&mut snapshot, format, explain, level, top);
 
@@ -779,6 +781,26 @@ fn apply_top_n(
         if let Some(n) = top {
             snapshot.functions.truncate(n);
         }
+    }
+}
+
+/// If `.hotspots/ranker.json` exists, overwrite each function's `activity_risk`
+/// with the trained model's vote score.  Silent no-op if the model is absent or
+/// fails to load — the formula score is the fallback.
+fn apply_trained_ranker(repo_root: &Path, snapshot: &mut Snapshot) {
+    let model_path = snapshot::hotspots_dir(repo_root).join("ranker.json");
+    if !model_path.exists() {
+        return;
+    }
+    let model = match hotspots_core::trainer::RankerModel::load(&model_path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("hotspots: warning: failed to load ranker.json: {e}");
+            return;
+        }
+    };
+    for func in &mut snapshot.functions {
+        func.activity_risk = Some(hotspots_core::trainer::score(&model, func));
     }
 }
 

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -3,6 +3,7 @@ use crate::util::{find_repo_root, write_html_report};
 use crate::{OutputFormat, OutputLevel, OutputMode};
 use anyhow::Context;
 use hotspots_core::delta::Delta;
+use hotspots_core::gate::{check_gate, GateConfig, GateVerdict};
 use hotspots_core::snapshot::{self, Snapshot};
 use hotspots_core::TouchMode;
 use hotspots_core::{analyze_with_progress, AnalysisOptions};
@@ -414,6 +415,26 @@ fn handle_snapshot_mode(
     apply_trained_ranker(repo_root, &mut snapshot);
 
     let total_function_count = snapshot.functions.len();
+
+    // Suppression gate: check if the activity ranker is working on this repo.
+    // Run on the full sorted snapshot (before top-N truncation) so calibration
+    // sees a representative top-50.
+    let gate_verdict = check_gate(repo_root, &snapshot.functions, &GateConfig::default());
+    match &gate_verdict {
+        GateVerdict::Suppressed {
+            p_at_10, threshold, ..
+        } => {
+            eprintln!(
+                "warning: suppression gate fired — activity ranker P@10={p_at_10:.2} < {threshold:.2} on this repo."
+            );
+            eprintln!("         Rankings may be misleading. Consider running: hotspots classify");
+        }
+        GateVerdict::Inconclusive { reason } => {
+            eprintln!("info: suppression gate inconclusive — {reason}");
+        }
+        GateVerdict::Pass { .. } => {}
+    }
+
     apply_top_n(&mut snapshot, format, explain, level, top);
 
     emit_snapshot_output(

--- a/hotspots-cli/src/cmd/mod.rs
+++ b/hotspots-cli/src/cmd/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod config;
 pub(crate) mod diff;
 pub(crate) mod init;
 pub(crate) mod prune;
+pub(crate) mod train;
 pub(crate) mod trends;

--- a/hotspots-cli/src/cmd/train.rs
+++ b/hotspots-cli/src/cmd/train.rs
@@ -1,0 +1,87 @@
+//! `hotspots train` — fit a local RandomForest ranker from git history.
+
+use anyhow::{bail, Context, Result};
+use hotspots_core::snapshot::{index_path, load_snapshot, Snapshot};
+use hotspots_core::trainer::{train, RankerModel, TrainConfig};
+use std::path::{Path, PathBuf};
+
+pub(crate) struct TrainArgs {
+    pub path: PathBuf,
+    pub output: PathBuf,
+    pub label_window_days: u32,
+    pub n_estimators: usize,
+    pub max_depth: usize,
+}
+
+pub(crate) fn handle_train(args: TrainArgs) -> Result<()> {
+    let repo_root = args.path.canonicalize().context("resolve repo path")?;
+    let snapshot = load_latest_snapshot(&repo_root)?;
+
+    let cfg = TrainConfig {
+        label_window_days: args.label_window_days,
+        n_estimators: args.n_estimators,
+        max_depth: args.max_depth,
+        ..Default::default()
+    };
+
+    let n_funcs = snapshot.functions.len();
+    eprintln!(
+        "hotspots train: {} functions in snapshot, scanning {} days of git history for fix commits…",
+        n_funcs, cfg.label_window_days
+    );
+
+    match train(&snapshot, &repo_root, &cfg)? {
+        None => {
+            bail!(
+                "Not enough training signal: need ≥20 functions and ≥2 positive/negative labels. \
+                 Try a larger --label-window or run `hotspots analyze` first to build a snapshot."
+            );
+        }
+        Some(model) => {
+            report_model(&model, n_funcs);
+            model.save(&args.output)?;
+            eprintln!("Model saved → {}", args.output.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn load_latest_snapshot(repo_root: &Path) -> Result<Snapshot> {
+    let idx_path = index_path(repo_root);
+    if !idx_path.exists() {
+        bail!(
+            "No snapshot index found at {}. Run `hotspots analyze .` first.",
+            idx_path.display()
+        );
+    }
+
+    let json = std::fs::read_to_string(&idx_path)
+        .with_context(|| format!("read {}", idx_path.display()))?;
+    let index = hotspots_core::snapshot::Index::from_json(&json).context("parse index")?;
+
+    let entry = index
+        .commits
+        .last()
+        .context("snapshot index is empty — run `hotspots analyze .` first")?;
+
+    let sha = entry.sha.clone();
+    let snapshot = load_snapshot(repo_root, &sha)
+        .context("load snapshot")?
+        .with_context(|| format!("snapshot {} not found on disk", sha))?;
+
+    eprintln!("Loaded snapshot {}", &sha[..8.min(sha.len())]);
+    Ok(snapshot)
+}
+
+fn report_model(model: &RankerModel, n_funcs: usize) {
+    let m = &model.meta;
+    let base_rate = m.n_pos as f64 / m.n_samples as f64;
+    eprintln!(
+        "Trained: {} trees × depth {} | {} samples ({} pos, {} neg) | base rate {:.1}% | {} functions in repo",
+        m.n_estimators, m.max_depth,
+        m.n_samples, m.n_pos, m.n_neg,
+        base_rate * 100.0,
+        n_funcs,
+    );
+}

--- a/hotspots-cli/src/cmd/train.rs
+++ b/hotspots-cli/src/cmd/train.rs
@@ -18,6 +18,14 @@ pub(crate) fn handle_train(args: TrainArgs) -> Result<()> {
     let repo_root = args.path.canonicalize().context("resolve repo path")?;
     let snapshot = load_latest_snapshot(&repo_root)?;
 
+    // Resolve relative --output against repo_root, not CWD.
+    let output = if args.output.is_relative() {
+        repo_root.join(&args.output)
+    } else {
+        args.output.clone()
+    };
+    let args = TrainArgs { output, ..args };
+
     let cfg = TrainConfig {
         label_window_days: args.label_window_days,
         n_estimators: args.n_estimators,

--- a/hotspots-cli/src/cmd/train.rs
+++ b/hotspots-cli/src/cmd/train.rs
@@ -11,6 +11,7 @@ pub(crate) struct TrainArgs {
     pub label_window_days: u32,
     pub n_estimators: usize,
     pub max_depth: usize,
+    pub blame_labels: bool,
 }
 
 pub(crate) fn handle_train(args: TrainArgs) -> Result<()> {
@@ -21,19 +22,25 @@ pub(crate) fn handle_train(args: TrainArgs) -> Result<()> {
         label_window_days: args.label_window_days,
         n_estimators: args.n_estimators,
         max_depth: args.max_depth,
+        blame_labels: args.blame_labels,
         ..Default::default()
     };
 
     let n_funcs = snapshot.functions.len();
+    let label_mode = if cfg.blame_labels {
+        "blame-based function labels"
+    } else {
+        "file-level labels"
+    };
     eprintln!(
-        "hotspots train: {} functions in snapshot, scanning {} days of git history for fix commits…",
-        n_funcs, cfg.label_window_days
+        "hotspots train: {} functions in snapshot, scanning {} days of git history ({})…",
+        n_funcs, cfg.label_window_days, label_mode
     );
 
     match train(&snapshot, &repo_root, &cfg)? {
         None => {
             bail!(
-                "Not enough training signal: need ≥20 functions and ≥2 positive/negative labels. \
+                "Not enough training signal: need ≥50 labelled functions, ≥5 positive and ≥10 negative. \
                  Try a larger --label-window or run `hotspots analyze` first to build a snapshot."
             );
         }

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -212,6 +212,28 @@ enum Commands {
         #[arg(long)]
         auto_analyze: bool,
     },
+    /// Train a local RandomForest ranker from fix-commit history
+    Train {
+        /// Path to repository root
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Output path for the trained model (JSON)
+        #[arg(long, default_value = ".hotspots/ranker.json")]
+        output: PathBuf,
+
+        /// Days of git history to scan for fix-commit labels
+        #[arg(long, default_value = "365")]
+        label_window: u32,
+
+        /// Number of trees in the RandomForest
+        #[arg(long, default_value = "200")]
+        n_estimators: usize,
+
+        /// Maximum tree depth
+        #[arg(long, default_value = "6")]
+        max_depth: usize,
+    },
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]
@@ -319,6 +341,19 @@ fn main() -> anyhow::Result<()> {
             top,
             config_path: config,
             auto_analyze,
+        })?,
+        Commands::Train {
+            path,
+            output,
+            label_window,
+            n_estimators,
+            max_depth,
+        } => cmd::train::handle_train(cmd::train::TrainArgs {
+            path,
+            output,
+            label_window_days: label_window,
+            n_estimators,
+            max_depth,
         })?,
     }
 

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -233,6 +233,12 @@ enum Commands {
         /// Maximum tree depth
         #[arg(long, default_value = "6")]
         max_depth: usize,
+
+        /// Use blame-based function-level labelling instead of file-level labelling.
+        /// More precise labels (only the function that owned the changed lines is
+        /// marked positive) but slower on repos with many fix commits.
+        #[arg(long, default_value = "false")]
+        blame: bool,
     },
 }
 
@@ -348,12 +354,14 @@ fn main() -> anyhow::Result<()> {
             label_window,
             n_estimators,
             max_depth,
+            blame,
         } => cmd::train::handle_train(cmd::train::TrainArgs {
             path,
             output,
             label_window_days: label_window,
             n_estimators,
             max_depth,
+            blame_labels: blame,
         })?,
     }
 

--- a/hotspots-core/Cargo.toml
+++ b/hotspots-core/Cargo.toml
@@ -38,6 +38,11 @@ tree-sitter-go = "0.25"
 tree-sitter-java = "0.23"
 tree-sitter-python = "0.23"
 tree-sitter-c-sharp = "0.23"
+linfa = "0.8.1"
+linfa-trees = "0.8.1"
+linfa-ensemble = "0.8.1"
+rand = { version = "0.8", features = ["small_rng"] }
+ndarray = "0.16"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -1100,6 +1100,7 @@ mod tests {
             patterns: vec![],
             pattern_details: None,
             subsystem: None,
+            authors_90d: None,
         }
     }
 

--- a/hotspots-core/src/db/mod.rs
+++ b/hotspots-core/src/db/mod.rs
@@ -431,6 +431,7 @@ fn load_functions(conn: &Connection, sha: &str) -> Result<Vec<FunctionSnapshot>>
             patterns,
             pattern_details: None,
             subsystem: None,
+            authors_90d: None,
         });
     }
 

--- a/hotspots-core/src/gate.rs
+++ b/hotspots-core/src/gate.rs
@@ -1,0 +1,266 @@
+//! Suppression gate: detect when the activity-based ranker has failed on this repo
+//! and recommend falling back to a code-semantic classifier.
+//!
+//! ## How it works
+//!
+//! 1. Scan the last 90 days of git history for commits whose message matches a
+//!    fix-keyword heuristic (same as `detect_fix_commit`).
+//! 2. Collect the set of files touched by those fix commits.
+//! 3. Take the top-N functions by their current hotspot score (activity_risk or lrs).
+//! 4. Compute P@10: of the top-10 functions, how many are in fix-touched files?
+//! 5. If P@10 < threshold → the ranker has failed; return `GateVerdict::Suppressed`.
+//!
+//! ## Why calibrate on the top of the ranking?
+//!
+//! A random calibration sample has ~base_rate positives by chance, so it looks
+//! fine even when the ranker is broken. Evaluating the top-N exposes failure
+//! directly: if the ranker is working, the top functions should be bug-prone;
+//! if it's not, they won't be.
+//!
+//! ## Promotion note
+//!
+//! The binary labels come from an on-the-fly commit scan — no pre-built holdout
+//! required. The 90-day window matches the prediction horizon in both the ranker
+//! and the LLM fallback prompt.
+
+use crate::snapshot::FunctionSnapshot;
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+/// Result of the suppression gate check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GateVerdict {
+    /// Ranker appears to be working — P@10 ≥ threshold.
+    Pass {
+        p_at_10: f64,
+        fix_files_found: usize,
+    },
+    /// Ranker has failed — P@10 < threshold. Recommend LLM fallback.
+    Suppressed {
+        p_at_10: f64,
+        fix_files_found: usize,
+        threshold: f64,
+    },
+    /// Not enough data to calibrate (too few fix commits or functions).
+    Inconclusive { reason: String },
+}
+
+impl GateVerdict {
+    pub fn is_suppressed(&self) -> bool {
+        matches!(self, GateVerdict::Suppressed { .. })
+    }
+
+    pub fn p_at_10(&self) -> Option<f64> {
+        match self {
+            GateVerdict::Pass { p_at_10, .. } => Some(*p_at_10),
+            GateVerdict::Suppressed { p_at_10, .. } => Some(*p_at_10),
+            GateVerdict::Inconclusive { .. } => None,
+        }
+    }
+}
+
+/// Configuration for the suppression gate.
+#[derive(Debug, Clone)]
+pub struct GateConfig {
+    /// Number of days of git history to scan for fix commits.
+    pub window_days: u32,
+    /// Number of top-ranked functions to use for calibration.
+    pub cal_n: usize,
+    /// P@10 below this → suppress the ranker.
+    pub threshold: f64,
+}
+
+impl Default for GateConfig {
+    fn default() -> Self {
+        GateConfig {
+            window_days: 90,
+            cal_n: 50,
+            threshold: 0.5,
+        }
+    }
+}
+
+/// Run the suppression gate against the current repo and scored functions.
+///
+/// `functions` must already be scored (activity_risk populated where available)
+/// and sorted descending by score — i.e. the output of `sort_reports` or equivalent.
+pub fn check_gate(
+    repo_root: &Path,
+    functions: &[FunctionSnapshot],
+    config: &GateConfig,
+) -> GateVerdict {
+    let fix_files = match scan_fix_files(repo_root, config.window_days) {
+        Ok(f) => f,
+        Err(e) => {
+            return GateVerdict::Inconclusive {
+                reason: format!("git scan failed: {e}"),
+            }
+        }
+    };
+
+    if fix_files.is_empty() {
+        return GateVerdict::Inconclusive {
+            reason: format!("no fix commits found in last {} days", config.window_days),
+        };
+    }
+
+    if functions.len() < 10 {
+        return GateVerdict::Inconclusive {
+            reason: format!("too few functions to compute P@10 ({})", functions.len()),
+        };
+    }
+
+    // Score top-cal_n functions descending (functions is already sorted)
+    let cal_n = config.cal_n.min(functions.len());
+    let top_n = &functions[..cal_n];
+
+    // P@10: of top-10, how many files are in the fix-touched set?
+    let p_at_10 = precision_at_k(top_n, &fix_files, 10);
+
+    if p_at_10 < config.threshold {
+        GateVerdict::Suppressed {
+            p_at_10,
+            fix_files_found: fix_files.len(),
+            threshold: config.threshold,
+        }
+    } else {
+        GateVerdict::Pass {
+            p_at_10,
+            fix_files_found: fix_files.len(),
+        }
+    }
+}
+
+/// Scan git history for files touched by fix commits in the last `window_days` days.
+fn scan_fix_files(repo_root: &Path, window_days: u32) -> anyhow::Result<HashSet<String>> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let since = now - (window_days as i64 * 24 * 60 * 60);
+    let since_arg = format!("--since={since}");
+
+    let result = Command::new("git")
+        .args(["log", "--format=COMMIT %s", "--name-only", &since_arg])
+        .current_dir(repo_root)
+        .output()?;
+
+    if !result.status.success() {
+        anyhow::bail!(
+            "git log failed: {}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+    }
+
+    let output = String::from_utf8_lossy(&result.stdout).into_owned();
+
+    let mut fix_files = HashSet::new();
+    let mut in_fix_commit = false;
+
+    for line in output.lines() {
+        if let Some(subject) = line.strip_prefix("COMMIT ") {
+            in_fix_commit = crate::git::detect_fix_commit(subject);
+        } else if in_fix_commit && !line.trim().is_empty() {
+            fix_files.insert(line.trim().to_string());
+        }
+    }
+
+    Ok(fix_files)
+}
+
+/// Precision at K: of the top-K functions by score, what fraction are in fix-touched files?
+fn precision_at_k(functions: &[FunctionSnapshot], fix_files: &HashSet<String>, k: usize) -> f64 {
+    let k = k.min(functions.len());
+    if k == 0 {
+        return 0.0;
+    }
+    let hits = functions[..k]
+        .iter()
+        .filter(|f| fix_files.contains(&f.file))
+        .count();
+    hits as f64 / k as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fix_set(files: &[&str]) -> HashSet<String> {
+        files.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn stub_fns(files: &[&str]) -> Vec<FunctionSnapshot> {
+        // Build minimal FunctionSnapshot values using serde_json round-trip
+        // to avoid depending on internal constructors.
+        files
+            .iter()
+            .enumerate()
+            .map(|(i, &file)| {
+                let score = (files.len() - i) as f64;
+                let json = serde_json::json!({
+                    "function_id": format!("fn_{i}"),
+                    "file": file,
+                    "line": 1u32,
+                    "language": "Rust",
+                    "metrics": {"cc":1,"nd":0,"fo":0,"ns":0,"loc":5},
+                    "lrs": score,
+                    "band": "low",
+                    "activity_risk": score,
+                });
+                serde_json::from_value(json).unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_precision_at_k_perfect() {
+        let files = [
+            "a.rs", "b.rs", "c.rs", "d.rs", "e.rs", "f.rs", "g.rs", "h.rs", "i.rs", "j.rs",
+        ];
+        let fns = stub_fns(&files);
+        let fix_files = fix_set(&files);
+        assert_eq!(precision_at_k(&fns, &fix_files, 10), 1.0);
+    }
+
+    #[test]
+    fn test_precision_at_k_zero() {
+        let files = [
+            "s1.rs", "s2.rs", "s3.rs", "s4.rs", "s5.rs", "s6.rs", "s7.rs", "s8.rs", "s9.rs",
+            "s10.rs",
+        ];
+        let fns = stub_fns(&files);
+        let fix_files = fix_set(&["bug.rs"]);
+        assert_eq!(precision_at_k(&fns, &fix_files, 10), 0.0);
+    }
+
+    #[test]
+    fn test_precision_at_k_partial() {
+        let files = [
+            "bug.rs", "s2.rs", "s3.rs", "s4.rs", "s5.rs", "s6.rs", "s7.rs", "s8.rs", "s9.rs",
+            "s10.rs",
+        ];
+        let fns = stub_fns(&files);
+        let fix_files = fix_set(&["bug.rs"]);
+        assert!((precision_at_k(&fns, &fix_files, 10) - 0.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_gate_verdict_pass() {
+        assert!(!GateVerdict::Pass {
+            p_at_10: 0.8,
+            fix_files_found: 5
+        }
+        .is_suppressed());
+    }
+
+    #[test]
+    fn test_gate_verdict_suppressed() {
+        assert!(GateVerdict::Suppressed {
+            p_at_10: 0.0,
+            fix_files_found: 3,
+            threshold: 0.5
+        }
+        .is_suppressed());
+    }
+}

--- a/hotspots-core/src/gate.rs
+++ b/hotspots-core/src/gate.rs
@@ -24,6 +24,7 @@
 //! and the LLM fallback prompt.
 
 use crate::snapshot::FunctionSnapshot;
+use crate::trainer::{make_rel, repo_prefixes};
 use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
@@ -111,12 +112,15 @@ pub fn check_gate(
         };
     }
 
-    // Score top-cal_n functions descending (functions is already sorted)
+    // Score top-cal_n functions descending (functions is already sorted).
+    // Snapshot paths are absolute; fix_files has repo-relative paths from git log.
+    // Normalise before comparison so the sets can actually intersect.
+    let (prefix_can, prefix_raw) = repo_prefixes(repo_root);
     let cal_n = config.cal_n.min(functions.len());
     let top_n = &functions[..cal_n];
 
     // P@10: of top-10, how many files are in the fix-touched set?
-    let p_at_10 = precision_at_k(top_n, &fix_files, 10);
+    let p_at_10 = precision_at_k(top_n, &fix_files, 10, &prefix_can, &prefix_raw);
 
     if p_at_10 < config.threshold {
         GateVerdict::Suppressed {
@@ -170,14 +174,20 @@ fn scan_fix_files(repo_root: &Path, window_days: u32) -> anyhow::Result<HashSet<
 }
 
 /// Precision at K: of the top-K functions by score, what fraction are in fix-touched files?
-fn precision_at_k(functions: &[FunctionSnapshot], fix_files: &HashSet<String>, k: usize) -> f64 {
+fn precision_at_k(
+    functions: &[FunctionSnapshot],
+    fix_files: &HashSet<String>,
+    k: usize,
+    prefix_can: &str,
+    prefix_raw: &str,
+) -> f64 {
     let k = k.min(functions.len());
     if k == 0 {
         return 0.0;
     }
     let hits = functions[..k]
         .iter()
-        .filter(|f| fix_files.contains(&f.file))
+        .filter(|f| fix_files.contains(&make_rel(&f.file, prefix_can, prefix_raw)))
         .count();
     hits as f64 / k as f64
 }
@@ -220,7 +230,7 @@ mod tests {
         ];
         let fns = stub_fns(&files);
         let fix_files = fix_set(&files);
-        assert_eq!(precision_at_k(&fns, &fix_files, 10), 1.0);
+        assert_eq!(precision_at_k(&fns, &fix_files, 10, "", ""), 1.0);
     }
 
     #[test]
@@ -231,7 +241,7 @@ mod tests {
         ];
         let fns = stub_fns(&files);
         let fix_files = fix_set(&["bug.rs"]);
-        assert_eq!(precision_at_k(&fns, &fix_files, 10), 0.0);
+        assert_eq!(precision_at_k(&fns, &fix_files, 10, "", ""), 0.0);
     }
 
     #[test]
@@ -242,7 +252,7 @@ mod tests {
         ];
         let fns = stub_fns(&files);
         let fix_files = fix_set(&["bug.rs"]);
-        assert!((precision_at_k(&fns, &fix_files, 10) - 0.1).abs() < 1e-9);
+        assert!((precision_at_k(&fns, &fix_files, 10, "", "") - 0.1).abs() < 1e-9);
     }
 
     #[test]

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod config;
 pub mod db;
 pub mod delta;
 pub mod discover;
+pub mod gate;
 pub mod git;
 pub mod html;
 pub mod imports;

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod scoring;
 pub mod snapshot;
 pub mod suppression;
 pub mod touch_cache;
+pub mod trainer;
 pub mod trends;
 
 pub use callgraph::CallGraph;

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -680,6 +680,7 @@ mod tests {
             patterns: vec![],
             pattern_details: None,
             subsystem: None,
+            authors_90d: None,
         }
     }
 

--- a/hotspots-core/src/sarif.rs
+++ b/hotspots-core/src/sarif.rs
@@ -286,6 +286,7 @@ mod tests {
             patterns: vec![],
             pattern_details: None,
             subsystem: None,
+            authors_90d: None,
         }
     }
 

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -189,6 +189,14 @@ pub struct FunctionSnapshot {
     /// Populated in `Snapshot::from_reports` when `repo_root` is available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subsystem: Option<String>,
+    /// Number of distinct commit authors for this file in the last 90 days.
+    /// File-level (shared by all functions in the same file).
+    /// Populated by `Snapshot::populate_authors_90d()`.
+    /// Used as a training feature in `hotspots train` — author diversity is a
+    /// non-windowed ownership signal that doesn't share the temporal leakage
+    /// of touch_count_30d.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authors_90d: Option<u32>,
 }
 
 /// Risk distribution by band
@@ -424,6 +432,7 @@ impl Snapshot {
                     patterns: report.patterns,
                     pattern_details: None,
                     subsystem: None,
+                    authors_90d: None,
                 }
             })
             .collect();
@@ -467,6 +476,54 @@ impl Snapshot {
                     lines_deleted: file_churn.lines_deleted,
                     net_change,
                 });
+            }
+        }
+    }
+
+    /// Populate `authors_90d` for every function.
+    ///
+    /// Runs one `git log` subprocess per unique file in the snapshot to count
+    /// distinct commit-author emails in the last 90 days.  File-level: all
+    /// functions in the same file receive the same value.  Functions in files
+    /// with no matching history receive `Some(0)`.
+    ///
+    /// Errors are soft: a failed git call leaves the affected file's functions
+    /// with `authors_90d = None`.
+    pub fn populate_authors_90d(&mut self, repo_root: &Path) {
+        use std::collections::{HashMap, HashSet};
+        use std::process::Command;
+
+        // Build unique-file → function-indices map
+        let mut file_indices: HashMap<String, Vec<usize>> = HashMap::new();
+        for (i, func) in self.functions.iter().enumerate() {
+            file_indices.entry(func.file.clone()).or_default().push(i);
+        }
+
+        for (abs_path, indices) in &file_indices {
+            let rel = if let Ok(r) = std::path::Path::new(abs_path).strip_prefix(repo_root) {
+                r.to_string_lossy().to_string()
+            } else {
+                abs_path.clone()
+            };
+
+            let out = Command::new("git")
+                .args(["log", "--after=90.days.ago", "--format=%ae", "--", &rel])
+                .current_dir(repo_root)
+                .output();
+
+            let count = match out {
+                Ok(o) if o.status.success() => {
+                    let text = String::from_utf8_lossy(&o.stdout);
+                    text.lines()
+                        .filter(|l| !l.is_empty())
+                        .collect::<HashSet<_>>()
+                        .len() as u32
+                }
+                _ => continue, // leave as None on error
+            };
+
+            for &i in indices {
+                self.functions[i].authors_90d = Some(count);
             }
         }
     }

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -1159,13 +1159,18 @@ impl Snapshot {
     ///
     /// Quadrant logic (Option C — combines both signals):
     ///   is_active = touches_30d > touch_p50 OR days_since_last_change <= 30
+    ///              [+ activity_risk >= 0.7 when ranker_applied]
     ///   fire  = high/critical + is_active
     ///   debt  = high/critical + !is_active
     ///   watch = moderate/low  + is_active
     ///   ok    = everything else
     ///
+    /// When `ranker_applied` is true, a trained RF score >= 0.7 also counts as
+    /// active — promoting structurally-risky-but-dormant functions from debt to
+    /// fire when the model predicts they are likely to be touched in a fix commit.
+    ///
     /// Must be called after populate_driver_labels().
-    pub fn compute_quadrants(&mut self, driver_threshold_percentile: u8) {
+    pub fn compute_quadrants(&mut self, driver_threshold_percentile: u8, ranker_applied: bool) {
         if self.functions.is_empty() {
             return;
         }
@@ -1181,7 +1186,9 @@ impl Snapshot {
                 .days_since_last_change
                 .map(|d| d <= 30)
                 .unwrap_or(false);
-            let is_active = touch_above_p50 || recently_changed;
+            let high_ranker_score =
+                ranker_applied && function.activity_risk.map(|r| r >= 0.7).unwrap_or(false);
+            let is_active = touch_above_p50 || recently_changed || high_ranker_score;
             let is_high_risk = matches!(function.band, RiskBand::Critical | RiskBand::High);
 
             function.quadrant = Some(
@@ -1707,7 +1714,8 @@ impl SnapshotEnricher {
         self.snapshot.compute_percentiles();
         self.snapshot
             .populate_driver_labels(driver_threshold_percentile);
-        self.snapshot.compute_quadrants(driver_threshold_percentile);
+        self.snapshot
+            .compute_quadrants(driver_threshold_percentile, false);
         self.snapshot.compute_summary(self.betweenness_approximate);
         self
     }

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -145,13 +145,50 @@ pub fn collect_fix_functions(
     use std::process::Command;
 
     // Build a per-file sorted index of function start lines from the snapshot.
-    // file_path -> sorted Vec<(start_line, function_id)>
+    // Snapshot stores absolute paths; git diff-tree emits repo-relative paths.
+    // Strip the repo_root prefix so lookup keys match diff-tree output.
+    // On macOS /tmp is a symlink to /private/tmp — canonicalize both sides so the
+    // prefix strip works regardless of which form the snapshot recorded.
+    let repo_canonical = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf());
+    let repo_prefix_canonical = format!(
+        "{}/",
+        repo_canonical.to_str().unwrap_or("").trim_end_matches('/')
+    );
+    let repo_prefix_raw = repo_root
+        .to_str()
+        .map(|s| format!("{}/", s.trim_end_matches('/')))
+        .unwrap_or_default();
+
+    let make_rel = |path: &str| -> String {
+        let p = path.replace('\\', "/");
+        // Try exact prefix strip first (fastest).
+        if let Some(r) = p.strip_prefix(&repo_prefix_canonical) {
+            return r.to_string();
+        }
+        if let Some(r) = p.strip_prefix(&repo_prefix_raw) {
+            return r.to_string();
+        }
+        // Snapshot may store a symlink path (e.g. /tmp/…) while repo_root
+        // canonicalises to a different form (e.g. /private/tmp/… on macOS).
+        // Canonicalise the snapshot path and retry.
+        if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
+            cp.to_str()
+                .and_then(|s| s.strip_prefix(&repo_prefix_canonical))
+                .map(str::to_string)
+        }) {
+            return r;
+        }
+        p
+    };
+
     let mut file_index: std::collections::HashMap<String, Vec<(u32, String)>> =
         std::collections::HashMap::new();
     for func in &snapshot.functions {
-        let path = func.file.replace('\\', "/");
+        let rel = make_rel(&func.file);
         file_index
-            .entry(path)
+            .entry(rel)
             .or_default()
             .push((func.line, func.function_id.clone()));
     }
@@ -222,7 +259,6 @@ pub fn collect_fix_functions(
 
         let diff_text = String::from_utf8_lossy(&diff_out.stdout);
         let mut current_file: Option<String> = None;
-
         for dline in diff_text.lines() {
             // "--- a/path" or "+++ b/path" lines
             if let Some(rest) = dline.strip_prefix("+++ b/") {
@@ -314,9 +350,37 @@ pub fn train(
 
     if cfg.blame_labels {
         let fix_funcs = collect_fix_functions(snapshot, repo_root, cfg.label_window_days)?;
+        let repo_canonical = repo_root
+            .canonicalize()
+            .unwrap_or_else(|_| repo_root.to_path_buf());
+        let prefix_can = format!(
+            "{}/",
+            repo_canonical.to_str().unwrap_or("").trim_end_matches('/')
+        );
+        let prefix_raw = repo_root
+            .to_str()
+            .map(|s| format!("{}/", s.trim_end_matches('/')))
+            .unwrap_or_default();
+        let make_rel = |path: &str| -> String {
+            let p = path.replace('\\', "/");
+            if let Some(r) = p.strip_prefix(&prefix_can) {
+                return r.to_string();
+            }
+            if let Some(r) = p.strip_prefix(&prefix_raw) {
+                return r.to_string();
+            }
+            if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
+                cp.to_str()
+                    .and_then(|s| s.strip_prefix(&prefix_can))
+                    .map(str::to_string)
+            }) {
+                return r;
+            }
+            p
+        };
         for func in &snapshot.functions {
-            let file_norm = func.file.replace('\\', "/");
-            let label = fix_funcs.contains(&(file_norm, func.line));
+            let rel = make_rel(&func.file);
+            let label = fix_funcs.contains(&(rel, func.line));
             rows.push((extract_features(func), label));
         }
     } else {

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -1,19 +1,23 @@
 //! `hotspots train` — fit a local RandomForest ranker from git history.
 //!
-//! # Feature set (9 features, index-stable)
+//! # Feature set (9 features, index-stable — model_version = 2)
 //!
-//! 0  lrs                    composite complexity score
-//! 1  cc                     cyclomatic complexity
-//! 2  nd                     nesting depth
-//! 3  loc                    lines of code
-//! 4  fo                     fan-out
-//! 5  fan_in                 call-graph fan-in
-//! 6  touch_count_30d        commit frequency (30-day window)
-//! 7  days_since_last_change recency (0 = changed today)
-//! 8  activity_risk          hotspots composite score (formula)
+//! 0  lrs           composite complexity score
+//! 1  cc            cyclomatic complexity
+//! 2  nd            nesting depth
+//! 3  loc           lines of code
+//! 4  fo            fan-out
+//! 5  fan_in        call-graph fan-in
+//! 6  total_churn   lifetime lines added + deleted (non-windowed structural signal)
+//! 7  activity_risk hotspots composite score (formula)
+//! 8  authors_90d   distinct commit authors in last 90 days (ownership diversity)
 //!
-//! Deliberately excluded: `bug_commits`, `convention_bug_fix_count` — both are derived
-//! from the same fix-keyword scan used to construct labels (data leakage).
+//! Deliberately excluded:
+//! - `touch_count_30d`, `days_since_last_change` — windowed activity signals that
+//!   correlate tautologically with labels when the training window overlaps the label
+//!   scan window (temporal leakage; see research Finding 15 and Finding 31).
+//! - `bug_commits`, `convention_bug_fix_count` — derived from the same fix-keyword
+//!   scan used to construct labels (direct data leakage).
 
 use crate::snapshot::{FunctionSnapshot, Snapshot};
 use anyhow::{bail, Context, Result};
@@ -37,13 +41,18 @@ pub const FEATURE_NAMES: [&str; 9] = [
     "loc",
     "fo",
     "fan_in",
-    "touch_count_30d",
-    "days_since_last_change",
+    "total_churn",
     "activity_risk",
+    "authors_90d",
 ];
 
 pub fn extract_features(func: &FunctionSnapshot) -> [f64; 9] {
     let cg = func.callgraph.as_ref();
+    let total_churn = func
+        .churn
+        .as_ref()
+        .map(|c| (c.lines_added + c.lines_deleted) as f64)
+        .unwrap_or(0.0);
     [
         func.lrs,
         f64::from(func.metrics.cc),
@@ -51,9 +60,9 @@ pub fn extract_features(func: &FunctionSnapshot) -> [f64; 9] {
         f64::from(func.metrics.loc),
         f64::from(func.metrics.fo),
         cg.map(|c| c.fan_in as f64).unwrap_or(0.0),
-        func.touch_count_30d.unwrap_or(0) as f64,
-        func.days_since_last_change.unwrap_or(365) as f64,
+        total_churn,
         func.activity_risk.unwrap_or(func.lrs),
+        func.authors_90d.unwrap_or(0) as f64,
     ]
 }
 
@@ -119,6 +128,148 @@ fn is_fix_message(msg: &str) -> bool {
         || lower.contains("hotfix")
 }
 
+/// Blame-based label extraction.
+///
+/// For each fix commit in the window, parse `git diff-tree` hunk headers to get
+/// the old (pre-fix) line ranges that changed.  Map each changed line to the
+/// snapshot function whose `start_line` is closest above that line.  Only that
+/// function is labelled positive — not every function in the file.
+///
+/// Returns `(file_path, start_line)` pairs.  Falls back silently to an empty set
+/// on any git subprocess error (caller should fall back to file-level labels).
+pub fn collect_fix_functions(
+    snapshot: &Snapshot,
+    repo_root: &Path,
+    window_days: u32,
+) -> Result<HashSet<(String, u32)>> {
+    use std::process::Command;
+
+    // Build a per-file sorted index of function start lines from the snapshot.
+    // file_path -> sorted Vec<(start_line, function_id)>
+    let mut file_index: std::collections::HashMap<String, Vec<(u32, String)>> =
+        std::collections::HashMap::new();
+    for func in &snapshot.functions {
+        let path = func.file.replace('\\', "/");
+        file_index
+            .entry(path)
+            .or_default()
+            .push((func.line, func.function_id.clone()));
+    }
+    for entries in file_index.values_mut() {
+        entries.sort_by_key(|(line, _)| *line);
+    }
+
+    // Collect fix commit SHAs and their touched files in one git log pass.
+    // Format: "<sha>|<subject>" followed by filenames, separated by blank lines.
+    let after = format!("{}.days.ago", window_days);
+    let out = Command::new("git")
+        .args([
+            "log",
+            "--after",
+            &after,
+            "--name-only",
+            "--pretty=format:%H|%s",
+            "--diff-filter=M",
+        ])
+        .current_dir(repo_root)
+        .output()
+        .context("git log failed")?;
+
+    if !out.status.success() {
+        bail!(
+            "git log exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut fix_shas: Vec<String> = Vec::new();
+    let mut current_sha: Option<String> = None;
+
+    for line in text.lines() {
+        if line.is_empty() {
+            current_sha = None;
+            continue;
+        }
+        if let Some((sha, subject)) = line.split_once('|') {
+            if is_fix_message(subject) {
+                current_sha = Some(sha.to_string());
+                fix_shas.push(sha.to_string());
+            }
+            continue;
+        }
+        // If we have an active fix commit, this is a touched filename — we only
+        // need the SHA list; skip the per-file tracking here.
+        let _ = current_sha.as_ref();
+    }
+
+    fix_shas.dedup();
+
+    let mut labelled: HashSet<(String, u32)> = HashSet::new();
+
+    for sha in &fix_shas {
+        // Get the unified diff for this commit with zero context lines.
+        let diff_out = Command::new("git")
+            .args(["diff-tree", "--no-commit-id", "-r", "--unified=0", sha])
+            .current_dir(repo_root)
+            .output();
+
+        let diff_out = match diff_out {
+            Ok(o) if o.status.success() => o,
+            _ => continue,
+        };
+
+        let diff_text = String::from_utf8_lossy(&diff_out.stdout);
+        let mut current_file: Option<String> = None;
+
+        for dline in diff_text.lines() {
+            // "--- a/path" or "+++ b/path" lines
+            if let Some(rest) = dline.strip_prefix("+++ b/") {
+                current_file = Some(rest.replace('\\', "/"));
+                continue;
+            }
+            // Hunk header: @@ -<old_start>[,<old_count>] +<new_start>[,<new_count>] @@
+            if let Some(rest) = dline.strip_prefix("@@ ") {
+                if let Some(file) = &current_file {
+                    if let Some(old_start) = parse_hunk_old_start(rest) {
+                        if let Some(func_line) = nearest_function_above(
+                            file_index.get(file).map(Vec::as_slice).unwrap_or(&[]),
+                            old_start,
+                        ) {
+                            labelled.insert((file.clone(), func_line));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(labelled)
+}
+
+/// Parse the old-file start line from a hunk header suffix like "-42,5 +50,3 @@".
+pub(crate) fn parse_hunk_old_start(rest: &str) -> Option<u32> {
+    // rest begins with "-<start>[,<count>] ..."
+    let after_minus = rest.strip_prefix('-')?;
+    let num_str = after_minus.split([',', ' ']).next()?;
+    num_str.parse::<u32>().ok()
+}
+
+/// Given a sorted list of (start_line, function_id) for a file, return the
+/// start_line of the function whose start_line is the largest value ≤ `line`.
+pub(crate) fn nearest_function_above(entries: &[(u32, String)], line: u32) -> Option<u32> {
+    if entries.is_empty() {
+        return None;
+    }
+    // Binary search for the last entry with start_line <= line
+    let pos = entries.partition_point(|(start, _)| *start <= line);
+    if pos == 0 {
+        return None;
+    }
+    Some(entries[pos - 1].0)
+}
+
 // ── Training ──────────────────────────────────────────────────────────────────
 
 /// Configuration for training a local ranker.
@@ -132,6 +283,9 @@ pub struct TrainConfig {
     pub max_depth: usize,
     /// RNG seed for reproducibility.
     pub seed: u64,
+    /// Use blame-based function-level labelling instead of file-level labelling.
+    /// More precise labels but slower (one git diff-tree subprocess per fix commit).
+    pub blame_labels: bool,
 }
 
 impl Default for TrainConfig {
@@ -141,34 +295,44 @@ impl Default for TrainConfig {
             n_estimators: 200,
             max_depth: 6,
             seed: 42,
+            blame_labels: false,
         }
     }
 }
 
 /// Train a ranker from a snapshot and the repo's git history.
 ///
-/// Returns `None` when the snapshot has fewer than 20 functions or the fix
-/// scan yields fewer than 2 positive labels — not enough signal to train.
+/// Returns `None` when the snapshot has fewer than 50 functions or the fix
+/// scan yields fewer than 5 positive / 10 negative labels.
 pub fn train(
     snapshot: &Snapshot,
     repo_root: &Path,
     cfg: &TrainConfig,
 ) -> Result<Option<RankerModel>> {
-    let fix_files = collect_fix_files(repo_root, cfg.label_window_days)?;
-
     // Build (features, label) pairs from snapshot functions
     let mut rows: Vec<([f64; 9], bool)> = Vec::new();
-    for func in &snapshot.functions {
-        let file_norm = func.file.replace('\\', "/");
-        let label = fix_files.contains(&file_norm)
-            || fix_files.iter().any(|f| file_norm.ends_with(f.as_str()));
-        rows.push((extract_features(func), label));
+
+    if cfg.blame_labels {
+        let fix_funcs = collect_fix_functions(snapshot, repo_root, cfg.label_window_days)?;
+        for func in &snapshot.functions {
+            let file_norm = func.file.replace('\\', "/");
+            let label = fix_funcs.contains(&(file_norm, func.line));
+            rows.push((extract_features(func), label));
+        }
+    } else {
+        let fix_files = collect_fix_files(repo_root, cfg.label_window_days)?;
+        for func in &snapshot.functions {
+            let file_norm = func.file.replace('\\', "/");
+            let label = fix_files.contains(&file_norm)
+                || fix_files.iter().any(|f| file_norm.ends_with(f.as_str()));
+            rows.push((extract_features(func), label));
+        }
     }
 
     let n_pos = rows.iter().filter(|(_, l)| *l).count();
     let n_neg = rows.len() - n_pos;
 
-    if rows.len() < 20 || n_pos < 2 || n_neg < 2 {
+    if rows.len() < 50 || n_pos < 5 || n_neg < 10 {
         return Ok(None);
     }
 
@@ -220,7 +384,11 @@ pub fn train(
         max_depth: cfg.max_depth,
     };
 
-    Ok(Some(RankerModel { trees, meta }))
+    Ok(Some(RankerModel {
+        model_version: 2,
+        trees,
+        meta,
+    }))
 }
 
 // ── Tree serialization ────────────────────────────────────────────────────────
@@ -366,8 +534,14 @@ pub struct TrainMeta {
     pub max_depth: usize,
 }
 
+fn default_model_version() -> u32 {
+    1
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankerModel {
+    #[serde(default = "default_model_version")]
+    pub model_version: u32,
     pub trees: Vec<SerializedTree>,
     pub meta: TrainMeta,
 }
@@ -381,6 +555,134 @@ impl RankerModel {
 
     pub fn load(path: &Path) -> Result<Self> {
         let json = std::fs::read_to_string(path).context("read model file")?;
-        serde_json::from_str(&json).context("deserialize model")
+        let model: Self = serde_json::from_str(&json).context("deserialize model")?;
+        if model.model_version < 2 {
+            bail!(
+                "{} was trained with an older feature set (model_version={}). \
+                 Run `hotspots train` to retrain with the current feature set.",
+                path.display(),
+                model.model_version
+            );
+        }
+        Ok(model)
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Feature names ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn feature_names_count_matches_array() {
+        assert_eq!(FEATURE_NAMES.len(), 9);
+    }
+
+    #[test]
+    fn no_leaky_windowed_features() {
+        for name in FEATURE_NAMES {
+            assert_ne!(name, "touch_count_30d", "leaky feature still present");
+            assert_ne!(
+                name, "days_since_last_change",
+                "leaky feature still present"
+            );
+        }
+        assert!(FEATURE_NAMES.contains(&"total_churn"));
+    }
+
+    // ── parse_hunk_old_start ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_hunk_simple() {
+        assert_eq!(parse_hunk_old_start("-42,5 +50,3 @@"), Some(42));
+    }
+
+    #[test]
+    fn parse_hunk_no_count() {
+        assert_eq!(parse_hunk_old_start("-10 +10 @@"), Some(10));
+    }
+
+    #[test]
+    fn parse_hunk_wrong_prefix() {
+        assert_eq!(parse_hunk_old_start("+42,5 -50,3 @@"), None);
+        assert_eq!(parse_hunk_old_start(""), None);
+    }
+
+    // ── nearest_function_above ────────────────────────────────────────────────
+
+    #[test]
+    fn nearest_exact_match() {
+        let entries = vec![
+            (1u32, "a".to_string()),
+            (10u32, "b".to_string()),
+            (20u32, "c".to_string()),
+        ];
+        assert_eq!(nearest_function_above(&entries, 10), Some(10));
+    }
+
+    #[test]
+    fn nearest_between_funcs() {
+        let entries = vec![
+            (1u32, "a".to_string()),
+            (10u32, "b".to_string()),
+            (20u32, "c".to_string()),
+        ];
+        assert_eq!(nearest_function_above(&entries, 15), Some(10));
+    }
+
+    #[test]
+    fn nearest_before_first_func() {
+        let entries = vec![(10u32, "a".to_string())];
+        assert_eq!(nearest_function_above(&entries, 5), None);
+    }
+
+    #[test]
+    fn nearest_empty_entries() {
+        assert_eq!(nearest_function_above(&[], 42), None);
+    }
+
+    #[test]
+    fn nearest_after_last_func() {
+        let entries = vec![
+            (1u32, "a".to_string()),
+            (10u32, "b".to_string()),
+            (50u32, "c".to_string()),
+        ];
+        assert_eq!(nearest_function_above(&entries, 999), Some(50));
+    }
+
+    // ── Model versioning ──────────────────────────────────────────────────────
+
+    #[test]
+    fn load_v1_model_returns_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ranker.json");
+        // v1 = no model_version field (defaults to 1 via serde)
+        std::fs::write(
+            &path,
+            r#"{"trees":[],"meta":{"n_samples":100,"n_pos":50,"n_neg":50,"label_window_days":365,"n_estimators":10,"max_depth":3}}"#,
+        )
+        .unwrap();
+        let err = RankerModel::load(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("retrain") || err.contains("model_version"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_v2_model_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ranker.json");
+        std::fs::write(
+            &path,
+            r#"{"model_version":2,"trees":[],"meta":{"n_samples":100,"n_pos":50,"n_neg":50,"label_window_days":365,"n_estimators":10,"max_depth":3}}"#,
+        )
+        .unwrap();
+        let model = RankerModel::load(&path).expect("should load");
+        assert_eq!(model.model_version, 2);
     }
 }

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -35,6 +35,49 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::Path;
 
+// ── Path helpers ─────────────────────────────────────────────────────────────
+
+/// Strip `repo_root` prefix from an absolute snapshot path to produce a
+/// repo-relative key matching `git diff-tree` / `git log --name-only` output.
+///
+/// Handles three sources of mismatch:
+/// - macOS `/tmp` → `/private/tmp` symlink: tries both canonical and raw prefix forms
+/// - Snapshot path itself may be a symlink: canonicalises as a last resort
+/// - `hotspots analyze .` stores paths with a leading `./` component: strips it
+pub(crate) fn make_rel(path: &str, prefix_can: &str, prefix_raw: &str) -> String {
+    let p = path.replace('\\', "/");
+    let rel = if let Some(r) = p.strip_prefix(prefix_can) {
+        r.to_string()
+    } else if let Some(r) = p.strip_prefix(prefix_raw) {
+        r.to_string()
+    } else if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
+        cp.to_str()
+            .and_then(|s| s.strip_prefix(prefix_can))
+            .map(str::to_string)
+    }) {
+        r
+    } else {
+        return p;
+    };
+    rel.strip_prefix("./").unwrap_or(&rel).to_string()
+}
+
+/// Build the canonical and raw prefix strings for a repo root.
+pub(crate) fn repo_prefixes(repo_root: &Path) -> (String, String) {
+    let canonical = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf());
+    let prefix_can = format!(
+        "{}/",
+        canonical.to_str().unwrap_or("").trim_end_matches('/')
+    );
+    let prefix_raw = repo_root
+        .to_str()
+        .map(|s| format!("{}/", s.trim_end_matches('/')))
+        .unwrap_or_default();
+    (prefix_can, prefix_raw)
+}
+
 // ── Feature extraction ────────────────────────────────────────────────────────
 
 pub const FEATURE_NAMES: [&str; 8] = [
@@ -150,43 +193,12 @@ pub fn collect_fix_functions(
     // Strip the repo_root prefix so lookup keys match diff-tree output.
     // On macOS /tmp is a symlink to /private/tmp — canonicalize both sides so the
     // prefix strip works regardless of which form the snapshot recorded.
-    let repo_canonical = repo_root
-        .canonicalize()
-        .unwrap_or_else(|_| repo_root.to_path_buf());
-    let repo_prefix_canonical = format!(
-        "{}/",
-        repo_canonical.to_str().unwrap_or("").trim_end_matches('/')
-    );
-    let repo_prefix_raw = repo_root
-        .to_str()
-        .map(|s| format!("{}/", s.trim_end_matches('/')))
-        .unwrap_or_default();
-
-    let make_rel = |path: &str| -> String {
-        let p = path.replace('\\', "/");
-        let rel = if let Some(r) = p.strip_prefix(&repo_prefix_canonical) {
-            r.to_string()
-        } else if let Some(r) = p.strip_prefix(&repo_prefix_raw) {
-            r.to_string()
-        } else if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
-            // Snapshot may store a symlink path (e.g. /tmp/…) while repo_root
-            // canonicalises to a different form (e.g. /private/tmp/… on macOS).
-            cp.to_str()
-                .and_then(|s| s.strip_prefix(&repo_prefix_canonical))
-                .map(str::to_string)
-        }) {
-            r
-        } else {
-            return p;
-        };
-        // Strip leading "./" that appears when the repo was analyzed as "."
-        rel.strip_prefix("./").unwrap_or(&rel).to_string()
-    };
+    let (repo_prefix_canonical, repo_prefix_raw) = repo_prefixes(repo_root);
 
     let mut file_index: std::collections::HashMap<String, Vec<(u32, String)>> =
         std::collections::HashMap::new();
     for func in &snapshot.functions {
-        let rel = make_rel(&func.file);
+        let rel = make_rel(&func.file, &repo_prefix_canonical, &repo_prefix_raw);
         file_index
             .entry(rel)
             .or_default()
@@ -350,36 +362,9 @@ pub fn train(
 
     if cfg.blame_labels {
         let fix_funcs = collect_fix_functions(snapshot, repo_root, cfg.label_window_days)?;
-        let repo_canonical = repo_root
-            .canonicalize()
-            .unwrap_or_else(|_| repo_root.to_path_buf());
-        let prefix_can = format!(
-            "{}/",
-            repo_canonical.to_str().unwrap_or("").trim_end_matches('/')
-        );
-        let prefix_raw = repo_root
-            .to_str()
-            .map(|s| format!("{}/", s.trim_end_matches('/')))
-            .unwrap_or_default();
-        let make_rel = |path: &str| -> String {
-            let p = path.replace('\\', "/");
-            let rel = if let Some(r) = p.strip_prefix(&prefix_can) {
-                r.to_string()
-            } else if let Some(r) = p.strip_prefix(&prefix_raw) {
-                r.to_string()
-            } else if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
-                cp.to_str()
-                    .and_then(|s| s.strip_prefix(&prefix_can))
-                    .map(str::to_string)
-            }) {
-                r
-            } else {
-                return p;
-            };
-            rel.strip_prefix("./").unwrap_or(&rel).to_string()
-        };
+        let (prefix_can, prefix_raw) = repo_prefixes(repo_root);
         for func in &snapshot.functions {
-            let rel = make_rel(&func.file);
+            let rel = make_rel(&func.file, &prefix_can, &prefix_raw);
             let label = fix_funcs.contains(&(rel, func.line));
             rows.push((extract_features(func), label));
         }
@@ -401,7 +386,7 @@ pub fn train(
     }
 
     let n = rows.len();
-    let mut x_data = Vec::with_capacity(n * 9);
+    let mut x_data = Vec::with_capacity(n * 8);
     let mut y_data: Vec<bool> = Vec::with_capacity(n);
 
     for (feats, label) in &rows {

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -164,24 +164,23 @@ pub fn collect_fix_functions(
 
     let make_rel = |path: &str| -> String {
         let p = path.replace('\\', "/");
-        // Try exact prefix strip first (fastest).
-        if let Some(r) = p.strip_prefix(&repo_prefix_canonical) {
-            return r.to_string();
-        }
-        if let Some(r) = p.strip_prefix(&repo_prefix_raw) {
-            return r.to_string();
-        }
-        // Snapshot may store a symlink path (e.g. /tmp/…) while repo_root
-        // canonicalises to a different form (e.g. /private/tmp/… on macOS).
-        // Canonicalise the snapshot path and retry.
-        if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
+        let rel = if let Some(r) = p.strip_prefix(&repo_prefix_canonical) {
+            r.to_string()
+        } else if let Some(r) = p.strip_prefix(&repo_prefix_raw) {
+            r.to_string()
+        } else if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
+            // Snapshot may store a symlink path (e.g. /tmp/…) while repo_root
+            // canonicalises to a different form (e.g. /private/tmp/… on macOS).
             cp.to_str()
                 .and_then(|s| s.strip_prefix(&repo_prefix_canonical))
                 .map(str::to_string)
         }) {
-            return r;
-        }
-        p
+            r
+        } else {
+            return p;
+        };
+        // Strip leading "./" that appears when the repo was analyzed as "."
+        rel.strip_prefix("./").unwrap_or(&rel).to_string()
     };
 
     let mut file_index: std::collections::HashMap<String, Vec<(u32, String)>> =
@@ -364,20 +363,20 @@ pub fn train(
             .unwrap_or_default();
         let make_rel = |path: &str| -> String {
             let p = path.replace('\\', "/");
-            if let Some(r) = p.strip_prefix(&prefix_can) {
-                return r.to_string();
-            }
-            if let Some(r) = p.strip_prefix(&prefix_raw) {
-                return r.to_string();
-            }
-            if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
+            let rel = if let Some(r) = p.strip_prefix(&prefix_can) {
+                r.to_string()
+            } else if let Some(r) = p.strip_prefix(&prefix_raw) {
+                r.to_string()
+            } else if let Some(r) = std::path::Path::new(&p).canonicalize().ok().and_then(|cp| {
                 cp.to_str()
                     .and_then(|s| s.strip_prefix(&prefix_can))
                     .map(str::to_string)
             }) {
-                return r;
-            }
-            p
+                r
+            } else {
+                return p;
+            };
+            rel.strip_prefix("./").unwrap_or(&rel).to_string()
         };
         for func in &snapshot.functions {
             let rel = make_rel(&func.file);

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -1,0 +1,386 @@
+//! `hotspots train` — fit a local RandomForest ranker from git history.
+//!
+//! # Feature set (9 features, index-stable)
+//!
+//! 0  lrs                    composite complexity score
+//! 1  cc                     cyclomatic complexity
+//! 2  nd                     nesting depth
+//! 3  loc                    lines of code
+//! 4  fo                     fan-out
+//! 5  fan_in                 call-graph fan-in
+//! 6  touch_count_30d        commit frequency (30-day window)
+//! 7  days_since_last_change recency (0 = changed today)
+//! 8  activity_risk          hotspots composite score (formula)
+//!
+//! Deliberately excluded: `bug_commits`, `convention_bug_fix_count` — both are derived
+//! from the same fix-keyword scan used to construct labels (data leakage).
+
+use crate::snapshot::{FunctionSnapshot, Snapshot};
+use anyhow::{bail, Context, Result};
+use linfa::prelude::Fit;
+use linfa::Dataset;
+use linfa_ensemble::RandomForestParams;
+use linfa_trees::DecisionTreeParams;
+use ndarray::{Array1, Array2};
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::Path;
+
+// ── Feature extraction ────────────────────────────────────────────────────────
+
+pub const FEATURE_NAMES: [&str; 9] = [
+    "lrs",
+    "cc",
+    "nd",
+    "loc",
+    "fo",
+    "fan_in",
+    "touch_count_30d",
+    "days_since_last_change",
+    "activity_risk",
+];
+
+pub fn extract_features(func: &FunctionSnapshot) -> [f64; 9] {
+    let cg = func.callgraph.as_ref();
+    [
+        func.lrs,
+        f64::from(func.metrics.cc),
+        f64::from(func.metrics.nd),
+        f64::from(func.metrics.loc),
+        f64::from(func.metrics.fo),
+        cg.map(|c| c.fan_in as f64).unwrap_or(0.0),
+        func.touch_count_30d.unwrap_or(0) as f64,
+        func.days_since_last_change.unwrap_or(365) as f64,
+        func.activity_risk.unwrap_or(func.lrs),
+    ]
+}
+
+// ── Label extraction from git ─────────────────────────────────────────────────
+
+/// Returns the set of file paths touched by fix-keyword commits in the last
+/// `window_days` days.  Uses `git log` via subprocess; tolerates missing git.
+pub fn collect_fix_files(repo_root: &Path, window_days: u32) -> Result<HashSet<String>> {
+    use std::process::Command;
+
+    let after = format!("{}.days.ago", window_days);
+    let out = Command::new("git")
+        .args([
+            "log",
+            "--after",
+            &after,
+            "--name-only",
+            "--pretty=format:%s",
+            "--diff-filter=M",
+        ])
+        .current_dir(repo_root)
+        .output()
+        .context("git log failed")?;
+
+    if !out.status.success() {
+        bail!(
+            "git log exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut fix_files = HashSet::new();
+    let mut in_fix_commit = false;
+
+    for line in text.lines() {
+        if line.is_empty() {
+            in_fix_commit = false;
+            continue;
+        }
+        // First non-empty line after blank is the commit subject
+        if !in_fix_commit && is_fix_message(line) {
+            in_fix_commit = true;
+            continue;
+        }
+        if in_fix_commit && !line.is_empty() {
+            // Normalize path separator
+            fix_files.insert(line.replace('\\', "/"));
+        }
+    }
+
+    Ok(fix_files)
+}
+
+fn is_fix_message(msg: &str) -> bool {
+    let lower = msg.to_lowercase();
+    lower.contains("fix")
+        || lower.contains("bug")
+        || lower.contains("patch")
+        || lower.contains("regression")
+        || lower.contains("defect")
+        || lower.contains("hotfix")
+}
+
+// ── Training ──────────────────────────────────────────────────────────────────
+
+/// Configuration for training a local ranker.
+#[derive(Debug, Clone)]
+pub struct TrainConfig {
+    /// Days of git history to scan for fix-commit labels.
+    pub label_window_days: u32,
+    /// Number of trees in the RandomForest.
+    pub n_estimators: usize,
+    /// Maximum tree depth.
+    pub max_depth: usize,
+    /// RNG seed for reproducibility.
+    pub seed: u64,
+}
+
+impl Default for TrainConfig {
+    fn default() -> Self {
+        Self {
+            label_window_days: 365,
+            n_estimators: 200,
+            max_depth: 6,
+            seed: 42,
+        }
+    }
+}
+
+/// Train a ranker from a snapshot and the repo's git history.
+///
+/// Returns `None` when the snapshot has fewer than 20 functions or the fix
+/// scan yields fewer than 2 positive labels — not enough signal to train.
+pub fn train(
+    snapshot: &Snapshot,
+    repo_root: &Path,
+    cfg: &TrainConfig,
+) -> Result<Option<RankerModel>> {
+    let fix_files = collect_fix_files(repo_root, cfg.label_window_days)?;
+
+    // Build (features, label) pairs from snapshot functions
+    let mut rows: Vec<([f64; 9], bool)> = Vec::new();
+    for func in &snapshot.functions {
+        let file_norm = func.file.replace('\\', "/");
+        let label = fix_files.contains(&file_norm)
+            || fix_files.iter().any(|f| file_norm.ends_with(f.as_str()));
+        rows.push((extract_features(func), label));
+    }
+
+    let n_pos = rows.iter().filter(|(_, l)| *l).count();
+    let n_neg = rows.len() - n_pos;
+
+    if rows.len() < 20 || n_pos < 2 || n_neg < 2 {
+        return Ok(None);
+    }
+
+    let n = rows.len();
+    let mut x_data = Vec::with_capacity(n * 9);
+    let mut y_data: Vec<bool> = Vec::with_capacity(n);
+
+    for (feats, label) in &rows {
+        x_data.extend_from_slice(feats);
+        y_data.push(*label);
+    }
+
+    let x: Array2<f64> =
+        Array2::from_shape_vec((n, 9), x_data).context("feature matrix shape error")?;
+    let y: Array1<bool> = Array1::from_vec(y_data);
+
+    let dataset = Dataset::new(x, y).with_feature_names(
+        FEATURE_NAMES
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>(),
+    );
+
+    let rng = SmallRng::seed_from_u64(cfg.seed);
+    let tree_params = DecisionTreeParams::new().max_depth(Some(cfg.max_depth));
+
+    let rf = RandomForestParams::new_fixed_rng(tree_params, rng.clone())
+        .ensemble_size(cfg.n_estimators)
+        .bootstrap_proportion(0.8)
+        .fit(&dataset)
+        .context("RandomForest fit failed")?;
+
+    // Serialize each tree as a compact node list
+    let mut trees: Vec<SerializedTree> = Vec::with_capacity(rf.models.len());
+    for (tree, feat_indices) in rf.models.iter().zip(rf.model_features.iter()) {
+        let nodes = serialize_tree(tree);
+        trees.push(SerializedTree {
+            nodes,
+            feature_indices: feat_indices.clone(),
+        });
+    }
+
+    let meta = TrainMeta {
+        n_samples: n,
+        n_pos,
+        n_neg,
+        label_window_days: cfg.label_window_days,
+        n_estimators: cfg.n_estimators,
+        max_depth: cfg.max_depth,
+    };
+
+    Ok(Some(RankerModel { trees, meta }))
+}
+
+// ── Tree serialization ────────────────────────────────────────────────────────
+
+/// Flat node representation.  Leaves have `feature_idx = usize::MAX`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TreeNodeRecord {
+    pub feature_idx: usize,
+    pub threshold: f64,
+    /// Index into `nodes` for the left child (feature ≤ threshold).
+    pub left: usize,
+    /// Index into `nodes` for the right child (feature > threshold).
+    pub right: usize,
+    /// For leaf nodes: true = predict positive.
+    pub leaf_value: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializedTree {
+    pub nodes: Vec<TreeNodeRecord>,
+    /// Which global feature indices this tree was trained on.
+    pub feature_indices: Vec<usize>,
+}
+
+fn serialize_tree<F, L>(tree: &linfa_trees::DecisionTree<F, L>) -> Vec<TreeNodeRecord>
+where
+    F: linfa::Float,
+    L: linfa::Label + Into<bool> + Copy,
+{
+    let mut nodes: Vec<TreeNodeRecord> = Vec::new();
+    serialize_node(tree.root_node(), &mut nodes);
+    nodes
+}
+
+fn serialize_node<F, L>(
+    node: &linfa_trees::TreeNode<F, L>,
+    nodes: &mut Vec<TreeNodeRecord>,
+) -> usize
+where
+    F: linfa::Float,
+    L: linfa::Label + Into<bool> + Copy,
+{
+    let idx = nodes.len();
+    // Push placeholder so children can reference correct indices
+    nodes.push(TreeNodeRecord {
+        feature_idx: usize::MAX,
+        threshold: 0.0,
+        left: 0,
+        right: 0,
+        leaf_value: false,
+    });
+
+    if node.is_leaf() {
+        let val: bool = node.prediction().map(|p| p.into()).unwrap_or(false);
+        nodes[idx].leaf_value = val;
+    } else {
+        let (feat, thresh, _) = node.split();
+        nodes[idx].feature_idx = feat;
+        nodes[idx].threshold = thresh.to_f64().unwrap_or(0.0);
+
+        let children = node.children();
+        let left_child = children[0].as_deref();
+        let right_child = children[1].as_deref();
+
+        let left_idx = if let Some(lc) = left_child {
+            serialize_node(lc, nodes)
+        } else {
+            idx // degenerate: point to self (won't happen in valid trees)
+        };
+        let right_idx = if let Some(rc) = right_child {
+            serialize_node(rc, nodes)
+        } else {
+            idx
+        };
+        nodes[idx].left = left_idx;
+        nodes[idx].right = right_idx;
+    }
+
+    idx
+}
+
+// ── Inference ─────────────────────────────────────────────────────────────────
+
+/// Score a function using the trained ranker.
+/// Returns a value in [0, 1]: fraction of trees voting positive.
+pub fn score(model: &RankerModel, func: &FunctionSnapshot) -> f64 {
+    let feats = extract_features(func);
+    let n = model.trees.len();
+    if n == 0 {
+        return 0.0;
+    }
+    let votes: usize = model
+        .trees
+        .iter()
+        .map(|tree| vote(tree, &feats) as usize)
+        .sum();
+    votes as f64 / n as f64
+}
+
+fn vote(tree: &SerializedTree, feats: &[f64; 9]) -> bool {
+    let nodes = &tree.nodes;
+    if nodes.is_empty() {
+        return false;
+    }
+    let mut cur = 0usize;
+    loop {
+        let node = &nodes[cur];
+        if node.feature_idx == usize::MAX {
+            return node.leaf_value;
+        }
+        // Map tree-local feature index (which may be a sub-sampled global index)
+        let global_idx = tree
+            .feature_indices
+            .get(node.feature_idx)
+            .copied()
+            .unwrap_or(node.feature_idx);
+        let val = if global_idx < 9 {
+            feats[global_idx]
+        } else {
+            0.0
+        };
+        if val <= node.threshold {
+            cur = node.left;
+        } else {
+            cur = node.right;
+        }
+        // Guard against cycles (shouldn't happen with valid serialization)
+        if cur >= nodes.len() {
+            return false;
+        }
+    }
+}
+
+// ── Persisted model ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrainMeta {
+    pub n_samples: usize,
+    pub n_pos: usize,
+    pub n_neg: usize,
+    pub label_window_days: u32,
+    pub n_estimators: usize,
+    pub max_depth: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RankerModel {
+    pub trees: Vec<SerializedTree>,
+    pub meta: TrainMeta,
+}
+
+impl RankerModel {
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let json = serde_json::to_string_pretty(self).context("serialize model")?;
+        std::fs::write(path, json).context("write model file")?;
+        Ok(())
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let json = std::fs::read_to_string(path).context("read model file")?;
+        serde_json::from_str(&json).context("deserialize model")
+    }
+}

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -1,6 +1,6 @@
 //! `hotspots train` — fit a local RandomForest ranker from git history.
 //!
-//! # Feature set (9 features, index-stable — model_version = 2)
+//! # Feature set (8 features, index-stable — model_version = 3)
 //!
 //! 0  lrs           composite complexity score
 //! 1  cc            cyclomatic complexity
@@ -9,8 +9,7 @@
 //! 4  fo            fan-out
 //! 5  fan_in        call-graph fan-in
 //! 6  total_churn   lifetime lines added + deleted (non-windowed structural signal)
-//! 7  activity_risk hotspots composite score (formula)
-//! 8  authors_90d   distinct commit authors in last 90 days (ownership diversity)
+//! 7  authors_90d   distinct commit authors in last 90 days (ownership diversity)
 //!
 //! Deliberately excluded:
 //! - `touch_count_30d`, `days_since_last_change` — windowed activity signals that
@@ -18,6 +17,10 @@
 //!   scan window (temporal leakage; see research Finding 15 and Finding 31).
 //! - `bug_commits`, `convention_bug_fix_count` — derived from the same fix-keyword
 //!   scan used to construct labels (direct data leakage).
+//! - `activity_risk` — a composite of `touch_count_30d` and `days_since_last_change`;
+//!   including it is indirect temporal leakage of the same windowed signals. It also
+//!   causes the trained ranker to reproduce the heuristic score rather than learning
+//!   from structural features, making `hotspots train` a no-op in practice.
 
 use crate::snapshot::{FunctionSnapshot, Snapshot};
 use anyhow::{bail, Context, Result};
@@ -34,7 +37,7 @@ use std::path::Path;
 
 // ── Feature extraction ────────────────────────────────────────────────────────
 
-pub const FEATURE_NAMES: [&str; 9] = [
+pub const FEATURE_NAMES: [&str; 8] = [
     "lrs",
     "cc",
     "nd",
@@ -42,11 +45,10 @@ pub const FEATURE_NAMES: [&str; 9] = [
     "fo",
     "fan_in",
     "total_churn",
-    "activity_risk",
     "authors_90d",
 ];
 
-pub fn extract_features(func: &FunctionSnapshot) -> [f64; 9] {
+pub fn extract_features(func: &FunctionSnapshot) -> [f64; 8] {
     let cg = func.callgraph.as_ref();
     let total_churn = func
         .churn
@@ -61,7 +63,6 @@ pub fn extract_features(func: &FunctionSnapshot) -> [f64; 9] {
         f64::from(func.metrics.fo),
         cg.map(|c| c.fan_in as f64).unwrap_or(0.0),
         total_churn,
-        func.activity_risk.unwrap_or(func.lrs),
         func.authors_90d.unwrap_or(0) as f64,
     ]
 }
@@ -346,7 +347,7 @@ pub fn train(
     cfg: &TrainConfig,
 ) -> Result<Option<RankerModel>> {
     // Build (features, label) pairs from snapshot functions
-    let mut rows: Vec<([f64; 9], bool)> = Vec::new();
+    let mut rows: Vec<([f64; 8], bool)> = Vec::new();
 
     if cfg.blame_labels {
         let fix_funcs = collect_fix_functions(snapshot, repo_root, cfg.label_window_days)?;
@@ -410,7 +411,7 @@ pub fn train(
     }
 
     let x: Array2<f64> =
-        Array2::from_shape_vec((n, 9), x_data).context("feature matrix shape error")?;
+        Array2::from_shape_vec((n, 8), x_data).context("feature matrix shape error")?;
     let y: Array1<bool> = Array1::from_vec(y_data);
 
     let dataset = Dataset::new(x, y).with_feature_names(
@@ -449,7 +450,7 @@ pub fn train(
     };
 
     Ok(Some(RankerModel {
-        model_version: 2,
+        model_version: 3,
         trees,
         meta,
     }))
@@ -552,7 +553,7 @@ pub fn score(model: &RankerModel, func: &FunctionSnapshot) -> f64 {
     votes as f64 / n as f64
 }
 
-fn vote(tree: &SerializedTree, feats: &[f64; 9]) -> bool {
+fn vote(tree: &SerializedTree, feats: &[f64; 8]) -> bool {
     let nodes = &tree.nodes;
     if nodes.is_empty() {
         return false;
@@ -569,7 +570,7 @@ fn vote(tree: &SerializedTree, feats: &[f64; 9]) -> bool {
             .get(node.feature_idx)
             .copied()
             .unwrap_or(node.feature_idx);
-        let val = if global_idx < 9 {
+        let val = if global_idx < 8 {
             feats[global_idx]
         } else {
             0.0
@@ -620,7 +621,7 @@ impl RankerModel {
     pub fn load(path: &Path) -> Result<Self> {
         let json = std::fs::read_to_string(path).context("read model file")?;
         let model: Self = serde_json::from_str(&json).context("deserialize model")?;
-        if model.model_version < 2 {
+        if model.model_version < 3 {
             bail!(
                 "{} was trained with an older feature set (model_version={}). \
                  Run `hotspots train` to retrain with the current feature set.",
@@ -642,7 +643,7 @@ mod tests {
 
     #[test]
     fn feature_names_count_matches_array() {
-        assert_eq!(FEATURE_NAMES.len(), 9);
+        assert_eq!(FEATURE_NAMES.len(), 8);
     }
 
     #[test]
@@ -653,6 +654,7 @@ mod tests {
                 name, "days_since_last_change",
                 "leaky feature still present"
             );
+            assert_ne!(name, "activity_risk", "leaky feature still present");
         }
         assert!(FEATURE_NAMES.contains(&"total_churn"));
     }
@@ -738,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn load_v2_model_succeeds() {
+    fn load_v2_model_returns_error() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("ranker.json");
         std::fs::write(
@@ -746,7 +748,23 @@ mod tests {
             r#"{"model_version":2,"trees":[],"meta":{"n_samples":100,"n_pos":50,"n_neg":50,"label_window_days":365,"n_estimators":10,"max_depth":3}}"#,
         )
         .unwrap();
+        let err = RankerModel::load(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("retrain") || err.contains("model_version"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_v3_model_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ranker.json");
+        std::fs::write(
+            &path,
+            r#"{"model_version":3,"trees":[],"meta":{"n_samples":100,"n_pos":50,"n_neg":50,"label_window_days":365,"n_estimators":10,"max_depth":3}}"#,
+        )
+        .unwrap();
         let model = RankerModel::load(&path).expect("should load");
-        assert_eq!(model.model_version, 2);
+        assert_eq!(model.model_version, 3);
     }
 }

--- a/hotspots-core/src/trends.rs
+++ b/hotspots-core/src/trends.rs
@@ -500,6 +500,7 @@ mod tests {
                     patterns: vec![],
                     pattern_details: None,
                     subsystem: None,
+                    authors_90d: None,
                 }],
             ),
             create_test_snapshot(
@@ -533,6 +534,7 @@ mod tests {
                     patterns: vec![],
                     pattern_details: None,
                     subsystem: None,
+                    authors_90d: None,
                 }],
             ),
         ];
@@ -578,6 +580,7 @@ mod tests {
                     patterns: vec![],
                     pattern_details: None,
                     subsystem: None,
+                    authors_90d: None,
                 }],
             ),
             create_test_snapshot(
@@ -611,6 +614,7 @@ mod tests {
                     patterns: vec![],
                     pattern_details: None,
                     subsystem: None,
+                    authors_90d: None,
                 }],
             ),
         ];
@@ -655,6 +659,7 @@ mod tests {
                         patterns: vec![],
                         pattern_details: None,
                         subsystem: None,
+                        authors_90d: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -684,6 +689,7 @@ mod tests {
                         patterns: vec![],
                         pattern_details: None,
                         subsystem: None,
+                        authors_90d: None,
                     },
                 ],
             ),
@@ -719,6 +725,7 @@ mod tests {
                         patterns: vec![],
                         pattern_details: None,
                         subsystem: None,
+                        authors_90d: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -748,6 +755,7 @@ mod tests {
                         patterns: vec![],
                         pattern_details: None,
                         subsystem: None,
+                        authors_90d: None,
                     },
                 ],
             ),

--- a/hotspots-core/tests/trainer_tests.rs
+++ b/hotspots-core/tests/trainer_tests.rs
@@ -1,0 +1,415 @@
+//! Integration tests for hotspots-core trainer.
+//!
+//! Tests that require a real git repository (collect_fix_files,
+//! collect_fix_functions, training guard, blame-based labelling).
+//! Pure-unit tests (feature names, hunk parsing, nearest_function_above,
+//! model versioning) live in trainer.rs itself.
+
+use hotspots_core::language::Language;
+use hotspots_core::report::MetricsReport;
+use hotspots_core::risk::RiskBand;
+use hotspots_core::snapshot::{
+    AnalysisInfo, CallGraphMetrics, ChurnMetrics, CommitInfo, FunctionSnapshot, Snapshot,
+};
+use hotspots_core::trainer::{
+    collect_fix_files, collect_fix_functions, extract_features, train, TrainConfig, FEATURE_NAMES,
+};
+use std::path::Path;
+use std::process::Command;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn git_cmd(repo: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .unwrap_or_else(|_| panic!("git {:?} failed to spawn", args));
+    if !out.status.success() {
+        panic!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn init_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    git_cmd(p, &["init", "--initial-branch=main"]);
+    git_cmd(p, &["config", "user.name", "Test"]);
+    git_cmd(p, &["config", "user.email", "test@example.com"]);
+    git_cmd(p, &["config", "commit.gpgsign", "false"]);
+    dir
+}
+
+fn commit_file(repo: &Path, filename: &str, content: &str, message: &str) {
+    std::fs::write(repo.join(filename), content).expect("write");
+    git_cmd(repo, &["add", filename]);
+    git_cmd(repo, &["commit", "-m", message]);
+}
+
+fn make_func(file: &str, name: &str, line: u32) -> FunctionSnapshot {
+    FunctionSnapshot {
+        function_id: name.to_string(),
+        file: file.to_string(),
+        line,
+        language: Language::Python,
+        metrics: MetricsReport {
+            cc: 2,
+            nd: 1,
+            fo: 0,
+            ns: 0,
+            loc: 10,
+        },
+        lrs: 1.0,
+        band: RiskBand::Low,
+        suppression_reason: None,
+        churn: None,
+        touch_count_30d: None,
+        days_since_last_change: None,
+        callgraph: None,
+        activity_risk: None,
+        risk_factors: None,
+        percentile: None,
+        driver: None,
+        driver_detail: None,
+        quadrant: None,
+        patterns: vec![],
+        pattern_details: None,
+        subsystem: None,
+        authors_90d: None,
+    }
+}
+
+fn make_snapshot(functions: Vec<FunctionSnapshot>) -> Snapshot {
+    Snapshot {
+        schema_version: 2,
+        commit: CommitInfo {
+            sha: "test".to_string(),
+            parents: vec![],
+            timestamp: 0,
+            branch: None,
+            message: None,
+            author: None,
+            is_fix_commit: None,
+            is_revert_commit: None,
+            ticket_ids: vec![],
+        },
+        analysis: AnalysisInfo {
+            scope: "test".to_string(),
+            tool_version: "0.0.0".to_string(),
+        },
+        functions,
+        summary: None,
+        aggregates: None,
+    }
+}
+
+// ── Feature extraction ────────────────────────────────────────────────────────
+
+#[test]
+fn extract_features_baseline() {
+    let func = make_func("src/foo.py", "foo", 1);
+    let feats = extract_features(&func);
+    assert_eq!(feats.len(), 9);
+    assert_eq!(FEATURE_NAMES.len(), 9);
+    // total_churn = 0 when no ChurnMetrics
+    assert_eq!(feats[6], 0.0);
+    // activity_risk falls back to lrs
+    assert_eq!(feats[7], feats[0]);
+}
+
+#[test]
+fn extract_features_with_churn_and_callgraph() {
+    let mut func = make_func("src/foo.py", "foo", 1);
+    func.churn = Some(ChurnMetrics {
+        lines_added: 300,
+        lines_deleted: 100,
+        net_change: 200,
+    });
+    func.callgraph = Some(CallGraphMetrics {
+        fan_in: 5,
+        fan_out: 2,
+        pagerank: 0.0,
+        betweenness: 0.0,
+        scc_id: 0,
+        scc_size: 1,
+        is_entrypoint: false,
+        dependency_depth: None,
+        neighbor_churn: None,
+    });
+    func.activity_risk = Some(3.5);
+
+    let feats = extract_features(&func);
+    assert_eq!(feats[5], 5.0); // fan_in
+    assert_eq!(feats[6], 400.0); // total_churn = 300+100
+    assert_eq!(feats[7], 3.5); // activity_risk
+}
+
+// ── collect_fix_files ─────────────────────────────────────────────────────────
+
+#[test]
+fn collect_fix_files_no_fix_commits() {
+    let dir = init_repo();
+    commit_file(dir.path(), "readme.txt", "hello", "initial commit");
+    let files = collect_fix_files(dir.path(), 365).expect("collect_fix_files");
+    assert!(files.is_empty());
+}
+
+#[test]
+fn collect_fix_files_detects_fix_keyword() {
+    let dir = init_repo();
+    let p = dir.path();
+    // First commit: create the files (Add, not Modify — excluded by --diff-filter=M)
+    commit_file(p, "foo.rs", "fn foo() {}", "initial: add files");
+    commit_file(p, "bar.rs", "fn bar() {}", "initial: add bar");
+    commit_file(p, "baz.rs", "fn baz() {}", "initial: add baz");
+    // Second pass: modify each file with semantically distinct commit types
+    commit_file(p, "foo.rs", "fn foo() { 1 }", "feat: enhance foo");
+    commit_file(
+        p,
+        "bar.rs",
+        "fn bar() { 1 }",
+        "fix: resolve null pointer in bar",
+    );
+    commit_file(p, "baz.rs", "fn baz() { 1 }", "chore: cleanup baz");
+
+    let files = collect_fix_files(p, 365).expect("collect_fix_files");
+    assert!(
+        files.contains("bar.rs"),
+        "fix commit file should be labelled"
+    );
+    assert!(
+        !files.contains("foo.rs"),
+        "feature commit should be excluded"
+    );
+    assert!(!files.contains("baz.rs"), "chore commit should be excluded");
+}
+
+#[test]
+fn collect_fix_files_all_keywords() {
+    let dir = init_repo();
+    let p = dir.path();
+    // Create files first (Add commits, not tracked by --diff-filter=M)
+    for (file, _) in &[
+        ("a.rs", ""),
+        ("b.rs", ""),
+        ("c.rs", ""),
+        ("d.rs", ""),
+        ("e.rs", ""),
+    ] {
+        commit_file(p, file, "content", &format!("initial: {}", file));
+    }
+    // Now modify each with a keyword-bearing fix commit
+    for (file, msg) in &[
+        ("a.rs", "bug: wrong output"),
+        ("b.rs", "patch security hole"),
+        ("c.rs", "regression in v2"),
+        ("d.rs", "hotfix prod issue"),
+        ("e.rs", "defect resolved"),
+    ] {
+        commit_file(p, file, "updated content", msg);
+    }
+    let files = collect_fix_files(p, 365).expect("collect_fix_files");
+    for f in &["a.rs", "b.rs", "c.rs", "d.rs", "e.rs"] {
+        assert!(files.contains(*f), "{} should be labelled", f);
+    }
+}
+
+// ── collect_fix_functions ─────────────────────────────────────────────────────
+
+#[test]
+fn collect_fix_functions_labels_correct_function() {
+    let dir = init_repo();
+    let p = dir.path();
+
+    // Initial commit: file with two functions
+    commit_file(
+        p,
+        "mod.py",
+        "def alpha():\n    pass\n\ndef beta():\n    x = 1\n    return x\n",
+        "feat: add mod",
+    );
+    // Fix commit: only beta() changes (line 4 onwards)
+    commit_file(
+        p,
+        "mod.py",
+        "def alpha():\n    pass\n\ndef beta():\n    x = 2  # fixed\n    return x\n",
+        "fix: correct beta value",
+    );
+
+    // Snapshot: alpha at line 1, beta at line 4
+    let snapshot = make_snapshot(vec![
+        make_func("mod.py", "alpha", 1),
+        make_func("mod.py", "beta", 4),
+    ]);
+
+    let labelled = collect_fix_functions(&snapshot, p, 365).expect("collect_fix_functions");
+
+    assert!(
+        labelled.contains(&("mod.py".to_string(), 4)),
+        "beta should be labelled"
+    );
+    assert!(
+        !labelled.contains(&("mod.py".to_string(), 1)),
+        "alpha should NOT be labelled"
+    );
+}
+
+#[test]
+fn collect_fix_functions_ignores_non_fix_commits() {
+    let dir = init_repo();
+    let p = dir.path();
+
+    commit_file(p, "mod.py", "def foo():\n    pass\n", "feat: add foo");
+    commit_file(
+        p,
+        "mod.py",
+        "def foo():\n    return 1\n",
+        "refactor: simplify",
+    );
+
+    let snapshot = make_snapshot(vec![make_func("mod.py", "foo", 1)]);
+    let labelled = collect_fix_functions(&snapshot, p, 365).expect("collect_fix_functions");
+    assert!(labelled.is_empty());
+}
+
+// ── End-to-end model quality ──────────────────────────────────────────────────
+
+/// Verify that a trained model assigns higher scores to functions labelled as
+/// buggy than to clean functions.
+///
+/// Setup:
+/// - 3 Python files, 20 functions each = 60 total (passes 50-func guard)
+/// - "buggy.py" functions have cc=10 (high complexity)
+/// - "clean_a.py" and "clean_b.py" functions have cc=2
+/// - Initial commits create all 3 files, then fix commits modify "buggy.py"
+///   multiple times — labelling its functions as positive
+/// - After training, buggy.py functions should score higher on average
+///
+/// This is a weak statistical test (not per-function), but with cc=10 vs cc=2
+/// and 20 positives vs 40 negatives the RandomForest reliably finds the signal.
+#[test]
+fn trained_model_ranks_buggy_functions_above_clean() {
+    let dir = init_repo();
+    let p = dir.path();
+
+    // Generate a Python file with `n` stub functions, each occupying 3 lines.
+    fn make_py_file(n: usize) -> String {
+        (0..n)
+            .map(|i| format!("def func_{i}():\n    x = {i}\n    return x\n\n"))
+            .collect()
+    }
+
+    // Initial commits: create all three files
+    commit_file(p, "buggy.py", &make_py_file(20), "feat: add buggy module");
+    commit_file(
+        p,
+        "clean_a.py",
+        &make_py_file(20),
+        "feat: add clean_a module",
+    );
+    commit_file(
+        p,
+        "clean_b.py",
+        &make_py_file(20),
+        "feat: add clean_b module",
+    );
+
+    // Fix commits: modify buggy.py multiple times to build up fix-commit labels.
+    // Each commit changes the file slightly so it qualifies as a modification (M).
+    for i in 0..8 {
+        let content = format!("{}\n# fix iteration {i}", make_py_file(20));
+        commit_file(
+            p,
+            "buggy.py",
+            &content,
+            &format!("fix: patch issue #{i} in buggy"),
+        );
+    }
+
+    // Build snapshot: buggy.py functions get cc=10, clean files get cc=2.
+    let mut functions = Vec::new();
+    for i in 0u32..20 {
+        let mut f = make_func("buggy.py", &format!("buggy_func_{i}"), i * 4 + 1);
+        f.metrics.cc = 10;
+        f.lrs = 5.0;
+        functions.push(f);
+    }
+    for i in 0u32..20 {
+        functions.push(make_func(
+            "clean_a.py",
+            &format!("clean_a_func_{i}"),
+            i * 4 + 1,
+        ));
+    }
+    for i in 0u32..20 {
+        functions.push(make_func(
+            "clean_b.py",
+            &format!("clean_b_func_{i}"),
+            i * 4 + 1,
+        ));
+    }
+    let snapshot = make_snapshot(functions);
+
+    let cfg = TrainConfig {
+        n_estimators: 50,
+        ..Default::default()
+    };
+    let model = train(&snapshot, p, &cfg)
+        .expect("train")
+        .expect("model should be returned — enough training signal");
+
+    assert_eq!(model.model_version, 2);
+
+    // Score all functions
+    let scores: Vec<(String, f64)> = snapshot
+        .functions
+        .iter()
+        .map(|f| (f.file.clone(), hotspots_core::trainer::score(&model, f)))
+        .collect();
+
+    let buggy_mean: f64 = {
+        let v: Vec<f64> = scores
+            .iter()
+            .filter(|(file, _)| file == "buggy.py")
+            .map(|(_, s)| *s)
+            .collect();
+        v.iter().sum::<f64>() / v.len() as f64
+    };
+    let clean_mean: f64 = {
+        let v: Vec<f64> = scores
+            .iter()
+            .filter(|(file, _)| file != "buggy.py")
+            .map(|(_, s)| *s)
+            .collect();
+        v.iter().sum::<f64>() / v.len() as f64
+    };
+
+    assert!(
+        buggy_mean > clean_mean,
+        "buggy functions (mean={buggy_mean:.3}) should score higher than clean (mean={clean_mean:.3})"
+    );
+}
+
+// ── Training guard ────────────────────────────────────────────────────────────
+
+#[test]
+fn train_returns_none_below_threshold() {
+    let dir = init_repo();
+    let p = dir.path();
+    commit_file(p, "a.py", "def foo(): pass", "fix: something");
+
+    // Only 3 functions — well below the 50-function minimum
+    let snapshot = make_snapshot(vec![
+        make_func("a.py", "foo", 1),
+        make_func("a.py", "bar", 5),
+        make_func("a.py", "baz", 9),
+    ]);
+
+    let result = train(&snapshot, p, &TrainConfig::default()).expect("train");
+    assert!(result.is_none(), "too few functions → None");
+}

--- a/hotspots-core/tests/trainer_tests.rs
+++ b/hotspots-core/tests/trainer_tests.rs
@@ -114,12 +114,12 @@ fn make_snapshot(functions: Vec<FunctionSnapshot>) -> Snapshot {
 fn extract_features_baseline() {
     let func = make_func("src/foo.py", "foo", 1);
     let feats = extract_features(&func);
-    assert_eq!(feats.len(), 9);
-    assert_eq!(FEATURE_NAMES.len(), 9);
+    assert_eq!(feats.len(), 8);
+    assert_eq!(FEATURE_NAMES.len(), 8);
     // total_churn = 0 when no ChurnMetrics
     assert_eq!(feats[6], 0.0);
-    // activity_risk falls back to lrs
-    assert_eq!(feats[7], feats[0]);
+    // authors_90d = 0 by default
+    assert_eq!(feats[7], 0.0);
 }
 
 #[test]
@@ -146,7 +146,7 @@ fn extract_features_with_churn_and_callgraph() {
     let feats = extract_features(&func);
     assert_eq!(feats[5], 5.0); // fan_in
     assert_eq!(feats[6], 400.0); // total_churn = 300+100
-    assert_eq!(feats[7], 3.5); // activity_risk
+    assert_eq!(feats[7], 0.0); // authors_90d
 }
 
 // ── collect_fix_files ─────────────────────────────────────────────────────────
@@ -363,7 +363,7 @@ fn trained_model_ranks_buggy_functions_above_clean() {
         .expect("train")
         .expect("model should be returned — enough training signal");
 
-    assert_eq!(model.model_version, 2);
+    assert_eq!(model.model_version, 3);
 
     // Score all functions
     let scores: Vec<(String, f64)> = snapshot


### PR DESCRIPTION
## Summary

- Adds `hotspots train` command: fits a local RandomForest ranker from the repo's own fix-commit git history
- 8-feature v3 model set: `lrs`, `cc`, `nd`, `loc`, `fo`, `fan_in`, `total_churn`, `authors_90d` — removes `activity_risk` to prevent circular feature leakage (the v2 model was a no-op: it just reproduced the formula)
- Supports `--blame` mode: blame-based function-level labels via `git diff-tree` hunk parsing, giving precise per-function signal instead of file-level labels
- Adds suppression gate (`hotspots-core/src/gate.rs`): scans 90-day fix history, computes P@10 on top-50 ranked functions, warns when activity ranker is performing poorly
- Adds `--skip-gate` flag; `Inconclusive` verdict (greenfield repos) is always silent
- Auto-routes default `hotspots analyze` through snapshot mode when a trained ranker is present
- Trained ranker scores recompute triage quadrants (debt→fire promotion for high-risk functions)

## Path handling fixes

Two macOS path normalization bugs were diagnosed and fixed during end-to-end testing on Django:
1. `/tmp` → `/private/tmp` symlink: `repo_root.canonicalize()` resolves to `/private/tmp/…` but snapshot stores `/tmp/…` — three-step fallback in `make_rel` handles this
2. Analyze-as-dot paths: snapshot stores `/private/tmp/django/./django/…` (with `./`) but `git diff-tree` emits `django/…` — `strip_prefix("./")` normalization added

## Validated on Django

`hotspots train /path/to/django --blame` → 1,166 blame-labelled functions from 553 fix commits (7.0% base rate, 16,587 functions total). Top RF-ranked results: `_alter_field`, `get_related_selections`, `_changeform_view`, `get_aggregation` — all in `db/models/sql/` and `db/backends/`, exactly where Django's bugs concentrate.

## Research basis

- F31: label quality + leaky features (removes windowed features and `activity_risk` from feature set)
- F27: suppression gate recovers failed tabular ranker
- F28: Linfa fidelity matches XGBoost on clean feature set
- F07/F19/F22: XGBoost tabular path validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)