### PR TITLE
docs: add scoring methodology and changelog reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@ to confirm the finding is validated and see whether a cross-repo task is already
 
 When a CLI change completes a promotion, update the tracker row to `promoted` and link the commit or PR.
 
+If the promotion changes any formula, weight, threshold, or ranking rule, **add an entry to
+[`docs/reference/scoring-changelog.md`](docs/reference/scoring-changelog.md)** in the same PR.
+The entry must include the version, the before/after values, and a back-link to the finding.
+This is how `hotspots-research` knows what formula version the CLI is running.
+
 ### Reading a promotion brief
 
 Each finding that is ready to implement has a brief in

--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Outputs ready-to-use shell hooks and pre-commit framework config for enforcing p
 
 - 🚀 [Quick Start](docs/getting-started/quick-start.md) - Get started in 5 minutes
 - 📖 [CLI Reference](docs/reference/cli.md) - All commands and options
+- 📊 [Scoring Methodology](docs/reference/scoring.md) - How scores are calculated and ranked
 - 🎯 [CI Integration](docs/guide/ci-integration.md) - GitHub Actions, GitLab CI
 - 🤖 [AI Integration](docs/integrations/ai-agents.md) - Claude, Cursor, Copilot
 - 🏗️ [Architecture](docs/architecture/overview.md) - How it works

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -51,6 +51,8 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'CLI Reference', link: '/reference/cli' },
+          { text: 'Scoring Methodology', link: '/reference/scoring' },
+          { text: 'Scoring Changelog', link: '/reference/scoring-changelog' },
           { text: 'Metrics & LRS', link: '/reference/metrics' },
           { text: 'Language Support', link: '/reference/language-support' },
         ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,17 @@ All languages produce the same metrics with consistent semantics. See [Language 
 
 ---
 
+## How scoring works
+
+Each function receives a **Local Risk Score (LRS)** derived from four structural metrics (CC, ND, FO, NS), then optionally enriched with git-based activity signals to produce an **Activity Risk Score**. Functions are grouped into quadrants (fire / debt / watch / ok) and assigned a **driver label** naming the dominant risk dimension.
+
+See [Scoring Methodology](/reference/scoring) for the full pipeline — transforms, weights, pattern detection, quadrant logic, and ranking order.
+
+---
+
 ## Where this is going
 
-Risk hotspots — structurally complex, frequently changed code — are the first category. Several more are in active research:
+**Risk Hotspots** — structurally complex, frequently changed code — are shipped and stable. Several more categories are in active research:
 
 - **Review Hotspots** — changes that need senior eyes, not rubber stamps
 - **Test Hotspots** — coverage gaps where CI misses real failures

--- a/docs/reference/scoring-changelog.md
+++ b/docs/reference/scoring-changelog.md
@@ -1,0 +1,83 @@
+# Scoring Changelog
+
+A versioned record of every change to Hotspots' scoring methodology — transforms, weights, thresholds, patterns, and ranking logic.
+
+**Audience:** `hotspots-research` authors who need to know exactly which formula version the CLI implements when designing experiments or writing promotion briefs.
+
+**Rule:** every promotion that touches a formula, weight, threshold, or ranking order gets an entry here, written by the CLI side as part of the same PR that ships the change.
+
+---
+
+## Entry format
+
+```markdown
+### vX.Y.Z — YYYY-MM-DD
+
+**Changed:** short name of what moved (e.g. "LRS weights", "churn_magnet threshold")
+**Research finding:** F## — title (link to brief)
+**PR:** hotspots#NNN
+
+| | Before | After |
+|--|--|--|
+| field or formula | old value | new value |
+
+**Notes:** (optional) why, edge cases, what stays the same
+```
+
+One entry per released version that contains a scoring change. If a release has no scoring changes, omit it.
+
+---
+
+## Changelog
+
+### v1.24.0 — current
+
+No scoring changes since this changelog was introduced. The formulas below in [Scoring Methodology](/reference/scoring) represent the current baseline.
+
+**Baseline snapshot (as of v1.24.0):**
+
+| Component | Value |
+|-----------|-------|
+| LRS weights | cc=1.0, nd=0.8, fo=0.6, ns=0.7 |
+| R_cc cap | 6.0 (log2 scale) |
+| R_nd cap | 8.0 (linear) |
+| R_fo cap | 6.0 (log2 scale) |
+| R_ns cap | 6.0 (linear) |
+| Band: Low | LRS < 3.0 |
+| Band: Moderate | 3.0 ≤ LRS < 6.0 |
+| Band: High | 6.0 ≤ LRS < 9.0 |
+| Band: Critical | LRS ≥ 9.0 |
+| Activity: churn weight | 0.5 |
+| Activity: fan-in weight | 0.4 |
+| Activity: touch weight | 0.3 |
+| Activity: SCC weight | 0.3 |
+| Activity: recency weight | 0.2 |
+| Activity: neighbor-churn weight | 0.2 |
+| Activity: depth weight | 0.1 |
+| Driver label percentile | P75 |
+| Quadrant active threshold | touch > P50 OR days_since ≤ 30 |
+| Pattern: complex_branching | CC ≥ 10 AND ND ≥ 4 |
+| Pattern: deeply_nested | ND ≥ 5 |
+| Pattern: exit_heavy | NS ≥ 5 |
+| Pattern: god_function | LOC ≥ 60 AND FO ≥ 10 |
+| Pattern: long_function | LOC ≥ 80 |
+| Pattern: churn_magnet | churn ≥ 200 AND CC ≥ 8 |
+| Pattern: hub_function | fan-in ≥ 10 AND CC ≥ 8 |
+| Pattern: middle_man | fan-in ≥ 8 AND FO ≥ 8 AND CC ≤ 4 |
+| Pattern: shotgun_target | fan-in ≥ 8 AND churn ≥ 150 |
+| Pattern: stale_complex | CC ≥ 10 AND LOC ≥ 60 AND days ≥ 180 |
+| Pattern: neighbor_risk | neighbor_churn ≥ 400 AND FO ≥ 8 |
+| Pattern: cyclic_hub | SCC ≥ 2 AND fan-in ≥ 6 |
+
+---
+
+## How research uses this
+
+When writing a promotion brief for a scoring change:
+
+1. Look up the current baseline row for the value you are changing.
+2. State the **Before** value explicitly in the brief — if it does not match what is here, the brief is stale.
+3. State the **After** value as the exact replacement.
+4. The CLI author fills in a new changelog entry (using the format above) in the same PR that ships the change.
+
+This keeps the changelog and the code in sync at every release boundary, and gives research a single doc to diff when asking "what formula is the CLI running right now?"

--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -1,0 +1,244 @@
+# Scoring Methodology
+
+This document describes the complete pipeline from raw source code to the ranked output Hotspots produces. Each stage builds on the previous one.
+
+---
+
+## Pipeline overview
+
+```
+Source Code
+  ↓
+Raw Metrics  (CC, ND, FO, NS, LOC)
+  ↓
+Risk Components  (log-scaled, bounded)
+  ↓
+Local Risk Score  (LRS) + Risk Band
+  ↓
+Pattern Classification  (Tier 1: structural, Tier 2: enriched)
+  ↓
+[optional enrichment: call graph, git churn, touch counts]
+  ↓
+Activity Risk Score  (LRS + activity modifiers)
+  ↓
+Driver Label  (primary dimension diagnosis)
+  ↓
+Quadrant Assignment  (2-D: complexity × activity)
+  ↓
+Ranked Output
+```
+
+Stages above the enrichment line run on source code alone. Stages below require `--git-dir` or a connected git repository.
+
+---
+
+## 1. Raw metrics
+
+Hotspots measures four structural dimensions per function:
+
+| Metric | Meaning |
+|--------|---------|
+| **CC** | Cyclomatic complexity — independent paths through the control flow graph |
+| **ND** | Nesting depth — maximum depth of nested control structures |
+| **FO** | Fan-out — distinct functions called from this function |
+| **NS** | Non-structured exits — early returns, throws, breaks, continues (excluding tail return) |
+
+Plus **LOC** (physical line count), used only for pattern detection.
+
+See [Metrics Reference](/reference/metrics) for full definitions and per-language counting rules.
+
+---
+
+## 2. Local Risk Score (LRS)
+
+Each raw metric is first passed through a monotonic, bounded transform:
+
+```
+R_cc = min(log2(CC + 1), 6.0)    # logarithmic, cap 6
+R_nd = min(ND, 8.0)              # linear, cap 8
+R_fo = min(log2(FO + 1), 6.0)   # logarithmic, cap 6
+R_ns = min(NS, 6.0)              # linear, cap 6
+```
+
+Logarithmic scaling for CC and FO means the jump from 1 to 4 counts more than the jump from 20 to 24 — early growth signals risk more reliably than marginal increases at high values.
+
+The four components combine into LRS:
+
+```
+LRS = 1.0 × R_cc  +  0.8 × R_nd  +  0.6 × R_fo  +  0.7 × R_ns
+```
+
+**Risk bands:**
+
+| Band     | LRS range | Interpretation |
+|----------|-----------|----------------|
+| Critical | ≥ 9.0     | Refactor now — highest-probability bug sources |
+| High     | 6.0–8.9   | Refactor the next time you touch this function |
+| Moderate | 3.0–5.9   | Monitor; block increases in CI |
+| Low      | < 3.0     | Not worth the risk of touching without a reason |
+
+Theoretical maximum LRS is **22.0** (all four metrics pegged at their caps). In practice, even the most complex real-world functions rarely exceed 15.
+
+See [LRS Specification](/reference/lrs-spec) for the complete formula derivation, worked examples, and precision notes.
+
+---
+
+## 3. Pattern classification
+
+Patterns are named code-smell labels assigned before any git data is needed (Tier 1) or after enrichment (Tier 2). They appear as `patterns: [...]` in JSON output and `--format text`.
+
+### Tier 1 — structural (raw metrics only)
+
+| Pattern | Trigger |
+|---------|---------|
+| `complex_branching` | CC ≥ 10 **and** ND ≥ 4 |
+| `deeply_nested` | ND ≥ 5 |
+| `exit_heavy` | NS ≥ 5 |
+| `god_function` | LOC ≥ 60 **and** FO ≥ 10 |
+| `long_function` | LOC ≥ 80 |
+
+### Tier 2 — enriched (call graph + git)
+
+| Pattern | Trigger |
+|---------|---------|
+| `churn_magnet` | file churn ≥ 200 lines **and** CC ≥ 8 |
+| `cyclic_hub` | SCC size ≥ 2 **and** fan-in ≥ 6 |
+| `hub_function` | fan-in ≥ 10 **and** CC ≥ 8 |
+| `middle_man` | fan-in ≥ 8 **and** FO ≥ 8 **and** CC ≤ 4 |
+| `neighbor_risk` | neighbor churn ≥ 400 **and** FO ≥ 8 |
+| `shotgun_target` | fan-in ≥ 8 **and** file churn ≥ 150 |
+| `stale_complex` | CC ≥ 10 **and** LOC ≥ 60 **and** days since change ≥ 180 |
+
+**Derived pattern:** `volatile_god` fires only when **both** `god_function` and `churn_magnet` are true.
+
+All thresholds are configurable in `.hotspotsrc.json`. See [Configuration](/guide/configuration).
+
+---
+
+## 4. Activity Risk Score
+
+When git history is available, Hotspots computes an activity-weighted risk score that combines LRS with change signals:
+
+```
+Activity Risk = LRS
+             + (lines_added + lines_deleted) / 100 × 0.5   # churn
+             + min(touch_count / 10, 5.0) × 0.3            # touches in 30 days
+             + max(0, 5.0 − days_since_change / 7) × 0.2   # recency
+             + min(fan_in / 5, 10.0) × 0.4                 # call-graph fan-in
+             + (scc_size if > 1 else 0) × 0.3              # cycle membership
+             + min(dependency_depth / 3, 5.0) × 0.1        # call-chain depth
+             + neighbor_churn / 500 × 0.2                  # churn in callers/callees
+```
+
+**Weights at a glance:**
+
+| Signal | Weight | Rationale |
+|--------|--------|-----------|
+| Churn | 0.5 | High change volume is a leading defect predictor |
+| Fan-in | 0.4 | Wide blast radius amplifies impact of any change |
+| Touch count | 0.3 | Frequent touches correlate with instability |
+| SCC membership | 0.3 | Cycles make reasoning about ordering impossible |
+| Recency | 0.2 | Recent changes haven't had time to stabilize |
+| Neighbor churn | 0.2 | Dependencies in flux transfer risk |
+| Dependency depth | 0.1 | Deep chains amplify cascading failures |
+
+Activity Risk is always ≥ LRS (all modifiers are non-negative). When no git data is available, Activity Risk equals LRS.
+
+---
+
+## 5. Driver labels
+
+Each function receives a primary **driver** label that names which dimension dominates its risk. This appears as `driver` in JSON output and is shown in the triage view.
+
+Labels are assigned by comparing each dimension against population percentiles (default: 75th percentile threshold):
+
+| Label | Condition |
+|-------|-----------|
+| `cyclic_dep` | SCC size > 1 (absolute, no percentile) |
+| `high_complexity` | CC above P75 |
+| `deep_nesting` | ND above P75 |
+| `high_fanout_churning` | FO above P75 **and** touch count above P50 |
+| `high_fanin_complex` | fan-in above P75 **and** CC above P50 |
+| `high_churn_low_cc` | touches above P75 **and** CC below P25 |
+| `composite` | no single dimension clearly dominates |
+
+Percentiles are computed independently per dimension across all functions in the current analysis scope, so thresholds adapt to each codebase.
+
+---
+
+## 6. Quadrant assignment
+
+Every function is placed in one of four quadrants using a 2-D matrix of complexity vs. activity:
+
+|  | Low activity | High activity |
+|--|---|---|
+| **High risk (High or Critical band)** | `debt` | `fire` |
+| **Low risk (Low or Moderate band)** | `ok` | `watch` |
+
+**Activity** is considered high when any of the following is true:
+- `touch_count` is above the population median for the analysis scope, **or**
+- `days_since_change` ≤ 30, **or**
+- Activity Risk is in the top 30% of the population (when a ranker has been applied)
+
+**Interpreting the quadrants:**
+
+| Quadrant | Signal | Recommended action |
+|----------|--------|--------------------|
+| `fire` | Complex **and** actively changing | Highest priority — live regression risk |
+| `debt` | Complex but dormant | Schedule refactor; don't defer indefinitely |
+| `watch` | Active but not yet complex | Monitor; block LRS increases in CI |
+| `ok` | Simple and quiet | Leave it alone |
+
+A high Activity Risk score alone does **not** mean a function is in `fire`. Always check `quadrant` and `touches_30d` — a complex function that hasn't been touched in a year is `debt`, not `fire`.
+
+---
+
+## 7. File risk score
+
+Hotspots also aggregates function-level data into a per-file score for the file-risk view:
+
+```
+File Risk Score = max_cc × 0.4
+               + avg_cc × 0.3
+               + log2(function_count + 1) × 0.2
+               + min(file_churn / 100, 10.0) × 0.1
+```
+
+Files are ranked descending by this score. Ties break alphabetically by path.
+
+---
+
+## 8. Ranking
+
+**Default ranking (no ranker applied):**
+
+1. LRS descending (highest structural risk first)
+2. File path ascending (alphabetical tiebreak)
+3. Line number ascending
+4. Function name ascending
+
+**With `--mode snapshot` triage view:**
+
+Functions are grouped by quadrant (`fire` → `debt` → `watch` → `ok`), then sorted by Activity Risk descending within each group.
+
+**With a trained ranker (`hotspots rank`):**
+
+The ML ranker re-scores functions using a RandomForest model trained on your repo's bug-fix history. Output is sorted by the ranker's predicted bug probability descending. LRS and quadrant remain in the output for context. See [Training a Ranker](/guide/usage#training-a-ranker) for details.
+
+---
+
+## Version history
+
+Every change to a formula, weight, threshold, or ranking rule is recorded in the [Scoring Changelog](/reference/scoring-changelog). If you are writing a promotion brief in `hotspots-research`, read that page first — it shows the exact current values and the format for expressing a before/after diff.
+
+---
+
+## Coming soon: ranker scoring
+
+The trained ranker layer is currently in active development. Once complete, the ranker will:
+
+- Assign a `rank_score` (predicted probability this function appears in a future bug-fix commit)
+- Surface functions that are statistically over-represented in past defects, even when LRS is moderate
+- Blend structural risk with historical signal rather than treating them as separate steps
+
+The heuristic pipeline above will remain the default for repos without training data.


### PR DESCRIPTION
## Summary

- Adds `docs/reference/scoring.md` — complete pipeline documentation covering LRS, Activity Risk, patterns, driver labels, quadrant assignment, file risk, and ranking
- Adds `docs/reference/scoring-changelog.md` — versioned record of scoring formula changes with a baseline snapshot at v1.24.0; serves as the semantic diff surface for `hotspots-research` when writing promotion briefs
- Wires both pages into the VitePress sidebar nav
- Updates `docs/index.md` with a "How scoring works" summary section and marks Risk Hotspots as shipped
- Updates `README.md` docs link list
- Updates `CLAUDE.md` with a rule: scoring promotions must include a changelog entry in the same PR

## Test plan

- [ ] `docs-ci.yml` build passes (VitePress build on push to main)
- [ ] Both new pages appear in sidebar under Reference
- [ ] Links between scoring.md ↔ scoring-changelog.md ↔ lrs-spec.md resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)