### PR TITLE
feat: directed coupling signal (F37/F38/F39)

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -435,12 +435,18 @@ fn handle_snapshot_mode(
 
     // Populate DC before persisting so the snapshot on disk includes the values,
     // and before apply_trained_ranker so the ranker reads real DC instead of 0.0.
+    // Partner scores use make_rel so keys match the repo-relative paths that
+    // compute_directed_coupling_for_repo produces from git log output.
     {
-        use std::collections::HashMap;
-        let partner_scores: HashMap<String, f64> = snapshot
+        use hotspots_core::trainer::{make_rel, repo_prefixes};
+        let (prefix_can, prefix_raw) = repo_prefixes(repo_root);
+        let partner_scores: std::collections::HashMap<String, f64> = snapshot
             .functions
             .iter()
-            .map(|f| (f.file.clone(), f.activity_risk.unwrap_or(f.lrs)))
+            .map(|f| {
+                let rel = make_rel(&f.file, &prefix_can, &prefix_raw);
+                (rel, f.activity_risk.unwrap_or(f.lrs))
+            })
             .collect();
         snapshot.populate_directed_coupling(repo_root, &partner_scores);
     }

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -433,6 +433,18 @@ fn handle_snapshot_mode(
         snapshot.populate_pattern_details(&resolved_config.pattern_thresholds);
     }
 
+    // Populate DC before persisting so the snapshot on disk includes the values,
+    // and before apply_trained_ranker so the ranker reads real DC instead of 0.0.
+    {
+        use std::collections::HashMap;
+        let partner_scores: HashMap<String, f64> = snapshot
+            .functions
+            .iter()
+            .map(|f| (f.file.clone(), f.activity_risk.unwrap_or(f.lrs)))
+            .collect();
+        snapshot.populate_directed_coupling(repo_root, &partner_scores);
+    }
+
     if !pr_context.is_pr && !no_persist {
         snapshot::persist_snapshot(repo_root, &snapshot, force)
             .context("failed to persist snapshot")?;

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -1101,6 +1101,8 @@ mod tests {
             pattern_details: None,
             subsystem: None,
             authors_90d: None,
+            directed_coupling: None,
+            jaccard_label_stability: None,
         }
     }
 

--- a/hotspots-core/src/coupling.rs
+++ b/hotspots-core/src/coupling.rs
@@ -282,6 +282,15 @@ pub fn compute_directed_coupling_for_repo(
         return (HashMap::new(), None);
     }
 
+    // On large repos the git log traversal can take several seconds.
+    // Surface this so users aren't surprised by latency in hotspots analyze.
+    if commits.len() > 50_000 {
+        eprintln!(
+            "hotspots: directed coupling loading {} commits (large repo — may be slow)",
+            commits.len()
+        );
+    }
+
     let jaccard = compute_jaccard_stability(&commits, DC_TRAIN_PCT, DC_TOP_FILE_PCT);
 
     let window_days = match jaccard {
@@ -293,4 +302,124 @@ pub fn compute_directed_coupling_for_repo(
         compute_directed_coupling(&commits, partner_scores, MIN_DC_APPEARANCES, window_days);
 
     (scores, jaccard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commit(ts: i64, subj: &str, files: &[&str]) -> (i64, String, Vec<String>) {
+        (
+            ts,
+            subj.to_string(),
+            files.iter().map(|f| f.to_string()).collect(),
+        )
+    }
+
+    // ── is_fix_subject ────────────────────────────────────────────────────────
+
+    #[test]
+    fn fix_subject_keyword_variants() {
+        assert!(is_fix_subject("fix: null deref"));
+        assert!(is_fix_subject("bug in parser"));
+        assert!(is_fix_subject("hotfix prod"));
+        assert!(is_fix_subject("patch security hole"));
+        assert!(is_fix_subject("regression in v2"));
+        assert!(is_fix_subject("defect resolved"));
+        assert!(!is_fix_subject("feat: add login"));
+        assert!(!is_fix_subject("refactor: cleanup"));
+        assert!(!is_fix_subject("chore: bump deps"));
+    }
+
+    // ── compute_directed_coupling ─────────────────────────────────────────────
+
+    #[test]
+    fn dc_empty_commits_returns_empty() {
+        let scores = compute_directed_coupling(&[], &HashMap::new(), 1, None);
+        assert!(scores.is_empty());
+    }
+
+    #[test]
+    fn dc_single_file_commits_no_co_change() {
+        let commits = vec![
+            commit(1, "fix: a", &["a.rs"]),
+            commit(2, "fix: a", &["a.rs"]),
+            commit(3, "fix: a", &["a.rs"]),
+        ];
+        let partner_scores: HashMap<String, f64> = [("a.rs".to_string(), 1.0)].into();
+        // a.rs never co-changes with anything, so weighted_co stays 0 → dc = 0
+        let scores = compute_directed_coupling(&commits, &partner_scores, 1, None);
+        assert_eq!(scores.get("a.rs").copied(), Some(0.0));
+    }
+
+    #[test]
+    fn dc_co_change_weights_by_partner_score() {
+        // a.rs and b.rs co-change in 10 commits; b.rs has score 2.0
+        let commits: Vec<_> = (0..10)
+            .map(|i| commit(i, "fix: x", &["a.rs", "b.rs"]))
+            .collect();
+        let partner_scores: HashMap<String, f64> = [("b.rs".to_string(), 2.0)].into();
+        let scores = compute_directed_coupling(&commits, &partner_scores, 1, None);
+        // a.rs appears 10 times; accumulated weight = 10 × 2.0 = 20.0; dc = 20/10 = 2.0
+        assert!((scores["a.rs"] - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dc_min_appearances_filters_rare_files() {
+        let commits: Vec<_> = (0..5)
+            .map(|i| commit(i, "fix: x", &["a.rs", "b.rs"]))
+            .collect();
+        let partner_scores: HashMap<String, f64> = [("b.rs".to_string(), 1.0)].into();
+        // require 10 appearances — both files appear only 5 times
+        let scores = compute_directed_coupling(&commits, &partner_scores, 10, None);
+        assert!(scores.is_empty());
+    }
+
+    #[test]
+    fn dc_window_restricts_to_recent_commits() {
+        // 5 old commits outside window, 5 new commits inside window
+        let mut commits: Vec<_> = (0..5)
+            .map(|i| commit(i * 86_400, "chore: old", &["a.rs", "b.rs"]))
+            .collect();
+        let base = 1_000 * 86_400_i64;
+        commits.extend((0..5).map(|i| commit(base + i * 86_400, "fix: new", &["a.rs", "b.rs"])));
+        let partner_scores: HashMap<String, f64> = [("b.rs".to_string(), 1.0)].into();
+        // window=10 days from last commit — only the 5 recent commits fall in
+        let scores = compute_directed_coupling(&commits, &partner_scores, 1, Some(10));
+        // a.rs appears 5 times in the window; dc = 5/5 = 1.0
+        assert!((scores["a.rs"] - 1.0).abs() < 1e-9);
+    }
+
+    // ── compute_jaccard_stability ─────────────────────────────────────────────
+
+    #[test]
+    fn jaccard_empty_returns_none() {
+        assert_eq!(compute_jaccard_stability(&[], 0.8, 0.2), None);
+    }
+
+    #[test]
+    fn jaccard_no_fix_commits_returns_none() {
+        let commits = vec![
+            commit(1, "feat: add login", &["a.rs"]),
+            commit(2, "chore: cleanup", &["b.rs"]),
+        ];
+        assert_eq!(compute_jaccard_stability(&commits, 0.8, 0.2), None);
+    }
+
+    #[test]
+    fn jaccard_same_files_in_both_windows_returns_one() {
+        // 10 fix commits on a.rs spread across both train and holdout windows
+        let commits: Vec<_> = (0..10).map(|i| commit(i, "fix: x", &["a.rs"])).collect();
+        let j = compute_jaccard_stability(&commits, 0.8, 0.2).unwrap();
+        assert!((j - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn jaccard_disjoint_files_returns_zero() {
+        // train window: only a.rs; holdout window: only b.rs
+        let mut commits: Vec<_> = (0..8).map(|i| commit(i, "fix: x", &["a.rs"])).collect();
+        commits.extend((8..10).map(|i| commit(i, "fix: y", &["b.rs"])));
+        let j = compute_jaccard_stability(&commits, 0.8, 0.2).unwrap();
+        assert!((j - 0.0).abs() < 1e-9);
+    }
 }

--- a/hotspots-core/src/coupling.rs
+++ b/hotspots-core/src/coupling.rs
@@ -1,0 +1,296 @@
+//! Directed coupling signal — F37/F38/F39.
+//!
+//! Directed coupling weights co-change relationships by partner defect score,
+//! filtering infrastructure noise: coupling to defect-prone files is more
+//! ominous than coupling to healthy utility code.
+//!
+//! Formula per file i:
+//!   dc(i) = Σ_j [co_changes(i,j) × partner_score(j)] / commit_count(i)
+//!
+//! The Jaccard screener gates which variant to use:
+//!   Jaccard < DC_JACCARD_THRESHOLD → dc_365d (architecturally volatile repo)
+//!   Jaccard ≥ DC_JACCARD_THRESHOLD → dc_full (stable repo, full history is an asset)
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+/// Minimum commit appearances for a file to receive a directed coupling score.
+pub const MIN_DC_APPEARANCES: usize = 10;
+
+/// Jaccard threshold: below this, use the 365-day window variant.
+pub const DC_JACCARD_THRESHOLD: f64 = 0.15;
+
+/// Train/holdout split fraction for Jaccard stability computation.
+pub const DC_TRAIN_PCT: f64 = 0.8;
+
+/// Top-file fraction used to compute Jaccard overlap.
+pub const DC_TOP_FILE_PCT: f64 = 0.2;
+
+/// 365-day window constant for windowed DC.
+pub const DC_WINDOW_365D: u32 = 365;
+
+/// Separator used in git log --format to delimit commits from file lists.
+const SEP: &str = "@@C@@";
+
+/// Regex patterns for fix-commit detection (mirrors the Python research scripts).
+fn is_fix_subject(subject: &str) -> bool {
+    let lower = subject.to_lowercase();
+    // Keyword match
+    if lower.contains("fix")
+        || lower.contains("bug")
+        || lower.contains("patch")
+        || lower.contains("regression")
+        || lower.contains("defect")
+        || lower.contains("hotfix")
+    {
+        return true;
+    }
+    // Conventional commits: "fix(...):..." or "fix!:..."
+    if let Some(rest) = lower.strip_prefix("fix") {
+        let rest = rest
+            .trim_start_matches(|c: char| c == '(' || c.is_alphanumeric() || c == '_' || c == '-');
+        let rest = rest.trim_start_matches(')');
+        let rest = rest.trim_start_matches('!');
+        if rest.starts_with(':') {
+            return true;
+        }
+    }
+    false
+}
+
+/// Load all first-parent commits as `(timestamp_secs, subject, [file_paths])`.
+///
+/// Uses `git log --first-parent --name-only --diff-filter=ACDMRT` against the
+/// repo at `git_dir`. Returns an empty vec on any error (caller treats as no-op).
+fn load_commits(git_dir: &Path) -> Vec<(i64, String, Vec<String>)> {
+    let format = format!("{}%at %s", SEP);
+    let out = Command::new("git")
+        .args([
+            "--git-dir",
+            &git_dir.to_string_lossy(),
+            "log",
+            "--first-parent",
+            "--name-only",
+            "--diff-filter=ACDMRT",
+            &format!("--format={}", format),
+        ])
+        .output();
+
+    let stdout = match out {
+        Ok(o) if o.status.success() || !o.stdout.is_empty() => o.stdout,
+        _ => return vec![],
+    };
+    let text = String::from_utf8_lossy(&stdout);
+
+    let mut commits: Vec<(i64, String, Vec<String>)> = Vec::new();
+    let mut cur_ts: i64 = 0;
+    let mut cur_subj = String::new();
+    let mut cur_files: Vec<String> = Vec::new();
+    let mut in_commit = false;
+
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix(SEP) {
+            if in_commit && !cur_files.is_empty() {
+                commits.push((cur_ts, cur_subj.clone(), cur_files.clone()));
+            }
+            let (ts_str, subj) = rest.split_once(' ').unwrap_or((rest, ""));
+            cur_ts = ts_str.parse().unwrap_or(0);
+            cur_subj = subj.to_string();
+            cur_files = Vec::new();
+            in_commit = true;
+        } else if in_commit && !line.trim().is_empty() {
+            cur_files.push(line.trim().to_string());
+        }
+    }
+    if in_commit && !cur_files.is_empty() {
+        commits.push((cur_ts, cur_subj, cur_files));
+    }
+
+    commits.sort_by_key(|c| c.0);
+    commits
+}
+
+/// Resolve the git directory path for a repo root.
+///
+/// Bare clones end in `.git`; working trees have a `.git` subdirectory.
+pub fn git_dir(repo_root: &Path) -> std::path::PathBuf {
+    if repo_root
+        .file_name()
+        .map(|n| n.to_string_lossy().ends_with(".git"))
+        .unwrap_or(false)
+    {
+        repo_root.to_path_buf()
+    } else {
+        repo_root.join(".git")
+    }
+}
+
+/// Compute directed coupling scores for all files in the commit list.
+///
+/// # Arguments
+/// - `commits`: list of `(timestamp, subject, files)` — only commits in the
+///   desired window should be passed; filtering by timestamp is the caller's job.
+/// - `partner_scores`: map of `file → defect_score` used to weight co-changes.
+/// - `min_appearances`: files appearing fewer times are excluded from output.
+/// - `window_days`: when `Some(n)`, use only commits within the last `n` days
+///   before the most-recent commit timestamp. When `None`, use all commits.
+///
+/// Returns a map of `file → directed_coupling_score`.
+pub fn compute_directed_coupling(
+    commits: &[(i64, String, Vec<String>)],
+    partner_scores: &HashMap<String, f64>,
+    min_appearances: usize,
+    window_days: Option<u32>,
+) -> HashMap<String, f64> {
+    let filtered: Vec<&(i64, String, Vec<String>)> = if let Some(days) = window_days {
+        let cutoff_ts = commits.last().map(|c| c.0).unwrap_or(0) - days as i64 * 86_400;
+        commits.iter().filter(|c| c.0 >= cutoff_ts).collect()
+    } else {
+        commits.iter().collect()
+    };
+
+    let mut appearances: HashMap<String, usize> = HashMap::new();
+    let mut weighted_co: HashMap<String, f64> = HashMap::new();
+
+    for (_, _, files) in &filtered {
+        let mut fs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
+        fs.sort_unstable();
+        fs.dedup();
+
+        for &f in &fs {
+            *appearances.entry(f.to_string()).or_insert(0) += 1;
+        }
+
+        for i in 0..fs.len() {
+            for j in (i + 1)..fs.len() {
+                let fa = fs[i];
+                let fb = fs[j];
+                if let Some(&sb) = partner_scores.get(fb) {
+                    if sb > 0.0 {
+                        *weighted_co.entry(fa.to_string()).or_insert(0.0) += sb;
+                    }
+                }
+                if let Some(&sa) = partner_scores.get(fa) {
+                    if sa > 0.0 {
+                        *weighted_co.entry(fb.to_string()).or_insert(0.0) += sa;
+                    }
+                }
+            }
+        }
+    }
+
+    appearances
+        .into_iter()
+        .filter(|(_, count)| *count >= min_appearances)
+        .map(|(f, count)| {
+            let score = weighted_co.get(&f).copied().unwrap_or(0.0) / count as f64;
+            (f, score)
+        })
+        .collect()
+}
+
+/// Compute Jaccard label stability for a repo.
+///
+/// Splits commit history at `train_pct`, computes the top `top_pct` fraction
+/// of files by fix-commit count in each window, and returns the Jaccard overlap.
+///
+/// High Jaccard → same files are risky across time → use `dc_full`.
+/// Low Jaccard → defect-prone files rotate → use `dc_365d`.
+///
+/// Returns `None` if either window has no fix commits.
+pub fn compute_jaccard_stability(
+    commits: &[(i64, String, Vec<String>)],
+    train_pct: f64,
+    top_pct: f64,
+) -> Option<f64> {
+    if commits.is_empty() {
+        return None;
+    }
+
+    let cutoff_idx = (commits.len() as f64 * train_pct) as usize;
+    let train = &commits[..cutoff_idx];
+    let holdout = &commits[cutoff_idx..];
+
+    let fix_counts = |window: &[(i64, String, Vec<String>)]| -> HashMap<String, usize> {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for (_, subj, files) in window {
+            if is_fix_subject(subj) {
+                for f in files {
+                    *counts.entry(f.clone()).or_insert(0) += 1;
+                }
+            }
+        }
+        counts
+    };
+
+    let train_fixes = fix_counts(train);
+    let holdout_fixes = fix_counts(holdout);
+
+    if train_fixes.is_empty() || holdout_fixes.is_empty() {
+        return None;
+    }
+
+    let n_top = ((train_fixes.len() as f64 * top_pct) as usize).max(1);
+
+    let mut train_ranked: Vec<(&String, usize)> =
+        train_fixes.iter().map(|(f, &c)| (f, c)).collect();
+    train_ranked.sort_by_key(|a| std::cmp::Reverse(a.1));
+    let train_top: std::collections::HashSet<&str> = train_ranked
+        .iter()
+        .take(n_top)
+        .map(|(f, _)| f.as_str())
+        .collect();
+
+    let n_holdout_top = ((holdout_fixes.len() as f64 * top_pct) as usize).max(1);
+    let mut holdout_ranked: Vec<(&String, usize)> =
+        holdout_fixes.iter().map(|(f, &c)| (f, c)).collect();
+    holdout_ranked.sort_by_key(|a| std::cmp::Reverse(a.1));
+    let holdout_top: std::collections::HashSet<&str> = holdout_ranked
+        .iter()
+        .take(n_holdout_top)
+        .map(|(f, _)| f.as_str())
+        .collect();
+
+    let intersection = train_top.intersection(&holdout_top).count();
+    let union = train_top.union(&holdout_top).count();
+
+    if union == 0 {
+        return None;
+    }
+
+    Some(intersection as f64 / union as f64)
+}
+
+/// High-level entry point: load commits from `repo_root`, compute Jaccard,
+/// select the correct DC variant, and return scores keyed by file path.
+///
+/// Also returns the Jaccard value (for snapshot observability).
+///
+/// `partner_scores` is a map of `file → hotspots_score` from the snapshot.
+pub fn compute_directed_coupling_for_repo(
+    repo_root: &Path,
+    partner_scores: &HashMap<String, f64>,
+) -> (HashMap<String, f64>, Option<f64>) {
+    let gd = git_dir(repo_root);
+    if !gd.exists() {
+        return (HashMap::new(), None);
+    }
+
+    let commits = load_commits(&gd);
+    if commits.is_empty() {
+        return (HashMap::new(), None);
+    }
+
+    let jaccard = compute_jaccard_stability(&commits, DC_TRAIN_PCT, DC_TOP_FILE_PCT);
+
+    let window_days = match jaccard {
+        Some(j) if j < DC_JACCARD_THRESHOLD => Some(DC_WINDOW_365D),
+        _ => None,
+    };
+
+    let scores =
+        compute_directed_coupling(&commits, partner_scores, MIN_DC_APPEARANCES, window_days);
+
+    (scores, jaccard)
+}

--- a/hotspots-core/src/db/mod.rs
+++ b/hotspots-core/src/db/mod.rs
@@ -432,6 +432,8 @@ fn load_functions(conn: &Connection, sha: &str) -> Result<Vec<FunctionSnapshot>>
             pattern_details: None,
             subsystem: None,
             authors_90d: None,
+            directed_coupling: None,
+            jaccard_label_stability: None,
         });
     }
 

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod callgraph;
 pub mod cfg;
 pub mod compact;
 pub mod config;
+pub mod coupling;
 pub mod db;
 pub mod delta;
 pub mod discover;

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -681,6 +681,8 @@ mod tests {
             pattern_details: None,
             subsystem: None,
             authors_90d: None,
+            directed_coupling: None,
+            jaccard_label_stability: None,
         }
     }
 

--- a/hotspots-core/src/sarif.rs
+++ b/hotspots-core/src/sarif.rs
@@ -287,6 +287,8 @@ mod tests {
             pattern_details: None,
             subsystem: None,
             authors_90d: None,
+            directed_coupling: None,
+            jaccard_label_stability: None,
         }
     }
 

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -197,6 +197,19 @@ pub struct FunctionSnapshot {
     /// of touch_count_30d.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authors_90d: Option<u32>,
+    /// Directed coupling score for this file.
+    /// dc(i) = Σ_j [co_changes(i,j) × hotspots_score(j)] / commit_count(i)
+    /// Weights co-change relationships by partner defect density.
+    /// Variant (full-history or 365d) selected by the Jaccard screener (F38/F39).
+    /// File-level (shared by all functions in the same file).
+    /// Populated by `Snapshot::populate_directed_coupling()`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directed_coupling: Option<f64>,
+    /// Jaccard label stability score for this repo (F38 screener).
+    /// Overlap of top-20% defect files between train and holdout windows.
+    /// Repo-level: same value for all functions. None when DC was not computed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jaccard_label_stability: Option<f64>,
 }
 
 /// Risk distribution by band
@@ -433,6 +446,8 @@ impl Snapshot {
                     pattern_details: None,
                     subsystem: None,
                     authors_90d: None,
+                    directed_coupling: None,
+                    jaccard_label_stability: None,
                 }
             })
             .collect();
@@ -524,6 +539,48 @@ impl Snapshot {
 
             for &i in indices {
                 self.functions[i].authors_90d = Some(count);
+            }
+        }
+    }
+
+    /// Populate `directed_coupling` and `jaccard_label_stability` for every function.
+    ///
+    /// Calls `crate::coupling::compute_directed_coupling_for_repo` which:
+    /// 1. Loads full commit history via git log.
+    /// 2. Computes Jaccard label stability to select dc_full vs dc_365d.
+    /// 3. Computes directed coupling scores keyed by file path.
+    ///
+    /// All functions in the same file receive the same file-level DC score.
+    /// Functions in files with no co-change history receive `directed_coupling = None`.
+    /// `jaccard_label_stability` is set repo-wide (same value for all functions).
+    ///
+    /// `partner_scores` is typically `file → hotspots_score` from the snapshot itself
+    /// (built before calling this method, or passed in from cheap_signals.csv).
+    pub fn populate_directed_coupling(
+        &mut self,
+        repo_root: &Path,
+        partner_scores: &std::collections::HashMap<String, f64>,
+    ) {
+        let (dc_scores, jaccard) =
+            crate::coupling::compute_directed_coupling_for_repo(repo_root, partner_scores);
+
+        // Build file → function-indices map
+        let mut file_indices: std::collections::HashMap<String, Vec<usize>> =
+            std::collections::HashMap::new();
+        for (i, func) in self.functions.iter().enumerate() {
+            // DC scores are keyed by repo-relative path; snapshot paths may be absolute.
+            let rel = std::path::Path::new(&func.file)
+                .strip_prefix(repo_root)
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_else(|_| func.file.replace('\\', "/"));
+            file_indices.entry(rel).or_default().push(i);
+        }
+
+        for (rel_path, indices) in &file_indices {
+            let score = dc_scores.get(rel_path).copied();
+            for &i in indices {
+                self.functions[i].directed_coupling = score;
+                self.functions[i].jaccard_label_stability = jaccard;
             }
         }
     }

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -1,15 +1,16 @@
 //! `hotspots train` — fit a local RandomForest ranker from git history.
 //!
