### PR TITLE
feat: add C language support (tree-sitter-c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "syn",
  "tempfile",
  "tree-sitter",
+ "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -1517,6 +1518,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/hotspots-core/Cargo.toml
+++ b/hotspots-core/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 keywords = { workspace = true }
 categories = { workspace = true }
-description = "Core library for static analysis and Local Risk Score (LRS) computation across TypeScript, JavaScript, Go, Python, Rust, Java, and C#"
+description = "Core library for static analysis and Local Risk Score (LRS) computation across TypeScript, JavaScript, Go, Python, Rust, Java, C#, and C"
 readme = "../README.md"
 
 [lib]
@@ -44,6 +44,7 @@ linfa-trees = "0.8.1"
 linfa-ensemble = "0.8.1"
 rand = { version = "0.8", features = ["small_rng"] }
 ndarray = "0.16"
+tree-sitter-c = "0.24.2"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/hotspots-core/src/analysis.rs
+++ b/hotspots-core/src/analysis.rs
@@ -143,6 +143,9 @@ fn create_parser(
         Language::CSharp => {
             Box::new(language::CSharpParser::new().context("Failed to create C# parser")?)
         }
+        Language::C | Language::CHeader => {
+            Box::new(language::CParser::new().context("Failed to create C parser")?)
+        }
     };
     Ok(parser)
 }

--- a/hotspots-core/src/imports.rs
+++ b/hotspots-core/src/imports.rs
@@ -27,6 +27,7 @@ pub fn extract_raw_imports(source: &str, language: Language) -> Vec<String> {
         | Language::JavaScriptReact
         | Language::Vue => extract_ecmascript_imports(source),
         Language::CSharp => extract_csharp_imports(source),
+        Language::C | Language::CHeader => vec![], // #include resolution not implemented
     }
 }
 
@@ -293,6 +294,7 @@ fn resolve_import(
         Language::Python => resolve_python(raw, importing_file, all_files_set, repo_root),
         Language::Java => resolve_java(raw, all_files_set),
         Language::CSharp => resolve_java(raw, all_files_set), // namespace-style, same strategy
+        Language::C | Language::CHeader => None,              // #include resolution not implemented
     }
 }
 

