### PR TITLE
fix: lazy join_node in C if/else prevents orphan CFG nodes

### DIFF
--- a/hotspots-core/src/language/c/cfg_builder.rs
+++ b/hotspots-core/src/language/c/cfg_builder.rs
@@ -130,7 +130,12 @@ impl CCfgBuilderState {
 
         let condition_node = self.cfg.add_node(NodeKind::Condition);
         self.cfg.add_edge(from_node, condition_node);
-        let join_node = self.cfg.add_node(NodeKind::Join);
+
+        // join_node is created lazily — only if at least one branch falls through.
+        let mut join_node: Option<NodeId> = None;
+        let mut get_join = |cfg: &mut Cfg| -> NodeId {
+            *join_node.get_or_insert_with(|| cfg.add_node(NodeKind::Join))
+        };
 
         // Then branch
         if let Some(consequence) = Self::get_if_consequence(node) {
@@ -140,7 +145,8 @@ impl CCfgBuilderState {
             self.visit_body(&consequence, source);
             if let Some(end) = self.current_node {
                 if end != self.cfg.exit {
-                    self.cfg.add_edge(end, join_node);
+                    let j = get_join(&mut self.cfg);
+                    self.cfg.add_edge(end, j);
                 }
             }
         }
@@ -152,7 +158,6 @@ impl CCfgBuilderState {
         for child in &children {
             if child.kind() == "else_clause" {
                 found_else = true;
-                // else_clause wraps the alternative — get its first named child
                 let mut ec_cursor = child.walk();
                 let alt_children: Vec<_> = child.children(&mut ec_cursor).collect();
                 if let Some(alt) = alt_children.iter().find(|c| c.is_named()) {
@@ -162,18 +167,21 @@ impl CCfgBuilderState {
                     self.visit_body(alt, source);
                     if let Some(end) = self.current_node {
                         if end != self.cfg.exit {
-                            self.cfg.add_edge(end, join_node);
+                            let j = get_join(&mut self.cfg);
+                            self.cfg.add_edge(end, j);
                         }
                     }
                 }
             }
         }
 
+        // No else: condition always has a fallthrough path to join.
         if !found_else {
-            self.cfg.add_edge(condition_node, join_node);
+            let j = get_join(&mut self.cfg);
+            self.cfg.add_edge(condition_node, j);
         }
 
-        self.current_node = Some(join_node);
+        self.current_node = join_node;
     }
 
     fn visit_while(&mut self, node: &Node, source: &str) {
@@ -456,6 +464,46 @@ mod tests {
     fn test_simple_function() {
         let source = "int test_func(int x) { return x + 1; }";
         assert_eq!(cc(source), 1);
+    }
+
+    #[test]
+    fn test_if_else_both_return_no_orphan() {
+        // Both branches return — join_node must not be created (would be unreachable).
+        // Previously caused "Nodes not reachable from entry" CFG validation failure.
+        let source = r#"
+int test_func(int x) {
+    if (x > 0) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+"#;
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        assert!(cfg.node_count() >= 2, "CFG must be valid");
+        assert_eq!(cc(source), 2);
+    }
+
+    #[test]
+    fn test_chained_else_if_all_return_no_orphan() {
+        // if / else-if / else all return — no join node, valid CFG.
+        let source = r#"
+int test_func(int x) {
+    if (x > 0) {
+        return 1;
+    } else if (x < 0) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+"#;
+        let function = make_c_function(source);
+        let cfg = CCfgBuilder.build(&function);
+        assert!(cfg.node_count() >= 2, "CFG must be valid");
+        // 2 conditions → CC 3
+        assert_eq!(cc(source), 3);
     }
 
     #[test]

--- a/tests/golden/c-control_flow.json
+++ b/tests/golden/c-control_flow.json
@@ -1,5 +1,47 @@
 [
   {
+    "band": "high",
+    "file": "tests/fixtures/c/control_flow.c",
+    "function": "nested_ifs",
+    "language": "C",
+    "line": 40,
+    "lrs": 7.207354922057604,
+    "metrics": {
+      "cc": 6,
+      "fo": 0,
+      "loc": 15,
+      "nd": 2,
+      "ns": 4
+    },
+    "risk": {
+      "r_cc": 2.807354922057604,
+      "r_fo": 0.0,
+      "r_nd": 2.0,
+      "r_ns": 4.0
+    }
+  },
+  {
+    "band": "high",
+    "file": "tests/fixtures/c/control_flow.c",
+    "function": "classify",
+    "language": "C",
+    "line": 1,
+    "lrs": 6.284962500721155,
+    "metrics": {
+      "cc": 5,
+      "fo": 0,
+      "loc": 9,
+      "nd": 2,
+      "ns": 3
+    },
+    "risk": {
+      "r_cc": 2.584962500721156,
+      "r_fo": 0.0,
+      "r_nd": 2.0,
+      "r_ns": 3.0
+    }
+  },
+  {
     "band": "moderate",
     "file": "tests/fixtures/c/control_flow.c",
     "function": "boolean_ops",
@@ -39,6 +81,27 @@
       "r_fo": 0.0,
       "r_nd": 1.0,
       "r_ns": 3.0
+    }
+  },
+  {
+    "band": "moderate",
+    "file": "tests/fixtures/c/control_flow.c",
+    "function": "braceless_if",
+    "language": "C",
+    "line": 11,
+    "lrs": 4.521928094887363,
+    "metrics": {
+      "cc": 4,
+      "fo": 0,
+      "loc": 6,
+      "nd": 1,
+      "ns": 2
+    },
+    "risk": {
+      "r_cc": 2.321928094887362,
+      "r_fo": 0.0,
+      "r_nd": 1.0,
+      "r_ns": 2.0
     }
   },
   {


### PR DESCRIPTION
## Summary

Fixes a CFG validity bug in the C builder where functions with `if`/`else` (or chained `else if`) blocks where **every branch returns** produced an orphaned `join_node` — a node with no predecessors, failing the "Nodes not reachable from entry" validator and causing those functions to be silently skipped.

**Root cause:** `join_node` was created eagerly at the top of `visit_if`, before knowing whether any branch would fall through to it.

**Fix:** `join_node` is now created lazily via a closure — only materialised when the first branch actually needs to connect to it. If both branches terminate (return/goto/break), no `join_node` is ever created and `current_node` is left as `None`.

## Impact

Functions like `_intsetValueEncoding`, `_intsetGetEncoded`, `aeWait`, `ACLSetSelector`, `ACLLoadFromFile`, and ~50 others in `redis/redis` were being skipped. They now analyse correctly.

## Tests

- 2 new regression tests: `test_if_else_both_return_no_orphan`, `test_chained_else_if_all_return_no_orphan`
- Updated `c-control_flow.json` golden — `classify` and `nested_ifs` now appear (previously skipped)
- All 385 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)