-//! # Feature set (8 features, index-stable — model_version = 3)
+//! # Feature set (9 features, index-stable — model_version = 4)
 //!
-//! 0  lrs           composite complexity score
-//! 1  cc            cyclomatic complexity
-//! 2  nd            nesting depth
-//! 3  loc           lines of code
-//! 4  fo            fan-out
-//! 5  fan_in        call-graph fan-in
-//! 6  total_churn   lifetime lines added + deleted (non-windowed structural signal)
-//! 7  authors_90d   distinct commit authors in last 90 days (ownership diversity)
+//! 0  lrs                composite complexity score
+//! 1  cc                 cyclomatic complexity
+//! 2  nd                 nesting depth
+//! 3  loc                lines of code
+//! 4  fo                 fan-out
+//! 5  fan_in             call-graph fan-in
+//! 6  total_churn        lifetime lines added + deleted (non-windowed structural signal)
+//! 7  authors_90d        distinct commit authors in last 90 days (ownership diversity)
+//! 8  directed_coupling  co-change weighted by partner defect score (F37/F38/F39)
 //!
 //! Deliberately excluded:
 //! - `touch_count_30d`, `days_since_last_change` — windowed activity signals that
@@ -80,7 +81,7 @@ pub(crate) fn repo_prefixes(repo_root: &Path) -> (String, String) {
 
 // ── Feature extraction ────────────────────────────────────────────────────────
 
-pub const FEATURE_NAMES: [&str; 8] = [
+pub const FEATURE_NAMES: [&str; 9] = [
     "lrs",
     "cc",
     "nd",
@@ -89,9 +90,10 @@ pub const FEATURE_NAMES: [&str; 8] = [
     "fan_in",
     "total_churn",
     "authors_90d",
+    "directed_coupling",
 ];
 
-pub fn extract_features(func: &FunctionSnapshot) -> [f64; 8] {
+pub fn extract_features(func: &FunctionSnapshot) -> [f64; 9] {
     let cg = func.callgraph.as_ref();
     let total_churn = func
         .churn
@@ -107,6 +109,7 @@ pub fn extract_features(func: &FunctionSnapshot) -> [f64; 8] {
         cg.map(|c| c.fan_in as f64).unwrap_or(0.0),
         total_churn,
         func.authors_90d.unwrap_or(0) as f64,
+        func.directed_coupling.unwrap_or(0.0),
     ]
 }
 
@@ -357,11 +360,31 @@ pub fn train(
     repo_root: &Path,
     cfg: &TrainConfig,
 ) -> Result<Option<RankerModel>> {
+    // Populate directed coupling on a mutable clone so the caller's snapshot
+    // is unchanged.  Partner scores are the hotspots_score proxy: use
+    // activity_risk when available, falling back to lrs.
+    let mut snapshot = snapshot.clone();
+    {
+        let partner_scores: std::collections::HashMap<String, f64> = {
+            let (prefix_can, prefix_raw) = repo_prefixes(repo_root);
+            snapshot
+                .functions
+                .iter()
+                .map(|f| {
+                    let rel = make_rel(&f.file, &prefix_can, &prefix_raw);
+                    let score = f.activity_risk.unwrap_or(f.lrs);
+                    (rel, score)
+                })
+                .collect()
+        };
+        snapshot.populate_directed_coupling(repo_root, &partner_scores);
+    }
+
     // Build (features, label) pairs from snapshot functions
-    let mut rows: Vec<([f64; 8], bool)> = Vec::new();
+    let mut rows: Vec<([f64; 9], bool)> = Vec::new();
 
     if cfg.blame_labels {
-        let fix_funcs = collect_fix_functions(snapshot, repo_root, cfg.label_window_days)?;
+        let fix_funcs = collect_fix_functions(&snapshot, repo_root, cfg.label_window_days)?;
         let (prefix_can, prefix_raw) = repo_prefixes(repo_root);
         for func in &snapshot.functions {
             let rel = make_rel(&func.file, &prefix_can, &prefix_raw);
@@ -386,7 +409,7 @@ pub fn train(
     }
 
     let n = rows.len();
-    let mut x_data = Vec::with_capacity(n * 8);
+    let mut x_data = Vec::with_capacity(n * 9);
     let mut y_data: Vec<bool> = Vec::with_capacity(n);
 
     for (feats, label) in &rows {
@@ -395,7 +418,7 @@ pub fn train(
     }
 
     let x: Array2<f64> =
-        Array2::from_shape_vec((n, 8), x_data).context("feature matrix shape error")?;
+        Array2::from_shape_vec((n, 9), x_data).context("feature matrix shape error")?;
     let y: Array1<bool> = Array1::from_vec(y_data);
 
     let dataset = Dataset::new(x, y).with_feature_names(
@@ -434,7 +457,7 @@ pub fn train(
     };
 
     Ok(Some(RankerModel {
-        model_version: 3,
+        model_version: 4,
         trees,
         meta,
     }))
@@ -537,7 +560,7 @@ pub fn score(model: &RankerModel, func: &FunctionSnapshot) -> f64 {
     votes as f64 / n as f64
 }
 
-fn vote(tree: &SerializedTree, feats: &[f64; 8]) -> bool {
+fn vote(tree: &SerializedTree, feats: &[f64; 9]) -> bool {
     let nodes = &tree.nodes;
     if nodes.is_empty() {
         return false;
@@ -627,7 +650,7 @@ mod tests {
 
     #[test]
     fn feature_names_count_matches_array() {
-        assert_eq!(FEATURE_NAMES.len(), 8);
+        assert_eq!(FEATURE_NAMES.len(), 9);
     }
 
     #[test]

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -45,7 +45,7 @@ use std::path::Path;
 /// - macOS `/tmp` → `/private/tmp` symlink: tries both canonical and raw prefix forms
 /// - Snapshot path itself may be a symlink: canonicalises as a last resort
 /// - `hotspots analyze .` stores paths with a leading `./` component: strips it
-pub(crate) fn make_rel(path: &str, prefix_can: &str, prefix_raw: &str) -> String {
+pub fn make_rel(path: &str, prefix_can: &str, prefix_raw: &str) -> String {
     let p = path.replace('\\', "/");
     let rel = if let Some(r) = p.strip_prefix(prefix_can) {
         r.to_string()
@@ -64,7 +64,7 @@ pub(crate) fn make_rel(path: &str, prefix_can: &str, prefix_raw: &str) -> String
 }
 
 /// Build the canonical and raw prefix strings for a repo root.
-pub(crate) fn repo_prefixes(repo_root: &Path) -> (String, String) {
+pub fn repo_prefixes(repo_root: &Path) -> (String, String) {
     let canonical = repo_root
         .canonicalize()
         .unwrap_or_else(|_| repo_root.to_path_buf());

--- a/hotspots-core/src/trends.rs
+++ b/hotspots-core/src/trends.rs
@@ -501,6 +501,8 @@ mod tests {
                     pattern_details: None,
                     subsystem: None,
                     authors_90d: None,
+                    directed_coupling: None,
+                    jaccard_label_stability: None,
                 }],
             ),
             create_test_snapshot(
@@ -535,6 +537,8 @@ mod tests {
                     pattern_details: None,
                     subsystem: None,
                     authors_90d: None,
+                    directed_coupling: None,
+                    jaccard_label_stability: None,
                 }],
             ),
         ];
@@ -581,6 +585,8 @@ mod tests {
                     pattern_details: None,
                     subsystem: None,
                     authors_90d: None,
+                    directed_coupling: None,
+                    jaccard_label_stability: None,
                 }],
             ),
             create_test_snapshot(
@@ -615,6 +621,8 @@ mod tests {
                     pattern_details: None,
                     subsystem: None,
                     authors_90d: None,
+                    directed_coupling: None,
+                    jaccard_label_stability: None,
                 }],
             ),
         ];
@@ -660,6 +668,8 @@ mod tests {
                         pattern_details: None,
                         subsystem: None,
                         authors_90d: None,
+                        directed_coupling: None,
+                        jaccard_label_stability: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -690,6 +700,8 @@ mod tests {
                         pattern_details: None,
                         subsystem: None,
                         authors_90d: None,
+                        directed_coupling: None,
+                        jaccard_label_stability: None,
                     },
                 ],
             ),
@@ -726,6 +738,8 @@ mod tests {
                         pattern_details: None,
                         subsystem: None,
                         authors_90d: None,
+                        directed_coupling: None,
+                        jaccard_label_stability: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -756,6 +770,8 @@ mod tests {
                         pattern_details: None,
                         subsystem: None,
                         authors_90d: None,
+                        directed_coupling: None,
+                        jaccard_label_stability: None,
                     },
                 ],
             ),

--- a/hotspots-core/tests/trainer_tests.rs
+++ b/hotspots-core/tests/trainer_tests.rs
@@ -81,6 +81,8 @@ fn make_func(file: &str, name: &str, line: u32) -> FunctionSnapshot {
         pattern_details: None,
         subsystem: None,
         authors_90d: None,
+        directed_coupling: None,
+        jaccard_label_stability: None,
     }
 }
 
@@ -114,12 +116,14 @@ fn make_snapshot(functions: Vec<FunctionSnapshot>) -> Snapshot {
 fn extract_features_baseline() {
     let func = make_func("src/foo.py", "foo", 1);
     let feats = extract_features(&func);
-    assert_eq!(feats.len(), 8);
-    assert_eq!(FEATURE_NAMES.len(), 8);
+    assert_eq!(feats.len(), 9);
+    assert_eq!(FEATURE_NAMES.len(), 9);
     // total_churn = 0 when no ChurnMetrics
     assert_eq!(feats[6], 0.0);
     // authors_90d = 0 by default
     assert_eq!(feats[7], 0.0);
+    // directed_coupling = 0 by default
+    assert_eq!(feats[8], 0.0);
 }
 
 #[test]
@@ -147,6 +151,7 @@ fn extract_features_with_churn_and_callgraph() {
     assert_eq!(feats[5], 5.0); // fan_in
     assert_eq!(feats[6], 400.0); // total_churn = 300+100
     assert_eq!(feats[7], 0.0); // authors_90d
+    assert_eq!(feats[8], 0.0); // directed_coupling
 }
 
 // ── collect_fix_files ─────────────────────────────────────────────────────────
@@ -363,7 +368,7 @@ fn trained_model_ranks_buggy_functions_above_clean() {
         .expect("train")
         .expect("model should be returned — enough training signal");
 
-    assert_eq!(model.model_version, 3);
+    assert_eq!(model.model_version, 4);
 
     // Score all functions
     let scores: Vec<(String, f64)> = snapshot


### PR DESCRIPTION
## Summary

- Adds `hotspots-core/src/coupling.rs` — directed coupling computation and Jaccard stability screener
- Adds `directed_coupling` and `jaccard_label_stability` fields to `FunctionSnapshot`
- Wires directed coupling into `hotspots train` as the 9th feature (`model_version` bumped to 4)

## What this does

`hotspots train` now computes a directed coupling score for each file before fitting the Random Forest. The score weights co-change relationships by partner defect density: files that frequently co-change with historically buggy files score higher.

The Jaccard screener automatically selects the right variant:
- **Jaccard ≥ 0.15** (stable repos like Django, Redis, Gin): use full-history co-change — more data is better
- **Jaccard < 0.15** (architecturally volatile repos like React, Svelte): use 365-day window — restricts to the current architectural era, avoiding stale coupling from prior rewrites

Temporal holdout results from research:
- Django: dc_full holdout ρ = +0.445
- Gin: dc_full holdout ρ = +0.187
- Svelte: dc_365d holdout ρ = +0.130 (beats ARS baseline +0.073; dc_full = +0.056)
- React: dc_90d holdout ρ = +0.208 (dc_full ≈ 0)

## Research artifacts

- `../hotspots-research/docs/promotion-briefs/f37-directed-coupling.md`
- `../hotspots-research/docs/promotion-briefs/f38-dc-screener.md`
- `../hotspots-research/docs/promotion-briefs/f39-recency-windowed-dc.md`

## Test plan

- [ ] All 452 existing tests pass (`cargo test`)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `hotspots train` on a real repo completes without error
- [ ] Snapshot JSON includes `directed_coupling` and `jaccard_label_stability` fields after training