### PR TITLE
chore: release v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Documentation
-- Add codebase guide (#77)
-
+## [1.21.0] - 2026-06-02
 
 ### Features
-- Hotspots train — RandomForest ranker from fix-commit history (v3) (#79)
+- `hotspots train`: fit a local RandomForest ranker from fix-commit history (#79)
+- Suppression gate: detects when activity heuristic is underperforming and recommends `hotspots train`
+- `hotspots analyze` auto-routes through snapshot mode and applies trained ranker when `.hotspots/ranker.json` exists
+- Trained ranker scores recompute triage quadrants (promotes debt → fire for high-RF functions)
+
+### Bug Fixes
+- Gate P@10 always-zero: snapshot absolute paths now normalised before comparing against git-relative fix-file set
+- Stale `Vec::with_capacity(n * 9)` in trainer corrected to `n * 8`
+
+### Documentation
+- Add codebase guide (#77)
+- Add `hotspots train` to README and full CLI reference
 
 ## [1.20.1] - 2026-05-24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["hotspots-core", "hotspots-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.20.2"
+version = "1.21.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Stephen Collins"]

--- a/hotspots-cli/Cargo.toml
+++ b/hotspots-cli/Cargo.toml
@@ -17,7 +17,7 @@ name = "hotspots"
 path = "src/main.rs"
 
 [dependencies]
-hotspots-core = { version = "1.20.2", path = "../hotspots-core" }
+hotspots-core = { version = "1.21.0", path = "../hotspots-core" }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.17"


### PR DESCRIPTION
Bump version 1.20.2 → 1.21.0 and update CHANGELOG.

## What's in this release

**Features**
- `hotspots train`: fit a local RandomForest ranker from fix-commit history
- Suppression gate: detects when the activity heuristic is underperforming
- `hotspots analyze` auto-applies trained ranker and recomputes triage quadrants

**Bug Fixes**
- Gate P@10 always-zero: snapshot absolute paths now normalised before comparing against git-relative fix-file set
- Stale `Vec::with_capacity(n * 9)` corrected to `n * 8`

**Documentation**
- `hotspots train` added to README and full CLI reference
- Removed stale "GitHub Action coming soon" notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)