--- a/hotspots-core/src/language/c/cfg_builder.rs
+++ b/hotspots-core/src/language/c/cfg_builder.rs
@@ -1,0 +1,412 @@
+//! C CFG builder implementation
+
+use crate::ast::FunctionNode;
+use crate::cfg::{Cfg, NodeId, NodeKind};
+use crate::language::cfg_builder::CfgBuilder;
+use crate::language::tree_sitter_utils::{
+    find_child_by_kind, find_function_by_start, with_cached_c_tree,
+};
+use tree_sitter::Node;
+
+/// C CFG builder
+pub struct CCfgBuilder;
+
+impl CfgBuilder for CCfgBuilder {
+    fn build(&self, function: &FunctionNode) -> Cfg {
+        let (_body_node_id, source) = function.body.as_c();
+
+        let result = with_cached_c_tree(source, |root| {
+            let func_node =
+                find_function_by_start(root, function.span.start, &["function_definition"])?;
+            let body_node = find_child_by_kind(func_node, "compound_statement")?;
+            let mut builder = CCfgBuilderState::new();
+            builder.build_from_block(&body_node, source);
+            // Connect final node to exit
+            if let Some(last) = builder.current_node {
+                if last != builder.cfg.exit {
+                    builder.cfg.add_edge(last, builder.cfg.exit);
+                }
+            }
+            Some(builder.cfg)
+        });
+
+        result.unwrap_or_else(|| {
+            let mut cfg = Cfg::new();
+            cfg.add_edge(cfg.entry, cfg.exit);
+            cfg
+        })
+    }
+}
+
+struct LoopContext {
+    break_target: NodeId,
+    continue_target: NodeId,
+}
+
+struct CCfgBuilderState {
+    cfg: Cfg,
+    current_node: Option<NodeId>,
+    loop_stack: Vec<LoopContext>,
+}
+
+impl CCfgBuilderState {
+    fn new() -> Self {
+        let cfg = Cfg::new();
+        let entry = cfg.entry;
+        CCfgBuilderState {
+            cfg,
+            current_node: Some(entry),
+            loop_stack: Vec::new(),
+        }
+    }
+
+    fn build_from_block(&mut self, block: &Node, source: &str) {
+        let mut cursor = block.walk();
+        for child in block.children(&mut cursor) {
+            if child.is_named() {
+                self.visit_node(&child, source);
+            }
+        }
+        // Callers are responsible for connecting self.current_node to whatever comes next.
+        // The top-level build() connects to exit after this returns.
+    }
+
+    fn visit_node(&mut self, node: &Node, source: &str) {
+        match node.kind() {
+            "if_statement" => self.visit_if(node, source),
+            "while_statement" => self.visit_while(node, source),
+            "for_statement" => self.visit_for(node, source),
+            "do_statement" => self.visit_do_while(node, source),
+            "switch_statement" => self.visit_switch(node, source),
+            "return_statement" => self.visit_return(),
+            "break_statement" => self.visit_break(),
+            "continue_statement" => self.visit_continue(),
+            "goto_statement" => self.visit_return(), // treat goto as exit for CC purposes
+            "compound_statement" => self.build_from_block(node, source),
+            _ => self.visit_simple_statement(),
+        }
+    }
+
+    fn visit_simple_statement(&mut self) {
+        if let Some(from_node) = self.current_node {
+            let stmt_node = self.cfg.add_node(NodeKind::Statement);
+            self.cfg.add_edge(from_node, stmt_node);
+            self.current_node = Some(stmt_node);
+        }
+    }
+
+    fn visit_if(&mut self, node: &Node, source: &str) {
+        let from_node = self.current_node.expect("current node should exist");
+
+        let condition_node = self.cfg.add_node(NodeKind::Condition);
+        self.cfg.add_edge(from_node, condition_node);
+
+        let join_node = self.cfg.add_node(NodeKind::Join);
+
+        // Then branch — the first compound_statement child
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.children(&mut cursor).collect();
+
+        let mut found_consequence = false;
+        let mut found_else = false;
+
+        for child in &children {
+            if child.kind() == "compound_statement" && !found_consequence {
+                found_consequence = true;
+                let then_start = self.cfg.add_node(NodeKind::Statement);
+                self.cfg.add_edge(condition_node, then_start);
+                self.current_node = Some(then_start);
+                self.build_from_block(child, source);
+                if let Some(end) = self.current_node {
+                    if end != self.cfg.exit {
+                        self.cfg.add_edge(end, join_node);
+                    }
+                }
+            } else if child.kind() == "else_clause" {
+                found_else = true;
+                // else_clause contains a compound_statement or another if_statement
+                let else_body = find_child_by_kind(*child, "compound_statement")
+                    .or_else(|| find_child_by_kind(*child, "if_statement"));
+                if let Some(body) = else_body {
+                    let else_start = self.cfg.add_node(NodeKind::Statement);
+                    self.cfg.add_edge(condition_node, else_start);
+                    self.current_node = Some(else_start);
+                    if body.kind() == "if_statement" {
+                        self.visit_if(&body, source);
+                    } else {
+                        self.build_from_block(&body, source);
+                    }
+                    if let Some(end) = self.current_node {
+                        if end != self.cfg.exit {
+                            self.cfg.add_edge(end, join_node);
+                        }
+                    }
+                }
+            }
+        }
+
+        // No else → condition can fall through to join
+        if !found_else {
+            self.cfg.add_edge(condition_node, join_node);
+        }
+
+        self.current_node = Some(join_node);
+    }
+
+    fn visit_while(&mut self, node: &Node, source: &str) {
+        let from_node = self.current_node.expect("current node should exist");
+
+        let loop_header = self.cfg.add_node(NodeKind::LoopHeader);
+        self.cfg.add_edge(from_node, loop_header);
+
+        let body_start = self.cfg.add_node(NodeKind::Statement);
+        self.cfg.add_edge(loop_header, body_start);
+
+        let join_node = self.cfg.add_node(NodeKind::Join);
+        self.loop_stack.push(LoopContext {
+            break_target: join_node,
+            continue_target: loop_header,
+        });
+
+        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
+            self.current_node = Some(body_start);
+            self.build_from_block(&body, source);
+            if let Some(end) = self.current_node {
+                if end != self.cfg.exit {
+                    self.cfg.add_edge(end, loop_header);
+                }
+            }
+        }
+
+        self.loop_stack.pop();
+        self.cfg.add_edge(loop_header, join_node);
+        self.current_node = Some(join_node);
+    }
+
+    fn visit_for(&mut self, node: &Node, source: &str) {
+        // Model for-loop the same as while: a single loop_header condition node.
+        // The init and increment expressions don't affect CC, only the condition does.
+        let from_node = self.current_node.expect("current node should exist");
+
+        let loop_header = self.cfg.add_node(NodeKind::LoopHeader);
+        self.cfg.add_edge(from_node, loop_header);
+
+        let body_start = self.cfg.add_node(NodeKind::Statement);
+        self.cfg.add_edge(loop_header, body_start);
+
+        let join_node = self.cfg.add_node(NodeKind::Join);
+        self.loop_stack.push(LoopContext {
+            break_target: join_node,
+            continue_target: loop_header,
+        });
+
+        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
+            self.current_node = Some(body_start);
+            self.build_from_block(&body, source);
+            if let Some(end) = self.current_node {
+                if end != self.cfg.exit {
+                    self.cfg.add_edge(end, loop_header);
+                }
+            }
+        } else {
+            self.cfg.add_edge(body_start, loop_header);
+        }
+
+        self.loop_stack.pop();
+        self.cfg.add_edge(loop_header, join_node);
+        self.current_node = Some(join_node);
+    }
+
+    fn visit_do_while(&mut self, node: &Node, source: &str) {
+        let from_node = self.current_node.expect("current node should exist");
+
+        let body_start = self.cfg.add_node(NodeKind::Statement);
+        self.cfg.add_edge(from_node, body_start);
+
+        let loop_header = self.cfg.add_node(NodeKind::LoopHeader);
+        let join_node = self.cfg.add_node(NodeKind::Join);
+
+        self.loop_stack.push(LoopContext {
+            break_target: join_node,
+            continue_target: loop_header,
+        });
+
+        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
+            self.current_node = Some(body_start);
+            self.build_from_block(&body, source);
+            if let Some(end) = self.current_node {
+                if end != self.cfg.exit {
+                    self.cfg.add_edge(end, loop_header);
+                }
+            }
+        }
+
+        self.loop_stack.pop();
+        // condition at loop_header: back edge or exit
+        self.cfg.add_edge(loop_header, body_start);
+        self.cfg.add_edge(loop_header, join_node);
+        self.current_node = Some(join_node);
+    }
+
+    fn visit_switch(&mut self, node: &Node, source: &str) {
+        let from_node = self.current_node.expect("current node should exist");
+
+        let switch_node = self.cfg.add_node(NodeKind::Condition);
+        self.cfg.add_edge(from_node, switch_node);
+
+        let join_node = self.cfg.add_node(NodeKind::Join);
+        self.loop_stack.push(LoopContext {
+            break_target: join_node,
+            continue_target: join_node, // switch doesn't have a natural continue target
+        });
+
+        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
+            let mut cursor = body.walk();
+            for child in body.children(&mut cursor) {
+                if child.kind() == "case_statement" || child.kind() == "default_statement" {
+                    let case_start = self.cfg.add_node(NodeKind::Statement);
+                    self.cfg.add_edge(switch_node, case_start);
+                    self.current_node = Some(case_start);
+                    // Visit children of the case
+                    let mut case_cursor = child.walk();
+                    for case_child in child.children(&mut case_cursor) {
+                        if case_child.is_named() && case_child.kind() != ":" {
+                            self.visit_node(&case_child, source);
+                        }
+                    }
+                    if let Some(end) = self.current_node {
+                        if end != self.cfg.exit {
+                            self.cfg.add_edge(end, join_node);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.loop_stack.pop();
+        self.cfg.add_edge(switch_node, join_node); // default fallthrough
+        self.current_node = Some(join_node);
+    }
+
+    fn visit_return(&mut self) {
+        if let Some(from_node) = self.current_node {
+            self.cfg.add_edge(from_node, self.cfg.exit);
+            self.current_node = Some(self.cfg.exit);
+        }
+    }
+
+    fn visit_break(&mut self) {
+        if let Some(loop_ctx) = self.loop_stack.last() {
+            if let Some(from_node) = self.current_node {
+                self.cfg.add_edge(from_node, loop_ctx.break_target);
+                self.current_node = Some(loop_ctx.break_target);
+            }
+        }
+    }
+
+    fn visit_continue(&mut self) {
+        if let Some(loop_ctx) = self.loop_stack.last() {
+            if let Some(from_node) = self.current_node {
+                self.cfg.add_edge(from_node, loop_ctx.continue_target);
+                self.current_node = Some(loop_ctx.continue_target);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{FunctionId, FunctionNode};
+    use crate::language::{FunctionBody, SourceSpan};
+
+    fn make_c_function(source: &str) -> FunctionNode {
+        use tree_sitter::Parser;
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_c::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let root = tree.root_node();
+
+        let mut cursor = root.walk();
+        let func_node = root
+            .children(&mut cursor)
+            .find(|n| n.kind() == "function_definition")
+            .expect("No function found in test source");
+
+        FunctionNode {
+            id: FunctionId {
+                file_index: 0,
+                local_index: 0,
+            },
+            name: Some("test_func".to_string()),
+            span: SourceSpan::new(
+                func_node.start_byte(),
+                func_node.end_byte(),
+                func_node.start_position().row as u32 + 1,
+                func_node.end_position().row as u32 + 1,
+                func_node.start_position().column as u32,
+            ),
+            body: FunctionBody::C {
+                body_node: 0,
+                source: source.to_string(),
+            },
+            suppression_reason: None,
+        }
+    }
+
+    #[test]
+    fn test_simple_function() {
+        let source = "int test_func(int x) { return x + 1; }";
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        assert!(cfg.node_count() >= 2);
+    }
+
+    #[test]
+    fn test_if_statement() {
+        let source = r#"
+int test_func(int x) {
+    if (x > 0) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+"#;
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        assert!(cfg.node_count() > 4);
+        assert!(cfg.edge_count() > 4);
+    }
+
+    #[test]
+    fn test_while_loop() {
+        let source = r#"
+void test_func(int n) {
+    while (n > 0) {
+        n--;
+    }
+}
+"#;
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        assert!(cfg.node_count() >= 4);
+    }
+
+    #[test]
+    fn test_for_loop() {
+        let source = r#"
+void test_func(int n) {
+    int i;
+    for (i = 0; i < n; i++) {
+        n--;
+    }
+}
+"#;
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        assert!(cfg.node_count() >= 5);
+    }
+}

--- a/hotspots-core/src/language/c/cfg_builder.rs
+++ b/hotspots-core/src/language/c/cfg_builder.rs
@@ -21,7 +21,6 @@ impl CfgBuilder for CCfgBuilder {
             let body_node = find_child_by_kind(func_node, "compound_statement")?;
             let mut builder = CCfgBuilderState::new();
             builder.build_from_block(&body_node, source);
-            // Connect final node to exit
             if let Some(last) = builder.current_node {
                 if last != builder.cfg.exit {
                     builder.cfg.add_edge(last, builder.cfg.exit);
@@ -39,7 +38,7 @@ impl CfgBuilder for CCfgBuilder {
 }
 
 struct LoopContext {
-    break_target: NodeId,
+    break_target: Option<NodeId>,
     continue_target: NodeId,
 }
 
@@ -67,8 +66,6 @@ impl CCfgBuilderState {
                 self.visit_node(&child, source);
             }
         }
-        // Callers are responsible for connecting self.current_node to whatever comes next.
-        // The top-level build() connects to exit after this returns.
     }
 
     fn visit_node(&mut self, node: &Node, source: &str) {
@@ -81,7 +78,8 @@ impl CCfgBuilderState {
             "return_statement" => self.visit_return(),
             "break_statement" => self.visit_break(),
             "continue_statement" => self.visit_continue(),
-            "goto_statement" => self.visit_return(), // treat goto as exit for CC purposes
+            "goto_statement" => self.visit_goto(),
+            "labeled_statement" => self.visit_labeled(node, source),
             "compound_statement" => self.build_from_block(node, source),
             _ => self.visit_simple_statement(),
         }
@@ -95,47 +93,73 @@ impl CCfgBuilderState {
         }
     }
 
+    /// Visit a statement body — compound blocks use build_from_block, single statements use visit_node.
+    fn visit_body(&mut self, node: &Node, source: &str) {
+        if node.kind() == "compound_statement" {
+            self.build_from_block(node, source);
+        } else {
+            self.visit_node(node, source);
+        }
+    }
+
+    /// Get the consequence (then-body) of an if_statement.
+    /// Tries the "consequence" field name first, then falls back to position-based search.
+    fn get_if_consequence<'a>(node: &Node<'a>) -> Option<Node<'a>> {
+        if let Some(n) = node.child_by_field_name("consequence") {
+            return Some(n);
+        }
+        // Fallback: first named child after the parenthesized condition
+        let mut cursor = node.walk();
+        let mut past_condition = false;
+        for child in node.children(&mut cursor) {
+            if child.kind() == "parenthesized_expression" {
+                past_condition = true;
+                continue;
+            }
+            if past_condition && child.is_named() && child.kind() != "else_clause" {
+                return Some(child);
+            }
+        }
+        None
+    }
+
     fn visit_if(&mut self, node: &Node, source: &str) {
-        let from_node = self.current_node.expect("current node should exist");
+        let Some(from_node) = self.current_node else {
+            return;
+        };
 
         let condition_node = self.cfg.add_node(NodeKind::Condition);
         self.cfg.add_edge(from_node, condition_node);
-
         let join_node = self.cfg.add_node(NodeKind::Join);
 
-        // Then branch — the first compound_statement child
+        // Then branch
+        if let Some(consequence) = Self::get_if_consequence(node) {
+            let then_start = self.cfg.add_node(NodeKind::Statement);
+            self.cfg.add_edge(condition_node, then_start);
+            self.current_node = Some(then_start);
+            self.visit_body(&consequence, source);
+            if let Some(end) = self.current_node {
+                if end != self.cfg.exit {
+                    self.cfg.add_edge(end, join_node);
+                }
+            }
+        }
+
+        // Else branch (via else_clause child)
+        let mut found_else = false;
         let mut cursor = node.walk();
         let children: Vec<_> = node.children(&mut cursor).collect();
-
-        let mut found_consequence = false;
-        let mut found_else = false;
-
         for child in &children {
-            if child.kind() == "compound_statement" && !found_consequence {
-                found_consequence = true;
-                let then_start = self.cfg.add_node(NodeKind::Statement);
-                self.cfg.add_edge(condition_node, then_start);
-                self.current_node = Some(then_start);
-                self.build_from_block(child, source);
-                if let Some(end) = self.current_node {
-                    if end != self.cfg.exit {
-                        self.cfg.add_edge(end, join_node);
-                    }
-                }
-            } else if child.kind() == "else_clause" {
+            if child.kind() == "else_clause" {
                 found_else = true;
-                // else_clause contains a compound_statement or another if_statement
-                let else_body = find_child_by_kind(*child, "compound_statement")
-                    .or_else(|| find_child_by_kind(*child, "if_statement"));
-                if let Some(body) = else_body {
+                // else_clause wraps the alternative — get its first named child
+                let mut ec_cursor = child.walk();
+                let alt_children: Vec<_> = child.children(&mut ec_cursor).collect();
+                if let Some(alt) = alt_children.iter().find(|c| c.is_named()) {
                     let else_start = self.cfg.add_node(NodeKind::Statement);
                     self.cfg.add_edge(condition_node, else_start);
                     self.current_node = Some(else_start);
-                    if body.kind() == "if_statement" {
-                        self.visit_if(&body, source);
-                    } else {
-                        self.build_from_block(&body, source);
-                    }
+                    self.visit_body(alt, source);
                     if let Some(end) = self.current_node {
                         if end != self.cfg.exit {
                             self.cfg.add_edge(end, join_node);
@@ -145,7 +169,6 @@ impl CCfgBuilderState {
             }
         }
 
-        // No else → condition can fall through to join
         if !found_else {
             self.cfg.add_edge(condition_node, join_node);
         }
@@ -154,7 +177,9 @@ impl CCfgBuilderState {
     }
 
     fn visit_while(&mut self, node: &Node, source: &str) {
-        let from_node = self.current_node.expect("current node should exist");
+        let Some(from_node) = self.current_node else {
+            return;
+        };
 
         let loop_header = self.cfg.add_node(NodeKind::LoopHeader);
         self.cfg.add_edge(from_node, loop_header);
@@ -162,47 +187,17 @@ impl CCfgBuilderState {
         let body_start = self.cfg.add_node(NodeKind::Statement);
         self.cfg.add_edge(loop_header, body_start);
 
-        let join_node = self.cfg.add_node(NodeKind::Join);
         self.loop_stack.push(LoopContext {
-            break_target: join_node,
+            break_target: None,
             continue_target: loop_header,
         });
 
-        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
+        let body = node
+            .child_by_field_name("body")
+            .or_else(|| find_child_by_kind(*node, "compound_statement"));
+        if let Some(body) = body {
             self.current_node = Some(body_start);
-            self.build_from_block(&body, source);
-            if let Some(end) = self.current_node {
-                if end != self.cfg.exit {
-                    self.cfg.add_edge(end, loop_header);
-                }
-            }
-        }
-
-        self.loop_stack.pop();
-        self.cfg.add_edge(loop_header, join_node);
-        self.current_node = Some(join_node);
-    }
-
-    fn visit_for(&mut self, node: &Node, source: &str) {
-        // Model for-loop the same as while: a single loop_header condition node.
-        // The init and increment expressions don't affect CC, only the condition does.
-        let from_node = self.current_node.expect("current node should exist");
-
-        let loop_header = self.cfg.add_node(NodeKind::LoopHeader);
-        self.cfg.add_edge(from_node, loop_header);
-
-        let body_start = self.cfg.add_node(NodeKind::Statement);
-        self.cfg.add_edge(loop_header, body_start);
-
-        let join_node = self.cfg.add_node(NodeKind::Join);
-        self.loop_stack.push(LoopContext {
-            break_target: join_node,
-            continue_target: loop_header,
-        });
-
-        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
-            self.current_node = Some(body_start);
-            self.build_from_block(&body, source);
+            self.visit_body(&body, source);
             if let Some(end) = self.current_node {
                 if end != self.cfg.exit {
                     self.cfg.add_edge(end, loop_header);
@@ -212,28 +207,70 @@ impl CCfgBuilderState {
             self.cfg.add_edge(body_start, loop_header);
         }
 
+        let join_node = self.get_or_create_loop_break(self.loop_stack.len() - 1);
+        self.loop_stack.pop();
+        self.cfg.add_edge(loop_header, join_node);
+        self.current_node = Some(join_node);
+    }
+
+    fn visit_for(&mut self, node: &Node, source: &str) {
+        let Some(from_node) = self.current_node else {
+            return;
+        };
+
+        let loop_header = self.cfg.add_node(NodeKind::LoopHeader);
+        self.cfg.add_edge(from_node, loop_header);
+
+        let body_start = self.cfg.add_node(NodeKind::Statement);
+        self.cfg.add_edge(loop_header, body_start);
+
+        self.loop_stack.push(LoopContext {
+            break_target: None,
+            continue_target: loop_header,
+        });
+
+        let body = node
+            .child_by_field_name("body")
+            .or_else(|| find_child_by_kind(*node, "compound_statement"));
+        if let Some(body) = body {
+            self.current_node = Some(body_start);
+            self.visit_body(&body, source);
+            if let Some(end) = self.current_node {
+                if end != self.cfg.exit {
+                    self.cfg.add_edge(end, loop_header);
+                }
+            }
+        } else {
+            self.cfg.add_edge(body_start, loop_header);
+        }
+
+        let join_node = self.get_or_create_loop_break(self.loop_stack.len() - 1);
         self.loop_stack.pop();
         self.cfg.add_edge(loop_header, join_node);
         self.current_node = Some(join_node);
     }
 
     fn visit_do_while(&mut self, node: &Node, source: &str) {
-        let from_node = self.current_node.expect("current node should exist");
+        let Some(from_node) = self.current_node else {
+            return;
+        };
 
         let body_start = self.cfg.add_node(NodeKind::Statement);
         self.cfg.add_edge(from_node, body_start);
 
         let loop_header = self.cfg.add_node(NodeKind::LoopHeader);
-        let join_node = self.cfg.add_node(NodeKind::Join);
 
         self.loop_stack.push(LoopContext {
-            break_target: join_node,
+            break_target: None,
             continue_target: loop_header,
         });
 
-        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
+        let body = node
+            .child_by_field_name("body")
+            .or_else(|| find_child_by_kind(*node, "compound_statement"));
+        if let Some(body) = body {
             self.current_node = Some(body_start);
-            self.build_from_block(&body, source);
+            self.visit_body(&body, source);
             if let Some(end) = self.current_node {
                 if end != self.cfg.exit {
                     self.cfg.add_edge(end, loop_header);
@@ -241,76 +278,128 @@ impl CCfgBuilderState {
             }
         }
 
+        let join_node = self.get_or_create_loop_break(self.loop_stack.len() - 1);
         self.loop_stack.pop();
-        // condition at loop_header: back edge or exit
         self.cfg.add_edge(loop_header, body_start);
         self.cfg.add_edge(loop_header, join_node);
         self.current_node = Some(join_node);
     }
 
     fn visit_switch(&mut self, node: &Node, source: &str) {
-        let from_node = self.current_node.expect("current node should exist");
+        let Some(from_node) = self.current_node else {
+            return;
+        };
 
         let switch_node = self.cfg.add_node(NodeKind::Condition);
         self.cfg.add_edge(from_node, switch_node);
 
-        let join_node = self.cfg.add_node(NodeKind::Join);
         self.loop_stack.push(LoopContext {
-            break_target: join_node,
-            continue_target: join_node, // switch doesn't have a natural continue target
+            break_target: None,
+            continue_target: switch_node,
         });
 
-        if let Some(body) = find_child_by_kind(*node, "compound_statement") {
+        let body = node
+            .child_by_field_name("body")
+            .or_else(|| find_child_by_kind(*node, "compound_statement"));
+        if let Some(body) = body {
             let mut cursor = body.walk();
             for child in body.children(&mut cursor) {
                 if child.kind() == "case_statement" || child.kind() == "default_statement" {
                     let case_start = self.cfg.add_node(NodeKind::Statement);
                     self.cfg.add_edge(switch_node, case_start);
                     self.current_node = Some(case_start);
-                    // Visit children of the case
                     let mut case_cursor = child.walk();
                     for case_child in child.children(&mut case_cursor) {
                         if case_child.is_named() && case_child.kind() != ":" {
                             self.visit_node(&case_child, source);
                         }
                     }
+                    let idx = self.loop_stack.len() - 1;
+                    let join = self.get_or_create_loop_break(idx);
                     if let Some(end) = self.current_node {
                         if end != self.cfg.exit {
-                            self.cfg.add_edge(end, join_node);
+                            self.cfg.add_edge(end, join);
                         }
                     }
                 }
             }
         }
 
+        let join_node = self.get_or_create_loop_break(self.loop_stack.len() - 1);
         self.loop_stack.pop();
-        self.cfg.add_edge(switch_node, join_node); // default fallthrough
+        self.cfg.add_edge(switch_node, join_node);
         self.current_node = Some(join_node);
     }
 
     fn visit_return(&mut self) {
         if let Some(from_node) = self.current_node {
             self.cfg.add_edge(from_node, self.cfg.exit);
-            self.current_node = Some(self.cfg.exit);
+            self.current_node = None;
+        }
+    }
+
+    fn visit_goto(&mut self) {
+        if let Some(from_node) = self.current_node {
+            // goto is a branch: +1 CC, then control leaves this path
+            let goto_node = self.cfg.add_node(NodeKind::Condition);
+            self.cfg.add_edge(from_node, goto_node);
+            self.cfg.add_edge(goto_node, self.cfg.exit);
+            self.current_node = None;
+        }
+    }
+
+    fn visit_labeled(&mut self, node: &Node, source: &str) {
+        // A label is a jump target reachable via goto. Always create a node for it.
+        let label_node = self.cfg.add_node(NodeKind::Statement);
+        if let Some(from) = self.current_node {
+            self.cfg.add_edge(from, label_node);
+        } else {
+            // Dead code path (after goto/return) — connect from entry so the CFG
+            // remains valid without inflating CC (adds one node and one edge: net 0).
+            self.cfg.add_edge(self.cfg.entry, label_node);
+        }
+        self.current_node = Some(label_node);
+        // Visit the labeled body (skip the statement_identifier child)
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.is_named() && child.kind() != "statement_identifier" {
+                self.visit_node(&child, source);
+                break;
+            }
         }
     }
 
     fn visit_break(&mut self) {
-        if let Some(loop_ctx) = self.loop_stack.last() {
-            if let Some(from_node) = self.current_node {
-                self.cfg.add_edge(from_node, loop_ctx.break_target);
-                self.current_node = Some(loop_ctx.break_target);
-            }
+        if let Some(from_node) = self.current_node {
+            let idx = self.loop_stack.len().wrapping_sub(1);
+            let target = self.get_or_create_loop_break(idx);
+            self.cfg.add_edge(from_node, target);
+            self.current_node = None;
         }
     }
 
     fn visit_continue(&mut self) {
         if let Some(loop_ctx) = self.loop_stack.last() {
             if let Some(from_node) = self.current_node {
-                self.cfg.add_edge(from_node, loop_ctx.continue_target);
-                self.current_node = Some(loop_ctx.continue_target);
+                let target = loop_ctx.continue_target;
+                self.cfg.add_edge(from_node, target);
+                self.current_node = None;
             }
         }
+    }
+
+    /// Get or lazily create the break/join target for the loop at `idx`.
+    fn get_or_create_loop_break(&mut self, idx: usize) -> NodeId {
+        if let Some(ctx) = self.loop_stack.get(idx) {
+            if let Some(id) = ctx.break_target {
+                return id;
+            }
+        }
+        let id = self.cfg.add_node(NodeKind::Join);
+        if let Some(ctx) = self.loop_stack.get_mut(idx) {
+            ctx.break_target = Some(id);
+        }
+        id
     }
 }
 
@@ -356,12 +445,17 @@ mod tests {
         }
     }
 
+    fn cc(source: &str) -> usize {
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        // CC = E - N + 2
+        (cfg.edge_count() as isize - cfg.node_count() as isize + 2).max(1) as usize
+    }
+
     #[test]
     fn test_simple_function() {
         let source = "int test_func(int x) { return x + 1; }";
-        let function = make_c_function(source);
-        let cfg = CCfgBuilder.build(&function);
-        assert!(cfg.node_count() >= 2);
+        assert_eq!(cc(source), 1);
     }
 
     #[test]
@@ -375,10 +469,45 @@ int test_func(int x) {
     }
 }
 "#;
-        let function = make_c_function(source);
-        let cfg = CCfgBuilder.build(&function);
-        assert!(cfg.node_count() > 4);
-        assert!(cfg.edge_count() > 4);
+        assert_eq!(cc(source), 2);
+    }
+
+    #[test]
+    fn test_if_no_else() {
+        let source = r#"
+int test_func(int x) {
+    if (x > 0) {
+        x = 0;
+    }
+    return x;
+}
+"#;
+        assert_eq!(cc(source), 2);
+    }
+
+    #[test]
+    fn test_braceless_if() {
+        let source = r#"
+int test_func(int x) {
+    if (x > 0)
+        return 1;
+    return 0;
+}
+"#;
+        assert_eq!(cc(source), 2);
+    }
+
+    #[test]
+    fn test_braceless_if_else() {
+        let source = r#"
+int test_func(int x) {
+    if (x > 0)
+        return 1;
+    else
+        return 0;
+}
+"#;
+        assert_eq!(cc(source), 2);
     }
 
     #[test]
@@ -390,9 +519,7 @@ void test_func(int n) {
     }
 }
 "#;
-        let function = make_c_function(source);
-        let cfg = CCfgBuilder.build(&function);
-        assert!(cfg.node_count() >= 4);
+        assert_eq!(cc(source), 2);
     }
 
     #[test]
@@ -405,8 +532,121 @@ void test_func(int n) {
     }
 }
 "#;
+        assert_eq!(cc(source), 2);
+    }
+
+    #[test]
+    fn test_do_while_loop() {
+        let source = r#"
+void test_func(int n) {
+    do {
+        n--;
+    } while (n > 0);
+}
+"#;
+        assert_eq!(cc(source), 2);
+    }
+
+    #[test]
+    fn test_switch() {
+        let source = r#"
+void test_func(int x) {
+    switch (x) {
+        case 1: break;
+        case 2: break;
+        default: break;
+    }
+}
+"#;
+        // switch condition node + 3 case edges + default fallthrough = CC 4
+        let c = cc(source);
+        assert!(c >= 3, "switch with 3 cases should have CC >= 3, got {}", c);
+    }
+
+    #[test]
+    fn test_goto_adds_branch() {
+        // goto should add +1 CC (branch node)
+        let source_no_goto = r#"
+int test_func(int x) {
+    return x;
+}
+"#;
+        let source_with_goto = r#"
+int test_func(int x) {
+    if (x < 0) goto done;
+    x = x + 1;
+    done:
+    return x;
+}
+"#;
+        let cc_base = cc(source_no_goto);
+        let cc_goto = cc(source_with_goto);
+        // if + goto = at least 2 more than base
+        assert!(
+            cc_goto > cc_base,
+            "goto should increase CC: base={}, goto={}",
+            cc_base,
+            cc_goto
+        );
+    }
+
+    #[test]
+    fn test_labeled_statement_after_goto() {
+        // Label after goto should not panic (dead code before label)
+        let source = r#"
+void test_func(void) {
+    goto end;
+    end:
+    return;
+}
+"#;
         let function = make_c_function(source);
         let cfg = CCfgBuilder.build(&function);
-        assert!(cfg.node_count() >= 5);
+        assert!(cfg.node_count() >= 2);
+    }
+
+    #[test]
+    fn test_break_in_loop() {
+        let source = r#"
+void test_func(int n) {
+    while (1) {
+        if (n <= 0) break;
+        n--;
+    }
+}
+"#;
+        let c = cc(source);
+        assert!(c >= 3, "while+if+break should have CC >= 3, got {}", c);
+    }
+
+    #[test]
+    fn test_continue_in_loop() {
+        let source = r#"
+void test_func(int n) {
+    int i;
+    for (i = 0; i < n; i++) {
+        if (i % 2 == 0) continue;
+        n--;
+    }
+}
+"#;
+        let c = cc(source);
+        assert!(c >= 3, "for+if+continue should have CC >= 3, got {}", c);
+    }
+
+    #[test]
+    fn test_dead_code_after_return_no_panic() {
+        // Dead code after return should not panic
+        let source = r#"
+int test_func(int x) {
+    return x;
+    if (x > 0) {
+        return 1;
+    }
+}
+"#;
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        assert!(cfg.node_count() >= 2);
     }
 }

--- a/hotspots-core/src/language/c/mod.rs
+++ b/hotspots-core/src/language/c/mod.rs
@@ -1,0 +1,10 @@
+//! C language support
+//!
+//! Parses C source files using tree-sitter-c. C has a flat AST (no classes),
+//! so function discovery is a single-level walk over `function_definition` nodes.
+
+pub mod cfg_builder;
+pub mod parser;
+
+pub use cfg_builder::CCfgBuilder;
+pub use parser::CParser;

--- a/hotspots-core/src/language/c/parser.rs
+++ b/hotspots-core/src/language/c/parser.rs
@@ -1,0 +1,229 @@
+//! C language parser using tree-sitter
+
+use crate::ast::FunctionNode;
+use crate::language::parser::{LanguageParser, ParsedModule};
+use crate::language::tree_sitter_utils::find_child_by_kind;
+use anyhow::{Context, Result};
+use tree_sitter::{Node, Parser, Tree};
+
+/// C parser using tree-sitter
+pub struct CParser;
+
+impl CParser {
+    pub fn new() -> Result<Self> {
+        let mut parser = Parser::new();
+        let language = tree_sitter_c::LANGUAGE;
+        parser
+            .set_language(&language.into())
+            .context("Failed to set C language for parser")?;
+        Ok(CParser)
+    }
+}
+
+impl Default for CParser {
+    fn default() -> Self {
+        Self::new().expect("Failed to create C parser")
+    }
+}
+
+impl LanguageParser for CParser {
+    fn parse(&self, source: &str, filename: &str) -> Result<Box<dyn ParsedModule>> {
+        let mut parser = Parser::new();
+        let language = tree_sitter_c::LANGUAGE;
+        parser
+            .set_language(&language.into())
+            .context("Failed to set C language")?;
+
+        let tree = parser
+            .parse(source, None)
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse C file: {}", filename))?;
+
+        Ok(Box::new(CModule {
+            tree,
+            source: source.to_string(),
+        }))
+    }
+}
+
+struct CModule {
+    tree: Tree,
+    source: String,
+}
+
+impl ParsedModule for CModule {
+    fn discover_functions(&self, file_index: usize, _source: &str) -> Vec<FunctionNode> {
+        let root = self.tree.root_node();
+        let mut functions = Vec::new();
+        discover_functions_recursive(root, &self.source, file_index, &mut functions);
+        functions.sort_by_key(|f| f.span.start);
+        functions
+    }
+}
+
+fn discover_functions_recursive(
+    node: Node,
+    source: &str,
+    file_index: usize,
+    functions: &mut Vec<FunctionNode>,
+) {
+    if node.kind() == "function_definition" {
+        if let Some(function_node) = extract_function(node, source, file_index, functions.len()) {
+            functions.push(function_node);
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        discover_functions_recursive(child, source, file_index, functions);
+    }
+}
+
+fn extract_function(
+    node: Node,
+    source: &str,
+    file_index: usize,
+    local_index: usize,
+) -> Option<FunctionNode> {
+    use crate::ast::FunctionId;
+    use crate::language::{FunctionBody, SourceSpan};
+
+    // C function_definition has a declarator child containing the function name
+    let name = extract_function_name(node, source);
+
+    // Body is a compound_statement
+    let body_node = find_child_by_kind(node, "compound_statement")?;
+
+    let span = SourceSpan::new(
+        node.start_byte(),
+        node.end_byte(),
+        node.start_position().row as u32 + 1,
+        node.end_position().row as u32 + 1,
+        node.start_position().column as u32,
+    );
+
+    let body = FunctionBody::C {
+        body_node: body_node.id(),
+        source: source.to_string(),
+    };
+
+    Some(FunctionNode {
+        id: FunctionId {
+            file_index,
+            local_index,
+        },
+        name,
+        span,
+        body,
+        suppression_reason: None,
+    })
+}
+
+/// Extract function name from a C function_definition node.
+///
+/// C grammar: function_definition → type declarator compound_statement
+/// The declarator may be a function_declarator or a pointer_declarator wrapping one.
+/// We find the innermost function_declarator and grab its identifier child.
+fn extract_function_name(node: Node, source: &str) -> Option<String> {
+    // Walk into declarator → function_declarator → identifier
+    fn find_identifier<'a>(n: Node<'a>, source: &str) -> Option<String> {
+        if n.kind() == "identifier" {
+            return Some(source[n.start_byte()..n.end_byte()].to_string());
+        }
+        let mut cursor = n.walk();
+        for child in n.children(&mut cursor) {
+            if let Some(name) = find_identifier(child, source) {
+                return Some(name);
+            }
+        }
+        None
+    }
+
+    // The declarator child is the second child (after the type specifier)
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        if kind == "function_declarator" || kind == "pointer_declarator" || kind == "declarator" {
+            if let Some(name) = find_identifier(child, source) {
+                return Some(name);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_parser() {
+        assert!(CParser::new().is_ok());
+    }
+
+    #[test]
+    fn test_parse_simple_function() {
+        let parser = CParser::new().unwrap();
+        let source = r#"
+int add(int a, int b) {
+    return a + b;
+}
+"#;
+        let module = parser.parse(source, "test.c").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name, Some("add".to_string()));
+    }
+
+    #[test]
+    fn test_parse_multiple_functions() {
+        let parser = CParser::new().unwrap();
+        let source = r#"
+void init(void) { }
+int compute(int x) { return x * 2; }
+static void helper(void) { }
+"#;
+        let module = parser.parse(source, "test.c").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 3);
+        assert_eq!(functions[0].name, Some("init".to_string()));
+        assert_eq!(functions[1].name, Some("compute".to_string()));
+        assert_eq!(functions[2].name, Some("helper".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pointer_return_type() {
+        let parser = CParser::new().unwrap();
+        let source = r#"
+char *get_name(int id) {
+    return names[id];
+}
+"#;
+        let module = parser.parse(source, "test.c").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name, Some("get_name".to_string()));
+    }
+
+    #[test]
+    fn test_parse_empty_file() {
+        let parser = CParser::new().unwrap();
+        let module = parser.parse("", "test.c").unwrap();
+        let functions = module.discover_functions(0, "");
+        assert_eq!(functions.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_header_declarations_ignored() {
+        let parser = CParser::new().unwrap();
+        // Declarations (no body) should not be discovered
+        let source = r#"
+int add(int a, int b);
+void cleanup(void);
+int real_function(void) { return 0; }
+"#;
+        let module = parser.parse(source, "test.h").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name, Some("real_function".to_string()));
+    }
+}

--- a/hotspots-core/src/language/cfg_builder.rs
+++ b/hotspots-core/src/language/cfg_builder.rs
@@ -33,6 +33,7 @@ pub fn get_builder_for_function(function: &FunctionNode) -> Box<dyn CfgBuilder> 
         FunctionBody::Python { .. } => Box::new(super::python::PythonCfgBuilder),
         FunctionBody::Rust { .. } => Box::new(super::rust::RustCfgBuilder),
         FunctionBody::CSharp { .. } => Box::new(super::csharp::CSharpCfgBuilder),
+        FunctionBody::C { .. } => Box::new(super::c::CCfgBuilder),
     }
 }
 

--- a/hotspots-core/src/language/function_body.rs
+++ b/hotspots-core/src/language/function_body.rs
@@ -65,6 +65,16 @@ pub enum FunctionBody {
         /// The source code (needed to reconstruct the tree)
         source: String,
     },
+
+    /// C function body
+    ///
+    /// Contains the tree-sitter node ID for the compound_statement and the source code.
+    C {
+        /// The tree-sitter node ID for the function body compound_statement
+        body_node: usize,
+        /// The source code (needed to reconstruct the tree)
+        source: String,
+    },
 }
 
 impl FunctionBody {
@@ -101,6 +111,11 @@ impl FunctionBody {
     /// Check if this is a C# function body
     pub fn is_csharp(&self) -> bool {
         matches!(self, FunctionBody::CSharp { .. })
+    }
+
+    /// Check if this is a C function body
+    pub fn is_c(&self) -> bool {
+        matches!(self, FunctionBody::C { .. })
     }
 
     /// Get the ECMAScript body, if this is one
@@ -185,6 +200,18 @@ impl FunctionBody {
         match self {
             FunctionBody::CSharp { body_node, source } => (*body_node, source.as_str()),
             _ => panic!("FunctionBody is not CSharp"),
+        }
+    }
+
+    /// Get the C body node ID and source, if this is a C function
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is not a C body. Use `is_c()` to check first.
+    pub fn as_c(&self) -> (usize, &str) {
+        match self {
+            FunctionBody::C { body_node, source } => (*body_node, source.as_str()),
+            _ => panic!("FunctionBody is not C"),
         }
     }
 }

--- a/hotspots-core/src/language/mod.rs
+++ b/hotspots-core/src/language/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides language-agnostic interfaces for parsing and analyzing
 //! source code across multiple programming languages.
 
+pub mod c;
 pub mod cfg_builder;
 pub mod csharp;
 pub mod ecmascript;
@@ -19,6 +20,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+pub use c::{CCfgBuilder, CParser};
 pub use cfg_builder::{get_builder_for_function, CfgBuilder};
 pub use csharp::{CSharpCfgBuilder, CSharpParser};
 pub use ecmascript::{ECMAScriptCfgBuilder, ECMAScriptParser, VueParser};
@@ -53,6 +55,10 @@ pub enum Language {
     Vue,
     /// C# (.cs)
     CSharp,
+    /// C (.c)
+    C,
+    /// C header (.h)
+    CHeader,
 }
 
 impl Language {
@@ -90,6 +96,9 @@ impl Language {
             "vue" => Some(Language::Vue),
             // C#
             "cs" => Some(Language::CSharp),
+            // C
+            "c" => Some(Language::C),
+            "h" => Some(Language::CHeader),
             // Unknown
             _ => None,
         }
@@ -148,6 +157,8 @@ impl Language {
             Language::Rust => "Rust",
             Language::Vue => "Vue",
             Language::CSharp => "C#",
+            Language::C => "C",
+            Language::CHeader => "C Header",
         }
     }
 
@@ -181,6 +192,8 @@ impl Language {
             Language::Rust => &["rs"],
             Language::Vue => &["vue"],
             Language::CSharp => &["cs"],
+            Language::C => &["c"],
+            Language::CHeader => &["h"],
         }
     }
 
@@ -197,6 +210,8 @@ impl Language {
             "Rust" => Some(Language::Rust),
             "Vue" => Some(Language::Vue),
             "C#" => Some(Language::CSharp),
+            "C" => Some(Language::C),
+            "C Header" => Some(Language::CHeader),
             _ => None,
         }
     }
@@ -260,8 +275,13 @@ mod tests {
     #[test]
     fn test_from_extension_unknown() {
         assert_eq!(Language::from_extension("cpp"), None);
-        assert_eq!(Language::from_extension("c"), None);
         assert_eq!(Language::from_extension(""), None);
+    }
+
+    #[test]
+    fn test_from_extension_c() {
+        assert_eq!(Language::from_extension("c"), Some(Language::C));
+        assert_eq!(Language::from_extension("h"), Some(Language::CHeader));
     }
 
     #[test]

--- a/hotspots-core/src/language/tree_sitter_utils.rs
+++ b/hotspots-core/src/language/tree_sitter_utils.rs
@@ -102,3 +102,5 @@ make_parse_cache!(
     with_cached_csharp_tree,
     tree_sitter_c_sharp::LANGUAGE
 );
+
+make_parse_cache!(C_TREE_CACHE, with_cached_c_tree, tree_sitter_c::LANGUAGE);

--- a/hotspots-core/src/metrics.rs
+++ b/hotspots-core/src/metrics.rs
@@ -80,6 +80,7 @@ pub fn extract_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
             extract_rust_metrics(function, cfg)
         }
         FunctionBody::CSharp { .. } => extract_csharp_metrics(function, cfg),
+        FunctionBody::C { .. } => extract_c_metrics(function, cfg),
     }
 }
 
@@ -948,6 +949,88 @@ fn extract_csharp_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
         loc: 0,
         callee_names: vec![],
     })
+}
+
+// ============================================================================
+// C Metrics Implementation
+// ============================================================================
+
+fn extract_c_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
+    let (_body_node_id, source) = function.body.as_c();
+    ts_with_function_body(
+        source,
+        tree_sitter_c::LANGUAGE.into(),
+        function.span.start,
+        &["function_definition"],
+        &["compound_statement"],
+        |func_node, body_node| {
+            let callee_names = c_extract_callees(&body_node, source);
+            RawMetrics {
+                cc: calculate_cc_from_cfg(cfg),
+                nd: ts_nesting_depth(
+                    &body_node,
+                    &[
+                        "if_statement",
+                        "while_statement",
+                        "do_statement",
+                        "for_statement",
+                        "switch_statement",
+                    ],
+                ),
+                fo: callee_names.len(),
+                ns: ts_non_structured_exits(
+                    &body_node,
+                    &[
+                        "return_statement",
+                        "break_statement",
+                        "continue_statement",
+                        "goto_statement",
+                    ],
+                ),
+                loc: calculate_loc_from_node(&func_node),
+                callee_names,
+            }
+        },
+    )
+    .unwrap_or(RawMetrics {
+        cc: 1,
+        nd: 0,
+        fo: 0,
+        ns: 0,
+        loc: 0,
+        callee_names: vec![],
+    })
+}
+
+/// Extract callee names from a C function body (call_expression nodes).
+fn c_extract_callees(body_node: &tree_sitter::Node, source: &str) -> Vec<String> {
+    fn collect(
+        node: tree_sitter::Node,
+        source: &str,
+        calls: &mut std::collections::HashSet<String>,
+    ) {
+        if node.kind() == "call_expression" {
+            // First child of call_expression is the function identifier
+            let child_count = node.child_count();
+            if child_count > 0 {
+                if let Some(callee) = node.child(0) {
+                    let text = &source[callee.start_byte()..callee.end_byte()];
+                    calls.insert(text.to_string());
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.children(&mut cursor).collect();
+        for child in children {
+            collect(child, source, calls);
+        }
+    }
+
+    let mut calls = std::collections::HashSet::new();
+    collect(*body_node, source, &mut calls);
+    let mut result: Vec<String> = calls.into_iter().collect();
+    result.sort();
+    result
 }
 
 /// Extract callee names from a C# function body.

--- a/hotspots-core/src/metrics.rs
+++ b/hotspots-core/src/metrics.rs
@@ -966,7 +966,7 @@ fn extract_c_metrics(function: &FunctionNode, cfg: &Cfg) -> RawMetrics {
         |func_node, body_node| {
             let callee_names = c_extract_callees(&body_node, source);
             RawMetrics {
-                cc: calculate_cc_from_cfg(cfg),
+                cc: calculate_cc_from_cfg(cfg) + c_count_cc_extras(&body_node),
                 nd: ts_nesting_depth(
                     &body_node,
                     &[
@@ -1031,6 +1031,34 @@ fn c_extract_callees(body_node: &tree_sitter::Node, source: &str) -> Vec<String>
     let mut result: Vec<String> = calls.into_iter().collect();
     result.sort();
     result
+}
+
+/// Count additional CC contributors in C (ternary expressions, boolean short-circuit operators).
+fn c_count_cc_extras(body_node: &tree_sitter::Node) -> usize {
+    fn count_extras(node: tree_sitter::Node, count: &mut usize) {
+        match node.kind() {
+            "conditional_expression" => {
+                *count += 1;
+            }
+            "binary_expression" => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if child.kind() == "&&" || child.kind() == "||" {
+                        *count += 1;
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            count_extras(child, count);
+        }
+    }
+    let mut count = 0;
+    count_extras(*body_node, &mut count);
+    count
 }
 
 /// Extract callee names from a C# function body.

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -477,6 +477,7 @@ fn extract_models_from_source(source: &str, language: Language, file: String) ->
         | Language::JavaScriptReact
         | Language::Vue => extract_regex_models(source, language, file, ECMASCRIPT_MODEL_PATTERNS),
         Language::CSharp => extract_regex_models(source, language, file, CSHARP_MODEL_PATTERNS),
+        Language::C | Language::CHeader => vec![], // struct/typedef model detection not implemented
     }
 }
 

--- a/hotspots-core/tests/golden_tests.rs
+++ b/hotspots-core/tests/golden_tests.rs
@@ -1003,3 +1003,88 @@ fn test_csharp_golden_determinism() {
 fn test_csharp_golden_switches() {
     test_csharp_golden("Switches");
 }
+
+// C language golden tests
+
+fn test_c_golden(fixture_name: &str) {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("c")
+        .join(format!("{}.c", fixture_name));
+    let golden = golden_path(&format!("c-{}.json", fixture_name));
+    let project_root = project_root();
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&fixture, options)
+        .unwrap_or_else(|e| panic!("Failed to analyze {}: {}", fixture.display(), e));
+
+    let output = render_json(&reports);
+    let expected = read_golden(&format!("c-{}.json", fixture_name));
+
+    let mut output_json: serde_json::Value =
+        serde_json::from_str(&output).unwrap_or_else(|e| panic!("Output is not valid JSON: {}", e));
+    let mut expected_json: serde_json::Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|e| panic!("Golden file {} is not valid JSON: {}", golden.display(), e));
+
+    normalize_paths(&mut output_json, &project_root);
+    normalize_paths(&mut expected_json, &project_root);
+
+    assert_eq!(
+        output_json, expected_json,
+        "Output does not match golden file for c-{}",
+        fixture_name
+    );
+}
+
+#[test]
+fn test_c_golden_simple() {
+    test_c_golden("simple");
+}
+
+#[test]
+fn test_c_golden_loops() {
+    test_c_golden("loops");
+}
+
+#[test]
+fn test_c_golden_control_flow() {
+    test_c_golden("control_flow");
+}
+
+#[test]
+fn test_c_golden_goto() {
+    test_c_golden("goto");
+}
+
+#[test]
+fn test_c_golden_determinism() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests")
+        .join("fixtures")
+        .join("c")
+        .join("simple.c");
+
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    let reports1 = analyze(&fixture, options).unwrap();
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    let reports2 = analyze(&fixture, options).unwrap();
+
+    let json1 = render_json(&reports1);
+    let json2 = render_json(&reports2);
+    assert_eq!(json1, json2, "C analysis is not deterministic");
+}

--- a/tests/fixtures/c/control_flow.c
+++ b/tests/fixtures/c/control_flow.c
@@ -1,0 +1,54 @@
+int classify(int x) {
+    if (x > 0) {
+        return 1;
+    } else if (x < 0) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+int braceless_if(int x) {
+    if (x > 0)
+        return 1;
+    else
+        return 0;
+}
+
+int switch_days(int day) {
+    switch (day) {
+        case 0: return 0;
+        case 6: return 0;
+        default: return 1;
+    }
+}
+
+int ternary_example(int x) {
+    return x > 0 ? x : -x;
+}
+
+int boolean_ops(int a, int b, int c) {
+    if (a > 0 && b > 0) {
+        return 1;
+    }
+    if (a < 0 || b < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int nested_ifs(int x, int y) {
+    if (x > 0) {
+        if (y > 0) {
+            return 1;
+        } else {
+            return 2;
+        }
+    } else {
+        if (y > 0) {
+            return 3;
+        } else {
+            return 4;
+        }
+    }
+}

--- a/tests/fixtures/c/goto.c
+++ b/tests/fixtures/c/goto.c
@@ -1,0 +1,25 @@
+int cleanup_pattern(int x) {
+    int result = 0;
+    if (x < 0) goto done;
+    result = x * 2;
+    done:
+    return result;
+}
+
+int multi_goto(int x, int y) {
+    if (x < 0) goto error;
+    if (y < 0) goto error;
+    return x + y;
+    error:
+    return -1;
+}
+
+void loop_goto(int n) {
+    int i = 0;
+    top:
+    if (i >= n) goto end;
+    i++;
+    goto top;
+    end:
+    return;
+}

--- a/tests/fixtures/c/loops.c
+++ b/tests/fixtures/c/loops.c
@@ -1,0 +1,44 @@
+int sum_while(int n) {
+    int sum = 0;
+    while (n > 0) {
+        sum += n;
+        n--;
+    }
+    return sum;
+}
+
+int sum_for(int n) {
+    int sum = 0;
+    int i;
+    for (i = 1; i <= n; i++) {
+        sum += i;
+    }
+    return sum;
+}
+
+int sum_do_while(int n) {
+    int sum = 0;
+    do {
+        sum += n;
+        n--;
+    } while (n > 0);
+    return sum;
+}
+
+int loop_with_break(int n) {
+    int i;
+    for (i = 0; i < n; i++) {
+        if (i == 5) break;
+    }
+    return i;
+}
+
+int loop_with_continue(int n) {
+    int sum = 0;
+    int i;
+    for (i = 0; i < n; i++) {
+        if (i % 2 == 0) continue;
+        sum += i;
+    }
+    return sum;
+}

--- a/tests/fixtures/c/simple.c
+++ b/tests/fixtures/c/simple.c
@@ -1,0 +1,18 @@
+int add(int a, int b) {
+    return a + b;
+}
+
+int multiply(int a, int b) {
+    int result = a * b;
+    return result;
+}
+
+void noop(void) {
+}
+
+int absolute_value(int x) {
+    if (x < 0) {
+        return -x;
+    }
+    return x;
+}

--- a/tests/golden/c-control_flow.json
+++ b/tests/golden/c-control_flow.json
@@ -1,0 +1,65 @@
+[
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/control_flow.c",
+    "function": "boolean_ops",
+    "language": "C",
+    "line": 30,
+    "lrs": 5.8999999999999995,
+    "metrics": {
+      "cc": 7,
+      "fo": 0,
+      "loc": 9,
+      "nd": 1,
+      "ns": 3
+    },
+    "risk": {
+      "r_cc": 3.0,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 3.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/control_flow.c",
+    "function": "switch_days",
+    "language": "C",
+    "line": 18,
+    "lrs": 5.707354922057604,
+    "metrics": {
+      "cc": 6,
+      "fo": 0,
+      "loc": 7,
+      "nd": 1,
+      "ns": 3
+    },
+    "risk": {
+      "r_cc": 2.807354922057604,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 3.0
+    }
+  },
+  {
+    "band": "low",
+    "file": "tests/fixtures/c/control_flow.c",
+    "function": "ternary_example",
+    "language": "C",
+    "line": 26,
+    "lrs": 2.2849625007211563,
+    "metrics": {
+      "cc": 2,
+      "fo": 0,
+      "loc": 3,
+      "nd": 0,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 1.584962500721156,
+      "r_fo": 0.0,
+      "r_nd": 0.0,
+      "r_ns": 1.0
+    }
+  }
+]

--- a/tests/golden/c-goto.json
+++ b/tests/golden/c-goto.json
@@ -1,0 +1,65 @@
+[
+  {
+    "band": "high",
+    "file": "tests/fixtures/c/goto.c",
+    "function": "multi_goto",
+    "language": "C",
+    "line": 9,
+    "lrs": 6.407354922057604,
+    "metrics": {
+      "cc": 6,
+      "fo": 0,
+      "loc": 7,
+      "nd": 1,
+      "ns": 4
+    },
+    "risk": {
+      "r_cc": 2.807354922057604,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 4.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/goto.c",
+    "function": "loop_goto",
+    "language": "C",
+    "line": 17,
+    "lrs": 5.4849625007211555,
+    "metrics": {
+      "cc": 5,
+      "fo": 0,
+      "loc": 9,
+      "nd": 1,
+      "ns": 3
+    },
+    "risk": {
+      "r_cc": 2.584962500721156,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 3.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/goto.c",
+    "function": "cleanup_pattern",
+    "language": "C",
+    "line": 1,
+    "lrs": 4.521928094887363,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 7,
+      "nd": 1,
+      "ns": 2
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 2.0
+    }
+  }
+]

--- a/tests/golden/c-loops.json
+++ b/tests/golden/c-loops.json
@@ -1,0 +1,107 @@
+[
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/loops.c",
+    "function": "loop_with_break",
+    "language": "C",
+    "line": 28,
+    "lrs": 5.584962500721156,
+    "metrics": {
+      "cc": 5,
+      "fo": 0,
+      "loc": 7,
+      "nd": 2,
+      "ns": 2
+    },
+    "risk": {
+      "r_cc": 2.584962500721156,
+      "r_fo": 0.0,
+      "r_nd": 2.0,
+      "r_ns": 2.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/loops.c",
+    "function": "loop_with_continue",
+    "language": "C",
+    "line": 36,
+    "lrs": 5.584962500721156,
+    "metrics": {
+      "cc": 5,
+      "fo": 0,
+      "loc": 9,
+      "nd": 2,
+      "ns": 2
+    },
+    "risk": {
+      "r_cc": 2.584962500721156,
+      "r_fo": 0.0,
+      "r_nd": 2.0,
+      "r_ns": 2.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/loops.c",
+    "function": "sum_while",
+    "language": "C",
+    "line": 1,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 8,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/loops.c",
+    "function": "sum_for",
+    "language": "C",
+    "line": 10,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 8,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/loops.c",
+    "function": "sum_do_while",
+    "language": "C",
+    "line": 19,
+    "lrs": 3.821928094887362,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 8,
+      "nd": 1,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 1.0
+    }
+  }
+]

--- a/tests/golden/c-simple.json
+++ b/tests/golden/c-simple.json
@@ -1,0 +1,86 @@
+[
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/simple.c",
+    "function": "absolute_value",
+    "language": "C",
+    "line": 13,
+    "lrs": 4.521928094887363,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 6,
+      "nd": 1,
+      "ns": 2
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 2.0
+    }
+  },
+  {
+    "band": "low",
+    "file": "tests/fixtures/c/simple.c",
+    "function": "multiply",
+    "language": "C",
+    "line": 5,
+    "lrs": 2.7,
+    "metrics": {
+      "cc": 3,
+      "fo": 0,
+      "loc": 4,
+      "nd": 0,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 2.0,
+      "r_fo": 0.0,
+      "r_nd": 0.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "low",
+    "file": "tests/fixtures/c/simple.c",
+    "function": "add",
+    "language": "C",
+    "line": 1,
+    "lrs": 1.7,
+    "metrics": {
+      "cc": 1,
+      "fo": 0,
+      "loc": 3,
+      "nd": 0,
+      "ns": 1
+    },
+    "risk": {
+      "r_cc": 1.0,
+      "r_fo": 0.0,
+      "r_nd": 0.0,
+      "r_ns": 1.0
+    }
+  },
+  {
+    "band": "low",
+    "file": "tests/fixtures/c/simple.c",
+    "function": "noop",
+    "language": "C",
+    "line": 10,
+    "lrs": 1.0,
+    "metrics": {
+      "cc": 1,
+      "fo": 0,
+      "loc": 2,
+      "nd": 0,
+      "ns": 0
+    },
+    "risk": {
+      "r_cc": 1.0,
+      "r_fo": 0.0,
+      "r_nd": 0.0,
+      "r_ns": 0.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- Adds C (`.c`) and C header (`.h`) file support via `tree-sitter-c`
- Registers `CParser` in `create_parser` alongside existing language parsers
- Updates `hotspots-core` description to include C in the supported language list

## Test plan

- [ ] Run `cargo test` — golden tests and existing suite pass
- [ ] Point `hotspots` at a C project and confirm `.c`/`.h` files are analysed and scored
- [ ] Confirm `.c`/`.h` files are not skipped or misclassified

🤖 Generated with [Claude Code](https://claude.com/claude-code)