### PR TITLE
docs: document --skip-gate, color output, and installer update check

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,10 +26,14 @@ curl -fsSL https://raw.githubusercontent.com/Stephen-Collins-tech/hotspots/main/
 
 This installs the binary to `~/.local/bin/hotspots` and prints a PATH reminder if needed.
 
+**Update check:** If `hotspots` is already installed, the script checks whether you're already on the latest version. If an update is available, it shows the current and target versions and prompts `[y/N]` before installing. Re-running the script on an up-to-date install exits immediately with no changes.
+
 **Install a specific version:**
 ```bash
 HOTSPOTS_VERSION=v1.0.0 curl -fsSL https://raw.githubusercontent.com/Stephen-Collins-tech/hotspots/main/install.sh | sh
 ```
+
+Setting `HOTSPOTS_VERSION` skips the version check and installs the pinned release directly.
 
 ### Windows
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,6 +81,7 @@ hotspots analyze . --mode snapshot --format sarif > results.sarif
 **Notes:**
 - HTML format requires `--mode snapshot` or `--mode delta`.
 - SARIF format requires `--mode snapshot`. Unlike HTML, SARIF has no default output file — without `--output`, SARIF is written to stdout.
+- `text` output is color-coded when stdout is a TTY: `critical` rows are red bold, `high` are yellow bold, and `moderate`/`low` are green. Colors are automatically suppressed when piped, redirected, or when the `NO_COLOR` environment variable is set (per [no-color.org](https://no-color.org/)).
 
 ##### `--mode <mode>`
 **Optional.** Output mode: `snapshot`, `delta`, or `models`.
@@ -327,6 +328,15 @@ hotspots analyze . --mode snapshot --callgraph-skip-above 50000
 Fan-in and fan-out are still computed; only betweenness (and derived PageRank) is
 skipped. Recommended for repositories with 50k+ functions where the full call graph
 would otherwise take many minutes.
+
+##### `--skip-gate`
+**Optional.** Disable the suppression gate P@10 calibration check that runs after every
+`analyze --mode snapshot`. Use when you know the gate would fire spuriously (e.g. a
+codebase with no conventional fix-commit keywords, or a greenfield repo with no bug history).
+
+```bash
+hotspots analyze . --mode snapshot --skip-gate
+```
 
 ##### `--all-functions`
 **Optional.** Output all functions as a flat array instead of the default triage-first


### PR DESCRIPTION
## Summary

Documents three features merged in the PR batch (PRs #72–#84):

- **`--skip-gate`** flag for `hotspots analyze` — added to `docs/reference/cli.md` alongside `--callgraph-skip-above`
- **Color output** — added a note under `--format` explaining TTY auto-detection, `NO_COLOR` support, and the color scheme (critical=red, high=yellow, low/moderate=green)
- **Installer update check** — added to `docs/getting-started/installation.md` explaining the version comparison prompt and `HOTSPOTS_VERSION` pin behavior

## Test plan
- [ ] Read through each added section for accuracy and clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)