### PR TITLE
feat: actionable band-grouped output with color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hotspots-cli"
 version = "1.21.1"
 dependencies = [
@@ -426,6 +432,8 @@ dependencies = [
  "clap",
  "hotspots-core",
  "indicatif",
+ "is-terminal",
+ "owo-colors",
  "rayon",
 ]
 
@@ -439,6 +447,7 @@ dependencies = [
  "linfa-ensemble",
  "linfa-trees",
  "ndarray",
+ "owo-colors",
  "proc-macro2",
  "quote",
  "rand",
@@ -611,6 +620,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -839,6 +859,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "percent-encoding"

--- a/hotspots-cli/Cargo.toml
+++ b/hotspots-cli/Cargo.toml
@@ -21,6 +21,8 @@ hotspots-core = { version = "1.21.1", path = "../hotspots-core" }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.17"
+is-terminal = "0.4"
+owo-colors = "4"
 rayon = "1"
 
 [lints]

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -321,7 +321,12 @@ fn handle_default_output(
 
     match format {
         OutputFormat::Text => {
-            print!("{}", hotspots_core::render_text_grouped(&reports, limit));
+            use is_terminal::IsTerminal;
+            let color = std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+            print!(
+                "{}",
+                hotspots_core::render_text_grouped(&reports, limit, color)
+            );
         }
         OutputFormat::Json => println!("{}", hotspots_core::render_json(&reports)),
         OutputFormat::Html | OutputFormat::Jsonl => {
@@ -767,7 +772,9 @@ fn emit_text_output(
     } else if level == Some(OutputLevel::Module) {
         explain::print_module_output(&aggregates.modules, top)?;
     } else if explain {
-        explain::print_explain_output(snapshot, total_function_count)?;
+        use is_terminal::IsTerminal;
+        let color = std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+        explain::print_explain_output(snapshot, total_function_count, color)?;
     } else {
         anyhow::bail!(
             "text format without --explain is not supported for snapshot mode (use --format json or add --explain)"

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -210,11 +210,6 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
                 skip_touch_metrics: touch_args.skip,
             },
         );
-        if touch_args.is_default(&resolved_config) {
-            eprintln!(
-                "tip: ran with hybrid touch mode (default). For full per-function precision, rerun with --per-function-touches."
-            );
-        }
         return result;
     }
 
@@ -248,11 +243,6 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
                 skip_touch_metrics: touch_args.skip,
             },
         );
-        if touch_args.is_default(&resolved_config) {
-            eprintln!(
-                "tip: ran with hybrid touch mode (default). For full per-function precision, rerun with --per-function-touches."
-            );
-        }
         return result;
     }
 
@@ -272,17 +262,6 @@ struct TouchArgs {
     per_function: bool,
     hybrid: Option<usize>,
     skip: bool,
-}
-
-impl TouchArgs {
-    fn is_default(&self, config: &hotspots_core::ResolvedConfig) -> bool {
-        !self.no_per_function
-            && !self.per_function
-            && self.hybrid.is_none()
-            && config.hybrid_touch_threshold.is_none()
-            && !config.per_function_touches
-            && !self.skip
-    }
 }
 
 fn handle_default_output(
@@ -1104,15 +1083,6 @@ pub(crate) fn build_snapshot_via_db(
     if function_count <= effective_skip_above {
         let call_graph = hotspots_core::build_call_graph_from_db(&db, &sha, repo_root)
             .context("failed to build call graph from DB")?;
-        let total = call_graph.total_callee_names;
-        let resolved = call_graph.resolved_callee_names;
-        if total > 0 {
-            let pct = (resolved as f64 / total as f64) * 100.0;
-            eprintln!(
-                "call graph: resolved {}/{} callee references ({:.0}% internal)",
-                resolved, total, pct
-            );
-        }
         db.update_callgraph_metrics(
             &sha,
             &call_graph,
@@ -1198,19 +1168,7 @@ pub(crate) fn build_enriched_snapshot(
         );
         None
     } else {
-        let cg = hotspots_core::build_call_graph(&reports, repo_root).ok();
-        if let Some(ref cg) = cg {
-            let total = cg.total_callee_names;
-            let resolved = cg.resolved_callee_names;
-            if total > 0 {
-                let pct = (resolved as f64 / total as f64) * 100.0;
-                eprintln!(
-                    "call graph: resolved {}/{} callee references ({:.0}% internal)",
-                    resolved, total, pct
-                );
-            }
-        }
-        cg
+        hotspots_core::build_call_graph(&reports, repo_root).ok()
     };
 
     for r in &mut reports {

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -295,15 +295,20 @@ fn handle_default_output(
 ) -> anyhow::Result<()> {
     let analysis_progress = make_analysis_progress();
     let explicit_top = top.or(resolved_config.top_n);
-    let limit = explicit_top.unwrap_or(10);
+    // 0 is the sentinel for "show all"; otherwise default to 20 for text output
+    let limit = match explicit_top {
+        Some(0) => usize::MAX,
+        Some(n) => n,
+        None => 20,
+    };
     let mut reports = analyze_with_progress(
         path,
         AnalysisOptions {
             min_lrs,
             top_n: if matches!(format, OutputFormat::Text) {
-                Some(limit)
+                Some(limit).filter(|&n| n != usize::MAX)
             } else {
-                explicit_top
+                explicit_top.filter(|&n| n != 0)
             },
         },
         Some(resolved_config),
@@ -839,7 +844,8 @@ fn apply_top_n(
     top: Option<usize>,
 ) {
     let is_aggregate_level = level == Some(OutputLevel::File) || level == Some(OutputLevel::Module);
-    if !is_aggregate_level && (top.is_some() || (matches!(format, OutputFormat::Text) && explain)) {
+    let is_text = matches!(format, OutputFormat::Text);
+    if !is_aggregate_level && (top.is_some() || (is_text && explain)) {
         snapshot.functions.sort_by(|a, b| {
             let a_score = a.activity_risk.unwrap_or(a.lrs);
             let b_score = b.activity_risk.unwrap_or(b.lrs);
@@ -847,8 +853,15 @@ fn apply_top_n(
                 .partial_cmp(&a_score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
-        if let Some(n) = top {
-            snapshot.functions.truncate(n);
+        // 0 = show all; None in text+explain defaults to 20
+        let limit = match top {
+            Some(0) => usize::MAX,
+            Some(n) => n,
+            None if is_text => 20,
+            None => usize::MAX,
+        };
+        if limit != usize::MAX {
+            snapshot.functions.truncate(limit);
         }
     }
 }

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -767,7 +767,7 @@ fn emit_text_output(
     } else if level == Some(OutputLevel::Module) {
         explain::print_module_output(&aggregates.modules, top)?;
     } else if explain {
-        explain::print_explain_output(snapshot, total_function_count, &aggregates.co_change)?;
+        explain::print_explain_output(snapshot, total_function_count)?;
     } else {
         anyhow::bail!(
             "text format without --explain is not supported for snapshot mode (use --format json or add --explain)"

--- a/hotspots-cli/src/output/explain.rs
+++ b/hotspots-cli/src/output/explain.rs
@@ -104,61 +104,10 @@ pub(crate) fn print_module_output(
     Ok(())
 }
 
-/// Format non-zero risk factor lines for a single function.
-/// Print co-change coupling section (source files only).
-pub(crate) fn print_co_change_section(co_change: &[hotspots_core::git::CoChangePair]) {
-    const SRC_EXTS: &[&str] = &[
-        ".rs", ".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".java", ".c", ".cpp", ".h",
-    ];
-    let is_src = |f: &str| SRC_EXTS.iter().any(|ext| f.ends_with(ext));
-    let is_notable = |p: &&hotspots_core::git::CoChangePair| {
-        is_src(&p.file_a) && is_src(&p.file_b) && p.risk != "low"
-    };
-    let notable: Vec<_> = co_change.iter().filter(is_notable).take(10).collect();
-    if notable.is_empty() {
-        return;
-    }
-    println!();
-    println!("Co-Change Coupling (90-day window)");
-    println!("{}", "=".repeat(80));
-    for (i, pair) in notable.iter().enumerate() {
-        let label = if pair.has_static_dep {
-            "expected".to_string()
-        } else {
-            pair.risk.to_uppercase()
-        };
-        println!(
-            "#{:<2} [{:8}] {:.2} ({:2}x)  {}  ↔  {}",
-            i + 1,
-            label,
-            pair.coupling_ratio,
-            pair.co_change_count,
-            pair.file_a,
-            pair.file_b,
-        );
-    }
-    println!("{}", "-".repeat(80));
-    let hidden_count = co_change
-        .iter()
-        .filter(|p| {
-            (p.risk == "high" || p.risk == "moderate")
-                && !p.has_static_dep
-                && is_src(&p.file_a)
-                && is_src(&p.file_b)
-        })
-        .count();
-    let total_notable = co_change.iter().filter(is_notable).count();
-    println!(
-        "{} notable pairs ({} hidden coupling)  |  Run with --format json for full list",
-        total_notable, hidden_count
-    );
-}
-
 /// Print human-readable risk explanations for top functions.
 pub(crate) fn print_explain_output(
     snapshot: &hotspots_core::snapshot::Snapshot,
     total_count: usize,
-    co_change: &[hotspots_core::git::CoChangePair],
 ) -> anyhow::Result<()> {
     use hotspots_core::risk::RiskBand;
 
@@ -247,8 +196,6 @@ pub(crate) fn print_explain_output(
         println!("{} functions shown ({} medium/low omitted)", shown, hidden);
         println!("Use --top 0 to show all  ·  --top N for a different limit  ·  --format json for full output");
     }
-
-    print_co_change_section(co_change);
 
     Ok(())
 }

--- a/hotspots-cli/src/output/explain.rs
+++ b/hotspots-cli/src/output/explain.rs
@@ -1,4 +1,4 @@
-use crate::util::{driving_dimension, truncate_string};
+use crate::util::truncate_string;
 
 /// Print ranked file risk table.
 pub(crate) fn print_file_risk_output(
@@ -105,84 +105,6 @@ pub(crate) fn print_module_output(
 }
 
 /// Format non-zero risk factor lines for a single function.
-pub(crate) fn format_risk_factor_lines(
-    func: &hotspots_core::snapshot::FunctionSnapshot,
-) -> Vec<String> {
-    let factors = match func.risk_factors.as_ref() {
-        Some(f) => f,
-        None => return Vec::new(),
-    };
-    let mut lines = Vec::new();
-    if factors.complexity > 0.0 {
-        lines.push(format!(
-            "     • Complexity:      {:>6.2}  (cyclomatic={}, nesting={}, fanout={})",
-            factors.complexity, func.metrics.cc, func.metrics.nd, func.metrics.fo
-        ));
-    }
-    if factors.churn > 0.0 {
-        let churn_lines = func
-            .churn
-            .as_ref()
-            .map(|c| c.lines_added + c.lines_deleted)
-            .unwrap_or(0);
-        lines.push(format!(
-            "     • Churn:           {:>6.2}  ({} lines changed recently)",
-            factors.churn, churn_lines
-        ));
-    }
-    if factors.activity > 0.0 {
-        let touches = func.touch_count_30d.unwrap_or(0);
-        lines.push(format!(
-            "     • Activity:        {:>6.2}  ({} commits in last 30 days)",
-            factors.activity, touches
-        ));
-    }
-    if factors.recency > 0.0 {
-        let days = func.days_since_last_change.unwrap_or(0);
-        lines.push(format!(
-            "     • Recency:         {:>6.2}  (last changed {} days ago)",
-            factors.recency, days
-        ));
-    }
-    if factors.fan_in > 0.0 {
-        let fi = func.callgraph.as_ref().map(|cg| cg.fan_in).unwrap_or(0);
-        lines.push(format!(
-            "     • Fan-in:          {:>6.2}  ({} functions depend on this)",
-            factors.fan_in, fi
-        ));
-    }
-    if factors.cyclic_dependency > 0.0 {
-        let scc = func.callgraph.as_ref().map(|cg| cg.scc_size).unwrap_or(1);
-        lines.push(format!(
-            "     • Cyclic deps:     {:>6.2}  (in a {}-function cycle)",
-            factors.cyclic_dependency, scc
-        ));
-    }
-    if factors.depth > 0.0 {
-        let depth = func
-            .callgraph
-            .as_ref()
-            .and_then(|cg| cg.dependency_depth)
-            .unwrap_or(0);
-        lines.push(format!(
-            "     • Depth:           {:>6.2}  ({} levels from entry point)",
-            factors.depth, depth
-        ));
-    }
-    if factors.neighbor_churn > 0.0 {
-        let nc = func
-            .callgraph
-            .as_ref()
-            .and_then(|cg| cg.neighbor_churn)
-            .unwrap_or(0);
-        lines.push(format!(
-            "     • Neighbor churn:  {:>6.2}  ({} lines changed in dependencies)",
-            factors.neighbor_churn, nc
-        ));
-    }
-    lines
-}
-
 /// Print co-change coupling section (source files only).
 pub(crate) fn print_co_change_section(co_change: &[hotspots_core::git::CoChangePair]) {
     const SRC_EXTS: &[&str] = &[
@@ -238,90 +160,93 @@ pub(crate) fn print_explain_output(
     total_count: usize,
     co_change: &[hotspots_core::git::CoChangePair],
 ) -> anyhow::Result<()> {
-    let display_count = snapshot.functions.len();
+    use hotspots_core::risk::RiskBand;
 
-    if display_count == 0 {
+    let funcs = &snapshot.functions;
+    if funcs.is_empty() {
         println!("No functions to display.");
         return Ok(());
     }
 
-    let title = if display_count < total_count {
-        format!("Top {} Functions by Activity Risk", display_count)
-    } else {
-        "All Functions by Activity Risk".to_string()
+    let show_all = funcs.len() >= total_count;
+
+    let critical: Vec<_> = funcs
+        .iter()
+        .filter(|f| f.band == RiskBand::Critical)
+        .collect();
+    let high: Vec<_> = funcs.iter().filter(|f| f.band == RiskBand::High).collect();
+    let lower: Vec<_> = funcs
+        .iter()
+        .filter(|f| matches!(f.band, RiskBand::Moderate | RiskBand::Low))
+        .collect();
+
+    let cwd = std::env::current_dir().ok();
+    let rel_path = |p: &str| -> String {
+        cwd.as_ref()
+            .and_then(|cwd| {
+                std::path::Path::new(p)
+                    .strip_prefix(cwd)
+                    .ok()
+                    .map(|r| r.to_string_lossy().into_owned())
+            })
+            .unwrap_or_else(|| p.to_string())
     };
 
-    println!("{}", title);
-    println!("{}", "=".repeat(80));
-    println!();
+    // Compute file:line column width across all visible rows.
+    let visible_iter: Box<dyn Iterator<Item = &&hotspots_core::snapshot::FunctionSnapshot>> =
+        if show_all {
+            Box::new(critical.iter().chain(high.iter()).chain(lower.iter()))
+        } else {
+            Box::new(critical.iter().chain(high.iter()))
+        };
+    let col_width = visible_iter
+        .map(|f| format!("{}:{}", rel_path(&f.file), f.line).len())
+        .max()
+        .unwrap_or(30)
+        .min(55);
 
-    for (i, func) in snapshot.functions.iter().take(display_count).enumerate() {
-        let score = func.activity_risk.unwrap_or(func.lrs);
-        let func_name = func
-            .function_id
-            .split("::")
-            .last()
-            .unwrap_or(&func.function_id);
-        let (driver, action) = driving_dimension(func);
-        println!(
-            "#{} {} [{}] [{}]",
-            i + 1,
-            func_name,
-            func.band.as_str().to_uppercase(),
-            driver
-        );
-        println!("   File: {}:{}", func.file, func.line);
-        println!(
-            "   Risk Score: {:.2} (complexity base: {:.2})",
-            score, func.lrs
-        );
-        let factor_lines = format_risk_factor_lines(func);
-        if !factor_lines.is_empty() {
-            println!("   Risk Breakdown:");
-            for line in factor_lines {
-                println!("{}", line);
+    let print_section =
+        |header: &str, rows: &[&hotspots_core::snapshot::FunctionSnapshot], col_w: usize| {
+            if rows.is_empty() {
+                return;
             }
-        }
-        println!("   Action: {}", action);
-        if driver == "composite" {
-            if let Some(ref detail) = func.driver_detail {
-                println!("   Near-threshold: {}", detail);
+            println!("{} ({})", header, rows.len());
+            for f in rows {
+                let score = f.activity_risk.unwrap_or(f.lrs);
+                let name = f.function_id.split("::").last().unwrap_or(&f.function_id);
+                let loc = format!("{}:{}", rel_path(&f.file), f.line);
+                let patterns_str = if f.patterns.is_empty() {
+                    String::new()
+                } else {
+                    format!("  [{}]", f.patterns.join(", "))
+                };
+                println!(
+                    "  {:.2}  {:<col_w$}  {}{}",
+                    score,
+                    loc,
+                    name,
+                    patterns_str,
+                    col_w = col_w
+                );
             }
-        }
-        if !func.patterns.is_empty() {
-            println!("   Patterns: {}", func.patterns.join(", "));
-            if let Some(ref details) = func.pattern_details {
-                for pd in details {
-                    let triggered = pd
-                        .triggered_by
-                        .iter()
-                        .map(|t| format!("{}={} ({}{})", t.metric, t.value, t.op, t.threshold))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    println!("     • {}: {}", pd.id, triggered);
-                }
-            }
-        }
-        println!();
+            println!();
+        };
+
+    print_section("CRITICAL", &critical, col_width);
+    print_section("HIGH", &high, col_width);
+    if show_all {
+        print_section("MEDIUM / LOW", &lower, col_width);
     }
 
-    println!("{}", "-".repeat(80));
-    let critical_count = snapshot
-        .functions
-        .iter()
-        .take(display_count)
-        .filter(|f| f.band == hotspots_core::risk::RiskBand::Critical)
-        .count();
-    let high_count = snapshot
-        .functions
-        .iter()
-        .take(display_count)
-        .filter(|f| f.band == hotspots_core::risk::RiskBand::High)
-        .count();
-    println!(
-        "Showing {}/{} functions  |  Critical: {}  High: {}",
-        display_count, total_count, critical_count, high_count
-    );
+    println!("{}", "─".repeat(60));
+    if show_all {
+        println!("{} functions total", funcs.len());
+    } else {
+        let shown = critical.len() + high.len();
+        let hidden = lower.len();
+        println!("{} functions shown ({} medium/low omitted)", shown, hidden);
+        println!("Use --top 0 to show all  ·  --top N for a different limit  ·  --format json for full output");
+    }
 
     print_co_change_section(co_change);
 

--- a/hotspots-cli/src/output/explain.rs
+++ b/hotspots-cli/src/output/explain.rs
@@ -108,8 +108,10 @@ pub(crate) fn print_module_output(
 pub(crate) fn print_explain_output(
     snapshot: &hotspots_core::snapshot::Snapshot,
     total_count: usize,
+    color: bool,
 ) -> anyhow::Result<()> {
     use hotspots_core::risk::RiskBand;
+    use owo_colors::OwoColorize;
 
     let funcs = &snapshot.functions;
     if funcs.is_empty() {
@@ -154,37 +156,51 @@ pub(crate) fn print_explain_output(
         .unwrap_or(30)
         .min(55);
 
-    let print_section =
-        |header: &str, rows: &[&hotspots_core::snapshot::FunctionSnapshot], col_w: usize| {
-            if rows.is_empty() {
-                return;
-            }
-            println!("{} ({})", header, rows.len());
-            for f in rows {
-                let score = f.activity_risk.unwrap_or(f.lrs);
-                let name = f.function_id.split("::").last().unwrap_or(&f.function_id);
-                let loc = format!("{}:{}", rel_path(&f.file), f.line);
-                let patterns_str = if f.patterns.is_empty() {
-                    String::new()
-                } else {
-                    format!("  [{}]", f.patterns.join(", "))
-                };
-                println!(
-                    "  {:.2}  {:<col_w$}  {}{}",
-                    score,
-                    loc,
-                    name,
-                    patterns_str,
-                    col_w = col_w
-                );
-            }
-            println!();
-        };
+    let paint = |s: &str, paint_fn: &dyn Fn(&str) -> String| -> String {
+        if color {
+            paint_fn(s)
+        } else {
+            s.to_string()
+        }
+    };
+    let red = |s: &str| s.red().bold().to_string();
+    let yellow = |s: &str| s.yellow().bold().to_string();
+    let green = |s: &str| s.green().to_string();
 
-    print_section("CRITICAL", &critical, col_width);
-    print_section("HIGH", &high, col_width);
+    let print_section = |header: &str,
+                         rows: &[&hotspots_core::snapshot::FunctionSnapshot],
+                         col_w: usize,
+                         painter: &dyn Fn(&str) -> String| {
+        if rows.is_empty() {
+            return;
+        }
+        println!("{} ({})", paint(header, painter), rows.len());
+        for f in rows {
+            let score = f.activity_risk.unwrap_or(f.lrs);
+            let score_str = format!("{:.2}", score);
+            let name = f.function_id.split("::").last().unwrap_or(&f.function_id);
+            let loc = format!("{}:{}", rel_path(&f.file), f.line);
+            let patterns_str = if f.patterns.is_empty() {
+                String::new()
+            } else {
+                format!("  [{}]", f.patterns.join(", "))
+            };
+            println!(
+                "  {}  {:<col_w$}  {}{}",
+                paint(&score_str, painter),
+                loc,
+                name,
+                patterns_str,
+                col_w = col_w
+            );
+        }
+        println!();
+    };
+
+    print_section("CRITICAL", &critical, col_width, &red);
+    print_section("HIGH", &high, col_width, &yellow);
     if show_all {
-        print_section("MEDIUM / LOW", &lower, col_width);
+        print_section("MEDIUM / LOW", &lower, col_width, &green);
     }
 
     println!("{}", "─".repeat(60));

--- a/hotspots-cli/src/output/explain.rs
+++ b/hotspots-cli/src/output/explain.rs
@@ -177,7 +177,6 @@ pub(crate) fn print_explain_output(
         println!("{} ({})", paint(header, painter), rows.len());
         for f in rows {
             let score = f.activity_risk.unwrap_or(f.lrs);
-            let score_str = format!("{:.2}", score);
             let name = f.function_id.split("::").last().unwrap_or(&f.function_id);
             let loc = format!("{}:{}", rel_path(&f.file), f.line);
             let patterns_str = if f.patterns.is_empty() {
@@ -186,8 +185,8 @@ pub(crate) fn print_explain_output(
                 format!("  [{}]", f.patterns.join(", "))
             };
             println!(
-                "  {}  {:<col_w$}  {}{}",
-                paint(&score_str, painter),
+                "  {:.2}  {:<col_w$}  {}{}",
+                score,
                 loc,
                 name,
                 patterns_str,

--- a/hotspots-cli/src/util.rs
+++ b/hotspots-cli/src/util.rs
@@ -1,16 +1,6 @@
 use anyhow::Context;
 use std::path::{Path, PathBuf};
 
-/// Map a driving dimension label to its (label, action) pair.
-pub(crate) fn driving_dimension(
-    func: &hotspots_core::snapshot::FunctionSnapshot,
-) -> (&'static str, &'static str) {
-    let label = hotspots_core::snapshot::normalize_driver_label(
-        func.driver.as_deref().unwrap_or("composite"),
-    );
-    (label, hotspots_core::snapshot::driver_action(label))
-}
-
 /// Truncate a string to at most `max_len` characters, appending `...` if truncated.
 pub(crate) fn truncate_string(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {

--- a/hotspots-core/Cargo.toml
+++ b/hotspots-core/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
+owo-colors = "4"
 globset = "0.4"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"

--- a/hotspots-core/src/report.rs
+++ b/hotspots-core/src/report.rs
@@ -256,15 +256,14 @@ pub fn render_text_grouped(reports: &[FunctionRiskReport], limit: usize, color: 
         s.push_str(&format!("{} ({})\n", paint(header), rows.len()));
         for r in rows {
             let loc = format!("{}:{}", rel(&r.file), r.line);
-            let score_str = format!("{:.2}", r.lrs);
             let patterns_str = if r.patterns.is_empty() {
                 String::new()
             } else {
                 format!("  [{}]", r.patterns.join(", "))
             };
             s.push_str(&format!(
-                "  {}  {:<col_w$}  {}{}",
-                paint(&score_str),
+                "  {:.2}  {:<col_w$}  {}{}",
+                r.lrs,
                 loc,
                 r.function,
                 patterns_str,

--- a/hotspots-core/src/report.rs
+++ b/hotspots-core/src/report.rs
@@ -195,11 +195,12 @@ pub fn render_text(reports: &[FunctionRiskReport]) -> String {
     output
 }
 
-/// Render reports grouped by file, with a footer showing counts and usage hints.
+/// Render reports grouped by risk band (CRITICAL → HIGH → MODERATE/LOW).
 ///
-/// `limit` is the top-N that was requested so the footer can hint at using --top.
+/// MODERATE and LOW are omitted unless `limit` is `usize::MAX` (i.e. `--top 0`).
+/// `limit` is also used in the footer hint.
 pub fn render_text_grouped(reports: &[FunctionRiskReport], limit: usize) -> String {
-    use std::collections::BTreeMap;
+    let show_all = limit == usize::MAX;
     let mut output = String::new();
     let cwd = std::env::current_dir().ok();
 
@@ -214,60 +215,88 @@ pub fn render_text_grouped(reports: &[FunctionRiskReport], limit: usize) -> Stri
             .unwrap_or_else(|| p.to_string())
     };
 
-    let mut by_file: BTreeMap<String, Vec<&FunctionRiskReport>> = BTreeMap::new();
-    let mut file_order: Vec<String> = Vec::new();
-    for r in reports {
-        let key = rel_path(&r.file);
-        if !by_file.contains_key(&key) {
-            file_order.push(key.clone());
-        }
-        by_file.entry(key).or_default().push(r);
-    }
+    let critical: Vec<&FunctionRiskReport> = reports
+        .iter()
+        .filter(|r| r.band == RiskBand::Critical)
+        .collect();
+    let high: Vec<&FunctionRiskReport> = reports
+        .iter()
+        .filter(|r| r.band == RiskBand::High)
+        .collect();
+    let lower: Vec<&FunctionRiskReport> = reports
+        .iter()
+        .filter(|r| matches!(r.band, RiskBand::Moderate | RiskBand::Low))
+        .collect();
 
-    for file_key in &file_order {
-        let fns = &by_file[file_key];
-        output.push_str(&format!("{}\n", file_key));
-        for r in fns.iter() {
-            let lrs_str = format!("{:.2}", r.lrs);
-            let band = r.band.as_str();
+    // Compute file:line column width across all visible rows for alignment.
+    let visible: Vec<&&FunctionRiskReport> = critical
+        .iter()
+        .chain(high.iter())
+        .chain(if show_all { lower.iter() } else { [].iter() })
+        .collect();
+    let col_width = visible
+        .iter()
+        .map(|r| format!("{}:{}", rel_path(&r.file), r.line).len())
+        .max()
+        .unwrap_or(30)
+        .min(55);
+
+    let render_section = |header: &str,
+                          rows: &[&FunctionRiskReport],
+                          col_w: usize,
+                          rel: &dyn Fn(&str) -> String|
+     -> String {
+        let mut s = String::new();
+        if rows.is_empty() {
+            return s;
+        }
+        s.push_str(&format!("{} ({})\n", header, rows.len()));
+        for r in rows {
+            let loc = format!("{}:{}", rel(&r.file), r.line);
             let patterns_str = if r.patterns.is_empty() {
                 String::new()
             } else {
                 format!("  [{}]", r.patterns.join(", "))
             };
-            output.push_str(&format!(
-                "  {:<6}  {:<8}  {}  line {}{}",
-                lrs_str, band, r.function, r.line, patterns_str
+            s.push_str(&format!(
+                "  {:.2}  {:<col_w$}  {}{}",
+                r.lrs,
+                loc,
+                r.function,
+                patterns_str,
+                col_w = col_w
             ));
-            output.push('\n');
-            if let Some(ref details) = r.pattern_details {
-                for d in details {
-                    let conds = d
-                        .triggered_by
-                        .iter()
-                        .map(|t| format!("{}={} ({}{})", t.metric, t.value, t.op, t.threshold))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    output.push_str(&format!("             {}: {}\n", d.id, conds));
-                }
-            }
+            s.push('\n');
         }
-        output.push('\n');
+        s.push('\n');
+        s
+    };
+
+    output.push_str(&render_section("CRITICAL", &critical, col_width, &rel_path));
+    output.push_str(&render_section("HIGH", &high, col_width, &rel_path));
+    if show_all {
+        output.push_str(&render_section(
+            "MEDIUM / LOW",
+            &lower,
+            col_width,
+            &rel_path,
+        ));
     }
 
-    let shown = reports.len();
     let sep = "─".repeat(60);
     output.push_str(&sep);
     output.push('\n');
-    output.push_str(&format!(
-        "Top {} functions across {} files\n",
-        shown,
-        file_order.len()
-    ));
-    output.push_str(&format!(
-        "Use --top N to see more (default {})  ·  --format json for full output\n",
-        limit
-    ));
+    if show_all {
+        output.push_str(&format!("{} functions total\n", reports.len()));
+    } else {
+        let shown = critical.len() + high.len();
+        let hidden = lower.len();
+        output.push_str(&format!(
+            "{} functions shown ({} medium/low omitted)\n",
+            shown, hidden
+        ));
+        output.push_str("Use --top 0 to show all  ·  --top N for a different limit  ·  --format json for full output\n");
+    }
     output
 }
 
@@ -321,51 +350,75 @@ mod tests {
     }
 
     #[test]
-    fn test_render_text_grouped_groups_by_file() {
-        let reports = vec![
-            make_report("/repo/src/a.ts", "foo", 10, 8.0),
-            make_report("/repo/src/b.ts", "bar", 20, 7.0),
-            make_report("/repo/src/a.ts", "baz", 30, 6.0),
-        ];
-        let out = render_text_grouped(&reports, 10);
-        // a.ts section appears before b.ts (rank order)
-        let a_pos = out.find("src/a.ts").unwrap_or(usize::MAX);
-        let b_pos = out.find("src/b.ts").unwrap_or(usize::MAX);
-        assert!(a_pos < b_pos, "a.ts should appear before b.ts");
-        // both functions from a.ts are present
+    fn test_render_text_grouped_groups_by_band() {
+        let mut critical = make_report("/repo/src/a.ts", "foo", 10, 12.0);
+        critical.band = RiskBand::Critical;
+        let mut high = make_report("/repo/src/b.ts", "bar", 20, 7.0);
+        high.band = RiskBand::High;
+        let reports = vec![critical, high];
+        let out = render_text_grouped(&reports, 20);
+        let crit_pos = out.find("CRITICAL").unwrap_or(usize::MAX);
+        let high_pos = out.find("HIGH").unwrap_or(usize::MAX);
+        assert!(
+            crit_pos < high_pos,
+            "CRITICAL section should appear before HIGH"
+        );
         assert!(out.contains("foo"), "should contain foo");
-        assert!(out.contains("baz"), "should contain baz");
         assert!(out.contains("bar"), "should contain bar");
     }
 
     #[test]
     fn test_render_text_grouped_footer_counts() {
-        let reports = vec![
-            make_report("/repo/src/a.ts", "foo", 10, 8.0),
-            make_report("/repo/src/b.ts", "bar", 20, 7.0),
-        ];
-        let out = render_text_grouped(&reports, 10);
+        let mut r1 = make_report("/repo/src/a.ts", "foo", 10, 12.0);
+        r1.band = RiskBand::Critical;
+        let mut r2 = make_report("/repo/src/b.ts", "bar", 20, 7.0);
+        r2.band = RiskBand::High;
+        let out = render_text_grouped(&[r1, r2], 20);
         assert!(
-            out.contains("Top 2 functions across 2 files"),
-            "footer should show correct counts"
-        );
-        assert!(
-            out.contains("default 10"),
-            "footer should show the default limit"
+            out.contains("2 functions shown"),
+            "footer should show shown count"
         );
     }
 
     #[test]
+    fn test_render_text_grouped_lower_omitted_by_default() {
+        let mut r = make_report("/repo/src/a.ts", "foo", 10, 2.0);
+        r.band = RiskBand::Low;
+        let out = render_text_grouped(&[r], 20);
+        assert!(
+            !out.contains("foo"),
+            "low band should be omitted by default"
+        );
+        assert!(
+            out.contains("medium/low omitted"),
+            "footer should note omission"
+        );
+    }
+
+    #[test]
+    fn test_render_text_grouped_lower_shown_when_show_all() {
+        let mut r = make_report("/repo/src/a.ts", "foo", 10, 2.0);
+        r.band = RiskBand::Low;
+        let out = render_text_grouped(&[r], usize::MAX);
+        assert!(
+            out.contains("foo"),
+            "low band should be shown with show-all"
+        );
+        assert!(out.contains("MEDIUM / LOW"));
+    }
+
+    #[test]
     fn test_render_text_grouped_patterns_shown() {
-        let mut r = make_report("/repo/src/a.ts", "foo", 10, 8.0);
+        let mut r = make_report("/repo/src/a.ts", "foo", 10, 12.0);
+        r.band = RiskBand::Critical;
         r.patterns = vec!["god_function".to_string(), "exit_heavy".to_string()];
-        let out = render_text_grouped(&[r], 10);
+        let out = render_text_grouped(&[r], 20);
         assert!(out.contains("[god_function, exit_heavy]"));
     }
 
     #[test]
     fn test_render_text_grouped_empty() {
-        let out = render_text_grouped(&[], 10);
-        assert!(out.contains("Top 0 functions across 0 files"));
+        let out = render_text_grouped(&[], 20);
+        assert!(out.contains("0 functions shown"));
     }
 }

--- a/hotspots-core/src/report.rs
+++ b/hotspots-core/src/report.rs
@@ -198,8 +198,10 @@ pub fn render_text(reports: &[FunctionRiskReport]) -> String {
 /// Render reports grouped by risk band (CRITICAL → HIGH → MODERATE/LOW).
 ///
 /// MODERATE and LOW are omitted unless `limit` is `usize::MAX` (i.e. `--top 0`).
-/// `limit` is also used in the footer hint.
-pub fn render_text_grouped(reports: &[FunctionRiskReport], limit: usize) -> String {
+/// `color` enables ANSI codes — pass `false` when stdout is not a TTY.
+pub fn render_text_grouped(reports: &[FunctionRiskReport], limit: usize, color: bool) -> String {
+    use owo_colors::OwoColorize;
+
     let show_all = limit == usize::MAX;
     let mut output = String::new();
     let cwd = std::env::current_dir().ok();
@@ -244,23 +246,25 @@ pub fn render_text_grouped(reports: &[FunctionRiskReport], limit: usize) -> Stri
     let render_section = |header: &str,
                           rows: &[&FunctionRiskReport],
                           col_w: usize,
-                          rel: &dyn Fn(&str) -> String|
+                          rel: &dyn Fn(&str) -> String,
+                          paint: &dyn Fn(&str) -> String|
      -> String {
         let mut s = String::new();
         if rows.is_empty() {
             return s;
         }
-        s.push_str(&format!("{} ({})\n", header, rows.len()));
+        s.push_str(&format!("{} ({})\n", paint(header), rows.len()));
         for r in rows {
             let loc = format!("{}:{}", rel(&r.file), r.line);
+            let score_str = format!("{:.2}", r.lrs);
             let patterns_str = if r.patterns.is_empty() {
                 String::new()
             } else {
                 format!("  [{}]", r.patterns.join(", "))
             };
             s.push_str(&format!(
-                "  {:.2}  {:<col_w$}  {}{}",
-                r.lrs,
+                "  {}  {:<col_w$}  {}{}",
+                paint(&score_str),
                 loc,
                 r.function,
                 patterns_str,
@@ -272,14 +276,41 @@ pub fn render_text_grouped(reports: &[FunctionRiskReport], limit: usize) -> Stri
         s
     };
 
-    output.push_str(&render_section("CRITICAL", &critical, col_width, &rel_path));
-    output.push_str(&render_section("HIGH", &high, col_width, &rel_path));
+    let red = |s: &str| -> String {
+        if color {
+            s.red().bold().to_string()
+        } else {
+            s.to_string()
+        }
+    };
+    let yellow = |s: &str| -> String {
+        if color {
+            s.yellow().bold().to_string()
+        } else {
+            s.to_string()
+        }
+    };
+    let green = |s: &str| -> String {
+        if color {
+            s.green().to_string()
+        } else {
+            s.to_string()
+        }
+    };
+
+    output.push_str(&render_section(
+        "CRITICAL", &critical, col_width, &rel_path, &red,
+    ));
+    output.push_str(&render_section(
+        "HIGH", &high, col_width, &rel_path, &yellow,
+    ));
     if show_all {
         output.push_str(&render_section(
             "MEDIUM / LOW",
             &lower,
             col_width,
             &rel_path,
+            &green,
         ));
     }
 
@@ -356,7 +387,7 @@ mod tests {
         let mut high = make_report("/repo/src/b.ts", "bar", 20, 7.0);
         high.band = RiskBand::High;
         let reports = vec![critical, high];
-        let out = render_text_grouped(&reports, 20);
+        let out = render_text_grouped(&reports, 20, false);
         let crit_pos = out.find("CRITICAL").unwrap_or(usize::MAX);
         let high_pos = out.find("HIGH").unwrap_or(usize::MAX);
         assert!(
@@ -373,7 +404,7 @@ mod tests {
         r1.band = RiskBand::Critical;
         let mut r2 = make_report("/repo/src/b.ts", "bar", 20, 7.0);
         r2.band = RiskBand::High;
-        let out = render_text_grouped(&[r1, r2], 20);
+        let out = render_text_grouped(&[r1, r2], 20, false);
         assert!(
             out.contains("2 functions shown"),
             "footer should show shown count"
@@ -384,7 +415,7 @@ mod tests {
     fn test_render_text_grouped_lower_omitted_by_default() {
         let mut r = make_report("/repo/src/a.ts", "foo", 10, 2.0);
         r.band = RiskBand::Low;
-        let out = render_text_grouped(&[r], 20);
+        let out = render_text_grouped(&[r], 20, false);
         assert!(
             !out.contains("foo"),
             "low band should be omitted by default"
@@ -399,7 +430,7 @@ mod tests {
     fn test_render_text_grouped_lower_shown_when_show_all() {
         let mut r = make_report("/repo/src/a.ts", "foo", 10, 2.0);
         r.band = RiskBand::Low;
-        let out = render_text_grouped(&[r], usize::MAX);
+        let out = render_text_grouped(&[r], usize::MAX, false);
         assert!(
             out.contains("foo"),
             "low band should be shown with show-all"
@@ -412,13 +443,13 @@ mod tests {
         let mut r = make_report("/repo/src/a.ts", "foo", 10, 12.0);
         r.band = RiskBand::Critical;
         r.patterns = vec!["god_function".to_string(), "exit_heavy".to_string()];
-        let out = render_text_grouped(&[r], 20);
+        let out = render_text_grouped(&[r], 20, false);
         assert!(out.contains("[god_function, exit_heavy]"));
     }
 
     #[test]
     fn test_render_text_grouped_empty() {
-        let out = render_text_grouped(&[], 20);
+        let out = render_text_grouped(&[], 20, false);
         assert!(out.contains("0 functions shown"));
     }
 }

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -792,14 +792,6 @@ impl Snapshot {
             return Ok(());
         }
 
-        let total = self.functions.len();
-        eprintln!(
-            "hybrid touch: {}/{} functions qualify (≥{} touches/30d), refining with git log -L",
-            hot_indices.len(),
-            total,
-            threshold
-        );
-
         self.populate_per_function_touch_for_indices(repo_root, &hot_indices, progress_fn)
     }
 


### PR DESCRIPTION
## Summary

Before: flat list with diagnostic noise, co-change section, no color, no default limit.

After:

\`\`\`
Using config: .../.hotspotsrc.json
CRITICAL (13)
  0.92  benchmarks/bench.py:478              _save_stress_results  [god_function, long_function]
  0.80  hotspots-core/src/trainer.rs:175     collect_fix_functions  [complex_branching, ...]
  ...

HIGH (7)
  0.71  hotspots-core/src/snapshot.rs:570    populate_per_function_touch_for_indices  [...]
  ...

────────────────────────────────────────────────────────────
20 functions shown (0 medium/low omitted)
Use --top 0 to show all  ·  --top N for a different limit  ·  --format json for full output
\`\`\`

## Changes

- **Band-grouped output** — CRITICAL → HIGH → MEDIUM/LOW sections replace flat list
- **Default limit** — top 20 by default; `--top 0` shows all including MEDIUM/LOW; `--top N` for custom
- **ANSI color** — section headers bold red/yellow/green on TTY; auto-disabled when piped or `NO_COLOR` set; color on headers only (scores unchanged)
- **Co-change section removed** — dropped from default text output entirely
- **Silent stderr** — call graph resolution stats, hybrid touch counts, and tip line suppressed by default

## Test plan

- [ ] `./target/release/hotspots analyze .` — CRITICAL/HIGH sections with color, clean stderr
- [ ] `./target/release/hotspots analyze . | cat` — no ANSI codes when piped
- [ ] `./target/release/hotspots analyze . --top 0` — MEDIUM/LOW section appears
- [ ] `cargo test` — 352 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)