### PR TITLE
feat: add C/C++ vendored dirs to default excludes

### DIFF
--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -66,6 +66,13 @@ const DEFAULT_EXCLUDES: &[&str] = &[
     // Java/Kotlin build output
     "**/target/**",
     "**/out/**",
+    // C/C++ vendored dependencies (common bundling conventions)
+    "**/deps/**",
+    "**/third_party/**",
+    "**/thirdparty/**",
+    "**/external/**",
+    "**/extern/**",
+    "**/contrib/**",
 ];
 
 /// Hotspots configuration loaded from a JSON config file
@@ -882,6 +889,16 @@ mod tests {
         assert!(!resolved.should_include(Path::new("dist/bundle.js")));
         assert!(resolved.should_include(Path::new("src/api.ts")));
         assert!(resolved.should_include(Path::new("src/components/Button.tsx")));
+        // C/C++ vendored directories
+        assert!(!resolved.should_include(Path::new("deps/jemalloc/src/arena.c")));
+        assert!(!resolved.should_include(Path::new("third_party/abseil/absl/base/base.cc")));
+        assert!(!resolved.should_include(Path::new("thirdparty/openssl/ssl/ssl_lib.c")));
+        assert!(!resolved.should_include(Path::new("external/zlib/deflate.c")));
+        assert!(!resolved.should_include(Path::new("extern/lua/lvm.c")));
+        assert!(!resolved.should_include(Path::new("contrib/hiredis/net.c")));
+        // Own source should still be included
+        assert!(resolved.should_include(Path::new("src/server.c")));
+        assert!(resolved.should_include(Path::new("src/networking.c")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds common C/C++ vendored dependency directories to `DEFAULT_EXCLUDES` in `config.rs`:

- `**/deps/**` — used by Redis, SQLite, and others
- `**/third_party/**` — used by Chromium, gRPC, protobuf
- `**/thirdparty/**` — alternate spelling
- `**/external/**` — used by CMake FetchContent projects
- `**/extern/**` — common shorthand
- `**/contrib/**` — used by PostgreSQL, OpenSSL

## Why

The first `redis/redis` analysis surfaced all 5 top hotspots from `deps/jemalloc/` — a vendored third-party allocator. These directories are structurally equivalent to `**/vendor/**` (already excluded for Go) — they contain third-party source bundled into the repo, not code the project owns or can refactor.

Users who genuinely want to analyze vendored deps can opt back in via `.hotspotsrc.json` `include` patterns.

## Test plan

- [x] All 383 tests pass
- [x] New assertions in `test_should_include_default_excludes` cover all 6 new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)