### PR TITLE
docs: add scoring methodology and changelog pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Outputs ready-to-use shell hooks and pre-commit framework config for enforcing p
 
 - 🚀 [Quick Start](docs/getting-started/quick-start.md) - Get started in 5 minutes
 - 📖 [CLI Reference](docs/reference/cli.md) - All commands and options
+- 📊 [Scoring Methodology](docs/reference/scoring.md) - How scores are calculated and ranked
 - 🎯 [CI Integration](docs/guide/ci-integration.md) - GitHub Actions, GitLab CI
 - 🤖 [AI Integration](docs/integrations/ai-agents.md) - Claude, Cursor, Copilot
 - 🏗️ [Architecture](docs/architecture/overview.md) - How it works

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -51,6 +51,8 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'CLI Reference', link: '/reference/cli' },
+          { text: 'Scoring Methodology', link: '/reference/scoring' },
+          { text: 'Scoring Changelog', link: '/reference/scoring-changelog' },
           { text: 'Metrics & LRS', link: '/reference/metrics' },
           { text: 'Language Support', link: '/reference/language-support' },
         ]

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -41,6 +41,7 @@ export default defineConfig({
         text: 'Guide',
         items: [
           { text: 'Usage & Workflows', link: '/guide/usage' },
+          { text: 'Training a Ranker', link: '/guide/training' },
           { text: 'Configuration', link: '/guide/configuration' },
           { text: 'CI/CD & GitHub Action', link: '/guide/ci-cd' },
           { text: 'Output Formats', link: '/guide/output-formats' },

--- a/docs/guide/training.md
+++ b/docs/guide/training.md
@@ -1,0 +1,155 @@
+# Training a Ranker
+
+By default, Hotspots ranks functions by **LRS** — a structural complexity score derived from the code itself. This works out of the box on any repo.
+
+`hotspots train` fits a local RandomForest model against your repo's own git history, learning which structural features correlate with bug-fix commits in *your* codebase. Once trained, `hotspots analyze` picks up the model automatically and uses it to re-rank functions and update triage quadrants.
+
+---
+
+## When it's worth training
+
+Training is most valuable when:
+
+- Your repo has **at least a year of meaningful commit history**
+- Fix commits follow recognizable conventions (`fix:`, `bug`, `patch`, `hotfix`, `regression`, `defect`)
+- Bugs have been concentrated in specific files or functions rather than spread uniformly
+
+Training is unlikely to help on:
+
+- Library or framework repos with low bug rates and tiny base rates
+- Repos with less than ~1 year of history
+- Repos with poor commit hygiene (unflagged fix commits can't be scanned)
+- Stable mature codebases where bugs are subtle and spread across the whole codebase
+
+Use `--eval` (described below) to verify the model actually learned something before relying on it.
+
+---
+
+## Basic usage
+
+```bash
+# Train with file-level labels (fast)
+hotspots train .
+
+# Train with blame-based function-level labels (slower, more precise)
+hotspots train . --blame
+```
+
+The model is saved to `.hotspots/ranker.json`. Once it exists, `hotspots analyze` loads it automatically on every run.
+
+---
+
+## Label modes
+
+### File-level (default)
+
+Every function in a file touched by a fix commit is marked as a positive training example. Fast, but noisy — a bug in one function marks every function in that file.
+
+### Blame-based (`--blame`)
+
+`git diff-tree` hunk headers are parsed to identify which exact function owned the changed lines. Only that function is marked positive.
+
+More precise signal, but requires one subprocess per fix commit. Recommended for repos with large files where a single file can contain many unrelated functions.
+
+```bash
+# Recommended for most production repos
+hotspots train . --blame
+```
+
+---
+
+## Checking whether training helped (`--eval`)
+
+`hotspots train` always produces a model, but that doesn't mean the model is better than the default LRS ranking. `--eval` measures this by computing **Precision@K** — how many of the top K ranked functions actually appeared in a bug-fix commit:
+
+```bash
+hotspots train . --blame --eval
+```
+
+Example output:
+
+```
+P@K evaluation (365-day fix-label window):
+  K      P@K      base_rate
+  10     0.400    0.084
+  20     0.300    0.084
+  50     0.200    0.084
+  100    0.150    0.084
+  200    0.110    0.084
+```
+
+**How to read it:**
+
+- `base_rate` is the fraction of all functions that appeared in any fix commit. It's the score a random ranker would achieve.
+- If `P@K` is meaningfully above `base_rate` (especially at low K), the model is surfacing real bug-prone functions at the top of the list.
+- If `P@K ≈ base_rate`, the model learned nothing useful. In that case, stick with the default LRS ranking — applying a weak model can demote functions that are genuinely risky.
+
+---
+
+## Label window
+
+By default, the scanner looks back 365 days for fix commits. Adjust with `--label-window`:
+
+```bash
+# Use 6 months of history
+hotspots train . --blame --label-window 180
+
+# Use 2 years for repos with sparse bug fixes
+hotspots train . --blame --label-window 730
+```
+
+Larger windows provide more training examples but may include stale patterns that no longer reflect the codebase.
+
+---
+
+## What the model trains on
+
+The v3 model trains on 8 structural features: `lrs`, `cc`, `nd`, `loc`, `fo`, `fan_in`, `total_churn`, `authors_90d`.
+
+Windowed activity signals (`touch_count_30d`, `days_since_last_change`, `activity_risk`) are deliberately excluded to prevent temporal leakage — these signals would be computed from the same time window being used for labels, inflating apparent performance.
+
+---
+
+## How it integrates with `hotspots analyze`
+
+Once `.hotspots/ranker.json` exists, every `hotspots analyze` run automatically:
+
+1. Loads the ranker and scores every function
+2. Uses RF scores to determine triage quadrants (in place of the activity heuristic)
+3. Promotes high-probability functions from `debt` → `fire` where the model score warrants it
+
+A suppression gate runs on every analysis to detect poor model performance. If `P@10` is at or below the base rate, the output will note that the model is not performing above baseline and suggest re-training or relying on the default LRS ranking.
+
+---
+
+## Minimum requirements
+
+Training will return an error if:
+
+- The snapshot has fewer than **50 functions**, or
+- The fix scan yields fewer than **5 positive** or **10 negative** labels
+
+If this happens:
+
+- Try a larger `--label-window`
+- Run `hotspots analyze . --mode snapshot --force` to regenerate a fresh snapshot
+- Verify fix commits use recognizable keywords (`fix:`, `bug`, `patch`, `hotfix`, `regression`, `defect`)
+
+---
+
+## Re-training
+
+The model reflects the git history at the time it was trained. Re-train periodically as new fix commits accumulate:
+
+```bash
+# Re-train and immediately re-analyze
+hotspots train . --blame && hotspots analyze .
+```
+
+There is no automatic re-training — the model file is updated only when you explicitly run `hotspots train`.
+
+---
+
+## Full options reference
+
+See [`hotspots train`](/reference/cli#hotspots-train) in the CLI reference for all flags and defaults.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,17 @@ All languages produce the same metrics with consistent semantics. See [Language 
 
 ---
 
+## How scoring works
+
+Each function receives a **Local Risk Score (LRS)** derived from four structural metrics (CC, ND, FO, NS), then optionally enriched with git-based activity signals to produce an **Activity Risk Score**. Functions are grouped into quadrants (fire / debt / watch / ok) and assigned a **driver label** naming the dominant risk dimension.
+
+See [Scoring Methodology](/reference/scoring) for the full pipeline — transforms, weights, pattern detection, quadrant logic, and ranking order.
+
+---
+
 ## Where this is going
 
-Risk hotspots — structurally complex, frequently changed code — are the first category. Several more are in active research:
+**Risk Hotspots** — structurally complex, frequently changed code — are shipped and stable. Several more categories are in active research:
 
 - **Review Hotspots** — changes that need senior eyes, not rubber stamps
 - **Test Hotspots** — coverage gaps where CI misses real failures

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ See [Scoring Methodology](/reference/scoring) for the full pipeline — transfor
 
 ## Where this is going
 
-**Risk Hotspots** — structurally complex, frequently changed code — are shipped and stable. Several more categories are in active research:
+**Risk Hotspots** — structurally complex, frequently changed code — are shipped. Several more categories are in active research:
 
 - **Review Hotspots** — changes that need senior eyes, not rubber stamps
 - **Test Hotspots** — coverage gaps where CI misses real failures

--- a/docs/reference/lrs-spec.md
+++ b/docs/reference/lrs-spec.md
@@ -246,7 +246,7 @@ LRS has a theoretical maximum:
 - Maximum R_nd = 8
 - Maximum R_fo = 6
 - Maximum R_ns = 6
-- **Maximum LRS** = 1.0 * 6 + 0.8 * 8 + 0.6 * 6 + 0.7 * 6 = **22.0**
+- **Maximum LRS** = 1.0 * 6 + 0.8 * 8 + 0.6 * 6 + 0.7 * 6 = **20.2**
 
 In practice, functions rarely approach this maximum.
 

--- a/docs/reference/scoring-changelog.md
+++ b/docs/reference/scoring-changelog.md
@@ -1,0 +1,67 @@
+# Scoring Changelog
+
+A versioned record of every change to the scoring methodology — transforms, weights, thresholds, patterns, and ranking logic.
+
+Every promotion that touches a formula, weight, threshold, or ranking order gets an entry here, written as part of the same PR that ships the change.
+
+---
+
+## Entry format
+
+```markdown
+### vX.Y.Z — YYYY-MM-DD
+
+**Changed:** short name of what moved (e.g. "LRS weights", "churn_magnet threshold")
+**PR:** hotspots#NNN
+
+| | Before | After |
+|--|--|--|
+| field or formula | old value | new value |
+
+**Notes:** (optional) why, edge cases, what stays the same
+```
+
+One entry per released version that contains a scoring change. If a release has no scoring changes, omit it.
+
+---
+
+## Changelog
+
+### v1.24.0 — current baseline
+
+No scoring changes since this changelog was introduced. The formulas in [Scoring Methodology](/reference/scoring) represent the current baseline.
+
+**Baseline snapshot:**
+
+| Component | Value |
+|-----------|-------|
+| LRS weights | cc=1.0, nd=0.8, fo=0.6, ns=0.7 |
+| R_cc cap | 6.0 (log2 scale) |
+| R_nd cap | 8.0 (linear) |
+| R_fo cap | 6.0 (log2 scale) |
+| R_ns cap | 6.0 (linear) |
+| Band: Low | LRS < 3.0 |
+| Band: Moderate | 3.0 ≤ LRS < 6.0 |
+| Band: High | 6.0 ≤ LRS < 9.0 |
+| Band: Critical | LRS ≥ 9.0 |
+| Activity: churn weight | 0.5 |
+| Activity: fan-in weight | 0.4 |
+| Activity: touch weight | 0.3 |
+| Activity: SCC weight | 0.3 |
+| Activity: recency weight | 0.2 |
+| Activity: neighbor-churn weight | 0.2 |
+| Activity: depth weight | 0.1 |
+| Driver label percentile | P75 |
+| Quadrant active threshold | touch > P50 OR days_since ≤ 30 |
+| Pattern: complex_branching | CC ≥ 10 AND ND ≥ 4 |
+| Pattern: deeply_nested | ND ≥ 5 |
+| Pattern: exit_heavy | NS ≥ 5 |
+| Pattern: god_function | LOC ≥ 60 AND FO ≥ 10 |
+| Pattern: long_function | LOC ≥ 80 |
+| Pattern: churn_magnet | churn ≥ 200 AND CC ≥ 8 |
+| Pattern: hub_function | fan-in ≥ 10 AND CC ≥ 8 |
+| Pattern: middle_man | fan-in ≥ 8 AND FO ≥ 8 AND CC ≤ 4 |
+| Pattern: shotgun_target | fan-in ≥ 8 AND churn ≥ 150 |
+| Pattern: stale_complex | CC ≥ 10 AND LOC ≥ 60 AND days ≥ 180 |
+| Pattern: neighbor_risk | neighbor_churn ≥ 400 AND FO ≥ 8 |
+| Pattern: cyclic_hub | SCC ≥ 2 AND fan-in ≥ 6 |

--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -1,5 +1,7 @@
 # Scoring Methodology
 
+🚧 **The scoring methodology is actively evolving.** Weights, thresholds, and formula details will change as research findings are validated and promoted. Check the [Scoring Changelog](/reference/scoring-changelog) for a versioned record of what has changed. 🚧
+
 This document describes every step of the pipeline from raw source code to the ranked output Hotspots produces. Each stage builds on the previous one.
 
 ---

--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -88,7 +88,7 @@ LRS = 1.0 × R_cc  +  0.8 × R_nd  +  0.6 × R_fo  +  0.7 × R_ns
 - **NS (0.7)** — non-structured exits increase the number of implicit exit conditions and make postconditions harder to reason about.
 - **FO (0.6)** — fan-out represents external coupling rather than internal complexity; weighted lower because some degree of fan-out is expected in most functions.
 
-LRS is always ≥ 1.0. The theoretical maximum is **22.0** (all four components at their caps). The theoretical minimum for a trivial single-path function with no nesting, calls, or exits is 1.0.
+LRS is always ≥ 1.0. The theoretical maximum is **20.2** (all four components at their caps: 1.0×6 + 0.8×8 + 0.6×6 + 0.7×6). The theoretical minimum for a trivial single-path function with no nesting, calls, or exits is 1.0.
 
 **Risk bands:**
 
@@ -149,7 +149,7 @@ Activity Risk = LRS
              + min(touch_count_30d / 10, 5.0) × 0.3
              + max(0, 5.0 − days_since_change / 7) × 0.2
              + min(fan_in / 5, 10.0) × 0.4
-             + (scc_size − 1, if in cycle, else 0) × 0.3
+             + (scc_size, if in cycle, else 0) × 0.3
              + min(dependency_depth / 3, 5.0) × 0.1
              + neighbor_churn / 500 × 0.2
 ```

--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -1,6 +1,6 @@
 # Scoring Methodology
 
-This document explains every step of the pipeline from raw source code to the ranked output Hotspots produces. Each stage builds on the previous one.
+This document describes every step of the pipeline from raw source code to the ranked output Hotspots produces. Each stage builds on the previous one.
 
 ---
 
@@ -37,16 +37,16 @@ Stages above the enrichment line run on source code alone and are always compute
 Hotspots parses each source file and visits every function, extracting four structural measurements:
 
 **CC — Cyclomatic Complexity**
-The number of independent decision paths through the function. Every `if`, `else if`, loop, `case`, `catch`, `&&`, `||`, and ternary adds one path. A function with no branches has CC 1. CC is the strongest single predictor of testing difficulty: CC 10 means at least 10 distinct paths to exercise.
+The number of independent decision paths through the function. Every `if`, `else if`, loop, `case`, `catch`, `&&`, `||`, and ternary adds one path. A function with no branches has CC 1.
 
 **ND — Nesting Depth**
-The maximum depth of nested control structures — how many layers of `if`/loop/`try` a reader must mentally track at once. Each level of nesting multiplies the number of implicit states the function can be in. ND 4 or higher almost always means the function is doing too many things at once.
+The maximum depth of nested control structures — how many layers of `if`/loop/`try` are present at the deepest point.
 
 **FO — Fan-Out**
-The number of distinct functions this function calls. High fan-out means the function coordinates many dependencies. Each additional callee is another place for the function's behavior to change unexpectedly — and another thing to mock in tests.
+The number of distinct functions called from within this function.
 
 **NS — Non-Structured Exits**
-The count of early returns, throws, breaks, and continues inside the function body, excluding the final tail return. Non-structured exits create multiple exit points that are hard to trace and make it difficult to reason about what state the function leaves behind.
+The count of early returns, throws, breaks, and continues inside the function body, excluding the final tail return.
 
 **LOC — Lines of Code**
 Physical line count. Used only for pattern detection (see Step 4), not for the risk score itself.
@@ -57,7 +57,7 @@ See [Metrics Reference](/reference/metrics) for exact counting rules per languag
 
 ## Step 2 — Transform to risk components
 
-Raw metric values are not summed directly. Each one is first passed through a bounded, monotonic transform that shapes how it contributes to the final score:
+Raw metric values are passed through bounded, monotonic transforms before being combined:
 
 ```
 R_cc = min(log2(CC + 1), 6.0)    # logarithmic, capped at 6
@@ -66,14 +66,11 @@ R_fo = min(log2(FO + 1), 6.0)   # logarithmic, capped at 6
 R_ns = min(NS, 6.0)              # linear, capped at 6
 ```
 
-**Why logarithmic for CC and FO?**
-The difference between CC 1 and CC 4 is enormous — one path versus four. The difference between CC 40 and CC 44 is negligible — already completely untestable either way. Logarithmic scaling captures this: early growth counts a lot, marginal increases at high values contribute little. Fan-out follows the same logic.
+**Logarithmic scaling for CC and FO** gives more weight to early growth than to increases at already-high values — the marginal risk of going from CC 1 to CC 4 is larger than going from CC 40 to CC 44. Fan-out follows the same reasoning.
 
-**Why linear for ND and NS?**
-Nesting depth and exit count grow more uniformly in practice. Each additional nesting level genuinely adds proportional cognitive load, and there is no diminishing-returns region to flatten.
+**Linear scaling for ND and NS** reflects that each additional nesting level or exit point contributes more uniformly to complexity in practice.
 
-**Why caps?**
-Caps prevent a single catastrophically bad metric from drowning out the others. A function with CC 200 and ND 1 should not score higher than a function with CC 30 and ND 8 — both are severe, and the score should reflect overall structural complexity, not just one runaway dimension.
+**Caps** prevent a single extreme metric from dominating the score. Each dimension is bounded independently so the combined score reflects overall structural complexity.
 
 ---
 
@@ -85,22 +82,22 @@ The four risk components are combined into a single score using a weighted sum:
 LRS = 1.0 × R_cc  +  0.8 × R_nd  +  0.6 × R_fo  +  0.7 × R_ns
 ```
 
-**Why these weights?**
-- **CC gets the highest weight (1.0)** because control-flow complexity is the primary driver of defect density across empirical studies. It directly determines how many paths must be tested and how many branch combinations can interact.
-- **ND gets the second-highest weight (0.8)** because deep nesting compounds complexity in a way CC alone doesn't capture — a function can have moderate CC but be nearly unreadable due to nesting.
-- **NS gets a medium-high weight (0.7)** because non-structured exits create implicit control flow that is hard to reason about and makes postconditions difficult to state or enforce.
-- **FO gets the lowest weight (0.6)** because some fan-out is expected and healthy — functions that orchestrate other functions aren't inherently risky unless combined with other signals.
+**Weight rationale:**
+- **CC (1.0)** — highest weight; control-flow complexity is the primary correlate of defect density and testing difficulty.
+- **ND (0.8)** — nesting depth captures a dimension of complexity that CC alone can miss; a function can have moderate CC but still be hard to follow due to deep nesting.
+- **NS (0.7)** — non-structured exits increase the number of implicit exit conditions and make postconditions harder to reason about.
+- **FO (0.6)** — fan-out represents external coupling rather than internal complexity; weighted lower because some degree of fan-out is expected in most functions.
 
-LRS is always ≥ 1.0 (minimum for a trivial single-path function with no nesting, calls, or exits). The theoretical maximum is **22.0** (all four components pegged at their caps). Real-world functions rarely exceed 15.
+LRS is always ≥ 1.0. The theoretical maximum is **22.0** (all four components at their caps). The theoretical minimum for a trivial single-path function with no nesting, calls, or exits is 1.0.
 
 **Risk bands:**
 
 | Band | LRS range | Meaning |
 |------|-----------|---------|
-| Critical | ≥ 9.0 | Refactor now — highest-probability bug sources |
-| High | 6.0–8.9 | Refactor the next time you touch this function |
-| Moderate | 3.0–5.9 | Monitor; block increases in CI |
-| Low | < 3.0 | Not worth the risk of touching without a reason |
+| Critical | ≥ 9.0 | High structural risk |
+| High | 6.0–8.9 | Elevated structural risk |
+| Moderate | 3.0–5.9 | Moderate structural risk |
+| Low | < 3.0 | Low structural risk |
 
 See [LRS Specification](/reference/lrs-spec) for the complete formula derivation, worked examples, and precision notes.
 
@@ -108,35 +105,35 @@ See [LRS Specification](/reference/lrs-spec) for the complete formula derivation
 
 ## Step 4 — Classify patterns
 
-Patterns are named labels that identify specific code smells. They complement LRS by naming *what kind* of problem a function has, not just *how bad* it is. A function can match multiple patterns simultaneously.
+Patterns are named labels that identify specific structural combinations. They complement LRS by describing *what kind* of issue a function has, not just its overall score. A function can match multiple patterns simultaneously.
 
 ### Tier 1 — structural (source code only)
 
-These patterns are detected from raw metrics alone and are always computed:
+Detected from raw metrics alone; always computed:
 
-| Pattern | Trigger | What it means |
-|---------|---------|---------------|
-| `complex_branching` | CC ≥ 10 **and** ND ≥ 4 | High branching *and* deep nesting — two independent complexity signals reinforcing each other |
-| `deeply_nested` | ND ≥ 5 | Nesting so deep that the function almost certainly needs to be decomposed |
-| `exit_heavy` | NS ≥ 5 | So many exit points that control flow is genuinely hard to trace |
-| `god_function` | LOC ≥ 60 **and** FO ≥ 10 | Long *and* calls many things — a function that knows too much and does too much |
-| `long_function` | LOC ≥ 80 | Physically long regardless of complexity — a readability and reviewability problem |
+| Pattern | Trigger | Description |
+|---------|---------|-------------|
+| `complex_branching` | CC ≥ 10 **and** ND ≥ 4 | High branching combined with deep nesting |
+| `deeply_nested` | ND ≥ 5 | Maximum nesting depth at or above threshold |
+| `exit_heavy` | NS ≥ 5 | High number of non-structured exits |
+| `god_function` | LOC ≥ 60 **and** FO ≥ 10 | Long function with high fan-out |
+| `long_function` | LOC ≥ 80 | High physical line count |
 
 ### Tier 2 — enriched (call graph + git data)
 
-These patterns require git history and the call graph and are only computed when that data is available:
+Require git history and the call graph; computed only when that data is available:
 
-| Pattern | Trigger | What it means |
-|---------|---------|---------------|
-| `churn_magnet` | file churn ≥ 200 lines **and** CC ≥ 8 | Complex *and* frequently changed — the highest-risk combination |
-| `cyclic_hub` | SCC size ≥ 2 **and** fan-in ≥ 6 | Part of a dependency cycle *and* widely called — hard to reason about ordering |
-| `hub_function` | fan-in ≥ 10 **and** CC ≥ 8 | Many callers depend on a complex function — wide blast radius |
-| `middle_man` | fan-in ≥ 8 **and** FO ≥ 8 **and** CC ≤ 4 | Called by many, calls many, but does very little itself — often a sign of unnecessary indirection |
-| `neighbor_risk` | neighbor churn ≥ 400 **and** FO ≥ 8 | The things this function calls are changing a lot — risk inherited from dependencies |
-| `shotgun_target` | fan-in ≥ 8 **and** file churn ≥ 150 | Many callers *and* the file changes frequently — changes here ripple widely |
-| `stale_complex` | CC ≥ 10 **and** LOC ≥ 60 **and** days since change ≥ 180 | Complex and old — institutional knowledge risk; the people who understood it may be gone |
+| Pattern | Trigger | Description |
+|---------|---------|-------------|
+| `churn_magnet` | file churn ≥ 200 lines **and** CC ≥ 8 | High complexity combined with high change volume |
+| `cyclic_hub` | SCC size ≥ 2 **and** fan-in ≥ 6 | Part of a dependency cycle with many callers |
+| `hub_function` | fan-in ≥ 10 **and** CC ≥ 8 | High fan-in with high complexity |
+| `middle_man` | fan-in ≥ 8 **and** FO ≥ 8 **and** CC ≤ 4 | High fan-in and fan-out with low internal complexity |
+| `neighbor_risk` | neighbor churn ≥ 400 **and** FO ≥ 8 | High fan-out into frequently changing functions |
+| `shotgun_target` | fan-in ≥ 8 **and** file churn ≥ 150 | Many callers in a frequently changed file |
+| `stale_complex` | CC ≥ 10 **and** LOC ≥ 60 **and** days since change ≥ 180 | High complexity with no recent changes |
 
-**Derived pattern:** `volatile_god` fires only when **both** `god_function` and `churn_magnet` are true — a large, widely-coupled function that is also actively changing.
+**Derived pattern:** `volatile_god` fires only when **both** `god_function` and `churn_magnet` are true.
 
 All thresholds are configurable in `.hotspotsrc.json`. See [Configuration](/guide/configuration).
 
@@ -144,7 +141,7 @@ All thresholds are configurable in `.hotspotsrc.json`. See [Configuration](/guid
 
 ## Step 5 — Compute the Activity Risk Score
 
-When git history is available, Hotspots extends LRS with activity signals to produce a score that reflects not just how complex a function is, but how much risk that complexity is generating *right now*:
+When git history is available, Hotspots extends LRS with activity signals:
 
 ```
 Activity Risk = LRS
@@ -157,66 +154,61 @@ Activity Risk = LRS
              + neighbor_churn / 500 × 0.2
 ```
 
-Each modifier adds to LRS — Activity Risk is always ≥ LRS. When no git data is available, Activity Risk equals LRS.
+Each modifier is non-negative, so Activity Risk is always ≥ LRS. When no git data is available, Activity Risk equals LRS.
 
-**What each signal captures:**
-
-| Signal | Weight | Why it matters |
-|--------|--------|----------------|
-| Churn (lines added + deleted) | 0.5 | Volume of recent change is the strongest activity signal — high churn means the function is a live target |
-| Fan-in (call-graph callers) | 0.4 | Many callers means changes here have a wide blast radius |
-| Touch count (30-day commits) | 0.3 | Frequent commits suggest instability or active development — either way, the function is in motion |
-| SCC membership | 0.3 | Being part of a dependency cycle makes any change harder to reason about safely |
-| Recency (days since last change) | 0.2 | A function changed this week is more likely to be changed again than one stable for a year |
-| Neighbor churn | 0.2 | When the functions this one calls are changing a lot, risk transfers inward |
-| Dependency depth | 0.1 | Deep call chains amplify cascading failures — lower weight because structural depth is already captured partially by LRS |
+| Signal | Weight | What it captures |
+|--------|--------|-----------------|
+| Churn (lines added + deleted) | 0.5 | Volume of recent change |
+| Fan-in (call-graph callers) | 0.4 | Number of functions that depend on this one |
+| Touch count (30-day commits) | 0.3 | Frequency of recent modification |
+| SCC membership | 0.3 | Presence in a dependency cycle |
+| Recency (days since last change) | 0.2 | How recently the function was last modified |
+| Neighbor churn | 0.2 | Change volume in called functions |
+| Dependency depth | 0.1 | Depth in the call graph from entry points |
 
 ---
 
 ## Step 6 — Assign driver labels
 
-Every function gets a single **driver** label that names the primary dimension responsible for its risk. This is computed after enrichment, using population-relative percentile thresholds so the labels adapt to each codebase rather than using fixed cutoffs.
+Every function gets a single **driver** label identifying which dimension contributes most to its risk. Labels are assigned using population-relative percentile thresholds, computed independently per dimension across all functions in the current scope.
 
-The label is assigned by checking dimensions in priority order:
+The label is assigned by checking dimensions in the following priority order:
 
-| Label | Condition | What it tells you |
-|-------|-----------|-------------------|
-| `cyclic_dep` | Function is part of a dependency cycle | The risk comes from circular dependencies, not just internal complexity |
-| `high_complexity` | CC is above the 75th percentile | Control-flow complexity is the dominant driver |
-| `deep_nesting` | ND is above the 75th percentile | Nesting depth is the dominant driver |
-| `high_fanout_churning` | FO above P75 **and** touches above P50 | Fan-out is high *and* the function is actively changing — dependencies in flux |
-| `high_fanin_complex` | Fan-in above P75 **and** CC above P50 | Many callers depend on a complex function |
-| `high_churn_low_cc` | Touches above P75 **and** CC below P25 | Unusually active for a simple function — worth investigating why |
-| `composite` | No single dimension clearly dominates | Multiple dimensions are elevated together |
+| Label | Condition | Interpretation |
+|-------|-----------|----------------|
+| `cyclic_dep` | Function is part of a dependency cycle | Risk is primarily structural — a cycle in the call graph |
+| `high_complexity` | CC above P75 | Cyclomatic complexity is the dominant dimension |
+| `deep_nesting` | ND above P75 | Nesting depth is the dominant dimension |
+| `high_fanout_churning` | FO above P75 **and** touches above P50 | High fan-out combined with active change |
+| `high_fanin_complex` | Fan-in above P75 **and** CC above P50 | High caller count combined with elevated complexity |
+| `high_churn_low_cc` | Touches above P75 **and** CC below P25 | High activity relative to structural complexity |
+| `composite` | No single dimension clearly dominates | Multiple dimensions are elevated |
 
-Percentiles are computed independently per dimension across all functions in the current analysis scope. A function in a mostly-simple codebase may be labeled `high_complexity` at CC 6; one in a complex codebase may need CC 20 to earn the same label.
+Because percentiles are codebase-relative, the absolute metric value that triggers a label varies across repos.
 
 ---
 
 ## Step 7 — Assign quadrants
 
-Every function is placed in one of four quadrants by combining its risk band with its activity level. Quadrant is the primary triage signal — it tells you whether to act now, schedule work, monitor, or leave it alone.
+Every function is placed in one of four quadrants by combining its risk band with its activity level:
 
 |  | Low activity | High activity |
 |--|---|---|
 | **High or Critical band** | `debt` | `fire` |
 | **Low or Moderate band** | `ok` | `watch` |
 
-**What "active" means:**
-A function is considered active if any of the following is true:
-- Its 30-day touch count is above the population median, **or**
-- It was changed within the last 30 days
+**Activity** is considered high if either of the following is true:
+- 30-day touch count is above the population median, **or**
+- Function was changed within the last 30 days
 
-**What each quadrant means:**
+| Quadrant | Signal | Typical action |
+|----------|--------|----------------|
+| `fire` | High complexity **and** high activity | Prioritize for review or refactoring |
+| `debt` | High complexity, low activity | Schedule for future refactoring |
+| `watch` | Low complexity, high activity | Monitor for complexity increases |
+| `ok` | Low complexity, low activity | No immediate action indicated |
 
-| Quadrant | Signal | What to do |
-|----------|--------|------------|
-| `fire` | Complex **and** actively changing right now | Highest priority. Live regression risk — every change to this function is high-stakes. |
-| `debt` | Complex but dormant | Schedule a refactor. Not urgent today, but don't let it stay this way indefinitely. |
-| `watch` | Active but not yet complex | Monitor. Block LRS increases in CI so it doesn't drift into `fire`. |
-| `ok` | Simple and quiet | Leave it alone. Touching it introduces risk with no expected return. |
-
-**Important:** A high Activity Risk score alone does **not** mean a function is in `fire`. Always check `quadrant` and `touches_30d` — a complex function that hasn't been touched in a year is `debt`, not `fire`. The quadrant is the more actionable signal.
+Note: a high Activity Risk score does not by itself place a function in `fire`. Quadrant is determined by band (from LRS) and activity independently. Always check `quadrant` alongside `touches_30d` for context.
 
 ---
 
@@ -224,25 +216,24 @@ A function is considered active if any of the following is true:
 
 **Default ranking (no trained ranker):**
 
-Functions are sorted by:
-1. LRS descending — highest structural risk first
-2. File path ascending — alphabetical tiebreak within the same LRS
-3. Line number ascending — earlier in the file wins ties within the same file
-4. Function name ascending — final tiebreak
+1. LRS descending
+2. File path ascending (tiebreak)
+3. Line number ascending (tiebreak)
+4. Function name ascending (tiebreak)
 
 **With `--mode snapshot` triage view:**
 
-Functions are grouped by quadrant in priority order (`fire` → `debt` → `watch` → `ok`), then sorted by Activity Risk descending within each group.
+Functions are grouped by quadrant (`fire` → `debt` → `watch` → `ok`), then sorted by Activity Risk descending within each group.
 
 **With a trained ranker (`hotspots train`):**
 
-The ML ranker re-scores functions using a RandomForest model trained on your repo's bug-fix history. Output is sorted by the ranker's predicted bug probability descending. LRS, band, and quadrant remain in the output for context.
+Functions are re-scored using a RandomForest model trained on the repo's bug-fix history and sorted by predicted probability descending. LRS, band, and quadrant remain in the output.
 
 ---
 
 ## File risk score
 
-In addition to per-function scoring, Hotspots aggregates function data into a per-file score for the file-risk view:
+In addition to per-function scoring, Hotspots computes a per-file score for the file-risk view:
 
 ```
 File Risk Score = max_cc × 0.4
@@ -251,7 +242,7 @@ File Risk Score = max_cc × 0.4
                + min(file_churn / 100, 10.0) × 0.1
 ```
 
-This weights the worst function in the file most heavily (max CC), considers the overall complexity distribution (avg CC), penalizes files with many functions (harder to navigate), and factors in recent change volume. Files are ranked descending by this score.
+The score weights the highest-complexity function most heavily, incorporates the average complexity distribution, accounts for file size by function count, and includes recent change volume. Files are ranked descending by this score.
 
 ---
 

--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -1,0 +1,244 @@
+# Scoring Methodology
+
+This document describes the complete pipeline from raw source code to the ranked output Hotspots produces. Each stage builds on the previous one.
+
+---
+
+## Pipeline overview
+
+```
+Source Code
+  ↓
+Raw Metrics  (CC, ND, FO, NS, LOC)
+  ↓
+Risk Components  (log-scaled, bounded)
+  ↓
+Local Risk Score  (LRS) + Risk Band
+  ↓
+Pattern Classification  (Tier 1: structural, Tier 2: enriched)
+  ↓
+[optional enrichment: call graph, git churn, touch counts]
+  ↓
+Activity Risk Score  (LRS + activity modifiers)
+  ↓
+Driver Label  (primary dimension diagnosis)
+  ↓
+Quadrant Assignment  (2-D: complexity × activity)
+  ↓
+Ranked Output
+```
+
+Stages above the enrichment line run on source code alone. Stages below require `--git-dir` or a connected git repository.
+
+---
+
+## 1. Raw metrics
+
+Hotspots measures four structural dimensions per function:
+
+| Metric | Meaning |
+|--------|---------|
+| **CC** | Cyclomatic complexity — independent paths through the control flow graph |
+| **ND** | Nesting depth — maximum depth of nested control structures |
+| **FO** | Fan-out — distinct functions called from this function |
+| **NS** | Non-structured exits — early returns, throws, breaks, continues (excluding tail return) |
+
+Plus **LOC** (physical line count), used only for pattern detection.
+
+See [Metrics Reference](/reference/metrics) for full definitions and per-language counting rules.
+
+---
+
+## 2. Local Risk Score (LRS)
+
+Each raw metric is first passed through a monotonic, bounded transform:
+
+```
+R_cc = min(log2(CC + 1), 6.0)    # logarithmic, cap 6
+R_nd = min(ND, 8.0)              # linear, cap 8
+R_fo = min(log2(FO + 1), 6.0)   # logarithmic, cap 6
+R_ns = min(NS, 6.0)              # linear, cap 6
+```
+
+Logarithmic scaling for CC and FO means the jump from 1 to 4 counts more than the jump from 20 to 24 — early growth signals risk more reliably than marginal increases at high values.
+
+The four components combine into LRS:
+
+```
+LRS = 1.0 × R_cc  +  0.8 × R_nd  +  0.6 × R_fo  +  0.7 × R_ns
+```
+
+**Risk bands:**
+
+| Band     | LRS range | Interpretation |
+|----------|-----------|----------------|
+| Critical | ≥ 9.0     | Refactor now — highest-probability bug sources |
+| High     | 6.0–8.9   | Refactor the next time you touch this function |
+| Moderate | 3.0–5.9   | Monitor; block increases in CI |
+| Low      | < 3.0     | Not worth the risk of touching without a reason |
+
+Theoretical maximum LRS is **22.0** (all four metrics pegged at their caps). In practice, even the most complex real-world functions rarely exceed 15.
+
+See [LRS Specification](/reference/lrs-spec) for the complete formula derivation, worked examples, and precision notes.
+
+---
+
+## 3. Pattern classification
+
+Patterns are named code-smell labels assigned before any git data is needed (Tier 1) or after enrichment (Tier 2). They appear as `patterns: [...]` in JSON output and `--format text`.
+
+### Tier 1 — structural (raw metrics only)
+
+| Pattern | Trigger |
+|---------|---------|
+| `complex_branching` | CC ≥ 10 **and** ND ≥ 4 |
+| `deeply_nested` | ND ≥ 5 |
+| `exit_heavy` | NS ≥ 5 |
+| `god_function` | LOC ≥ 60 **and** FO ≥ 10 |
+| `long_function` | LOC ≥ 80 |
+
+### Tier 2 — enriched (call graph + git)
+
+| Pattern | Trigger |
+|---------|---------|
+| `churn_magnet` | file churn ≥ 200 lines **and** CC ≥ 8 |
+| `cyclic_hub` | SCC size ≥ 2 **and** fan-in ≥ 6 |
+| `hub_function` | fan-in ≥ 10 **and** CC ≥ 8 |
+| `middle_man` | fan-in ≥ 8 **and** FO ≥ 8 **and** CC ≤ 4 |
+| `neighbor_risk` | neighbor churn ≥ 400 **and** FO ≥ 8 |
+| `shotgun_target` | fan-in ≥ 8 **and** file churn ≥ 150 |
+| `stale_complex` | CC ≥ 10 **and** LOC ≥ 60 **and** days since change ≥ 180 |
+
+**Derived pattern:** `volatile_god` fires only when **both** `god_function` and `churn_magnet` are true.
+
+All thresholds are configurable in `.hotspotsrc.json`. See [Configuration](/guide/configuration).
+
+---
+
+## 4. Activity Risk Score
+
+When git history is available, Hotspots computes an activity-weighted risk score that combines LRS with change signals:
+
+```
+Activity Risk = LRS
+             + (lines_added + lines_deleted) / 100 × 0.5   # churn
+             + min(touch_count / 10, 5.0) × 0.3            # touches in 30 days
+             + max(0, 5.0 − days_since_change / 7) × 0.2   # recency
+             + min(fan_in / 5, 10.0) × 0.4                 # call-graph fan-in
+             + (scc_size if > 1 else 0) × 0.3              # cycle membership
+             + min(dependency_depth / 3, 5.0) × 0.1        # call-chain depth
+             + neighbor_churn / 500 × 0.2                  # churn in callers/callees
+```
+
+**Weights at a glance:**
+
+| Signal | Weight | Rationale |
+|--------|--------|-----------|
+| Churn | 0.5 | High change volume is a leading defect predictor |
+| Fan-in | 0.4 | Wide blast radius amplifies impact of any change |
+| Touch count | 0.3 | Frequent touches correlate with instability |
+| SCC membership | 0.3 | Cycles make reasoning about ordering impossible |
+| Recency | 0.2 | Recent changes haven't had time to stabilize |
+| Neighbor churn | 0.2 | Dependencies in flux transfer risk |
+| Dependency depth | 0.1 | Deep chains amplify cascading failures |
+
+Activity Risk is always ≥ LRS (all modifiers are non-negative). When no git data is available, Activity Risk equals LRS.
+
+---
+
+## 5. Driver labels
+
+Each function receives a primary **driver** label that names which dimension dominates its risk. This appears as `driver` in JSON output and is shown in the triage view.
+
+Labels are assigned by comparing each dimension against population percentiles (default: 75th percentile threshold):
+
+| Label | Condition |
+|-------|-----------|
+| `cyclic_dep` | SCC size > 1 (absolute, no percentile) |
+| `high_complexity` | CC above P75 |
+| `deep_nesting` | ND above P75 |
+| `high_fanout_churning` | FO above P75 **and** touch count above P50 |
+| `high_fanin_complex` | fan-in above P75 **and** CC above P50 |
+| `high_churn_low_cc` | touches above P75 **and** CC below P25 |
+| `composite` | no single dimension clearly dominates |
+
+Percentiles are computed independently per dimension across all functions in the current analysis scope, so thresholds adapt to each codebase.
+
+---
+
+## 6. Quadrant assignment
+
+Every function is placed in one of four quadrants using a 2-D matrix of complexity vs. activity:
+
+|  | Low activity | High activity |
+|--|---|---|
+| **High risk (High or Critical band)** | `debt` | `fire` |
+| **Low risk (Low or Moderate band)** | `ok` | `watch` |
+
+**Activity** is considered high when any of the following is true:
+- `touch_count` is above the population median for the analysis scope, **or**
+- `days_since_change` ≤ 30, **or**
+- Activity Risk is in the top 30% of the population (when a ranker has been applied)
+
+**Interpreting the quadrants:**
+
+| Quadrant | Signal | Recommended action |
+|----------|--------|--------------------|
+| `fire` | Complex **and** actively changing | Highest priority — live regression risk |
+| `debt` | Complex but dormant | Schedule refactor; don't defer indefinitely |
+| `watch` | Active but not yet complex | Monitor; block LRS increases in CI |
+| `ok` | Simple and quiet | Leave it alone |
+
+A high Activity Risk score alone does **not** mean a function is in `fire`. Always check `quadrant` and `touches_30d` — a complex function that hasn't been touched in a year is `debt`, not `fire`.
+
+---
+
+## 7. File risk score
+
+Hotspots also aggregates function-level data into a per-file score for the file-risk view:
+
+```
+File Risk Score = max_cc × 0.4
+               + avg_cc × 0.3
+               + log2(function_count + 1) × 0.2
+               + min(file_churn / 100, 10.0) × 0.1
+```
+
+Files are ranked descending by this score. Ties break alphabetically by path.
+
+---
+
+## 8. Ranking
+
+**Default ranking (no ranker applied):**
+
+1. LRS descending (highest structural risk first)
+2. File path ascending (alphabetical tiebreak)
+3. Line number ascending
+4. Function name ascending
+
+**With `--mode snapshot` triage view:**
+
+Functions are grouped by quadrant (`fire` → `debt` → `watch` → `ok`), then sorted by Activity Risk descending within each group.
+
+**With a trained ranker (`hotspots rank`):**
+
+The ML ranker re-scores functions using a RandomForest model trained on your repo's bug-fix history. Output is sorted by the ranker's predicted bug probability descending. LRS and quadrant remain in the output for context. See [Training a Ranker](/guide/usage#training-a-ranker) for details.
+
+---
+
+## Version history
+
+Every change to a formula, weight, threshold, or ranking rule is recorded in the [Scoring Changelog](/reference/scoring-changelog).
+
+---
+
+## Coming soon: ranker scoring
+
+The trained ranker layer is currently in active development. Once complete, the ranker will:
+
+- Assign a `rank_score` (predicted probability this function appears in a future bug-fix commit)
+- Surface functions that are statistically over-represented in past defects, even when LRS is moderate
+- Blend structural risk with historical signal rather than treating them as separate steps
+
+The heuristic pipeline above will remain the default for repos without training data.

--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -1,6 +1,6 @@
 # Scoring Methodology
 
-This document describes the complete pipeline from raw source code to the ranked output Hotspots produces. Each stage builds on the previous one.
+This document explains every step of the pipeline from raw source code to the ranked output Hotspots produces. Each stage builds on the previous one.
 
 ---
 
@@ -11,11 +11,11 @@ Source Code
   ↓
 Raw Metrics  (CC, ND, FO, NS, LOC)
   ↓
-Risk Components  (log-scaled, bounded)
+Risk Components  (log-scaled, bounded transforms)
   ↓
 Local Risk Score  (LRS) + Risk Band
   ↓
-Pattern Classification  (Tier 1: structural, Tier 2: enriched)
+Pattern Classification  (Tier 1: structural · Tier 2: enriched)
   ↓
 [optional enrichment: call graph, git churn, touch counts]
   ↓
@@ -28,174 +28,221 @@ Quadrant Assignment  (2-D: complexity × activity)
 Ranked Output
 ```
 
-Stages above the enrichment line run on source code alone. Stages below require `--git-dir` or a connected git repository.
+Stages above the enrichment line run on source code alone and are always computed. Stages below require a git repository.
 
 ---
 
-## 1. Raw metrics
+## Step 1 — Collect raw metrics
 
-Hotspots measures four structural dimensions per function:
+Hotspots parses each source file and visits every function, extracting four structural measurements:
 
-| Metric | Meaning |
-|--------|---------|
-| **CC** | Cyclomatic complexity — independent paths through the control flow graph |
-| **ND** | Nesting depth — maximum depth of nested control structures |
-| **FO** | Fan-out — distinct functions called from this function |
-| **NS** | Non-structured exits — early returns, throws, breaks, continues (excluding tail return) |
+**CC — Cyclomatic Complexity**
+The number of independent decision paths through the function. Every `if`, `else if`, loop, `case`, `catch`, `&&`, `||`, and ternary adds one path. A function with no branches has CC 1. CC is the strongest single predictor of testing difficulty: CC 10 means at least 10 distinct paths to exercise.
 
-Plus **LOC** (physical line count), used only for pattern detection.
+**ND — Nesting Depth**
+The maximum depth of nested control structures — how many layers of `if`/loop/`try` a reader must mentally track at once. Each level of nesting multiplies the number of implicit states the function can be in. ND 4 or higher almost always means the function is doing too many things at once.
 
-See [Metrics Reference](/reference/metrics) for full definitions and per-language counting rules.
+**FO — Fan-Out**
+The number of distinct functions this function calls. High fan-out means the function coordinates many dependencies. Each additional callee is another place for the function's behavior to change unexpectedly — and another thing to mock in tests.
+
+**NS — Non-Structured Exits**
+The count of early returns, throws, breaks, and continues inside the function body, excluding the final tail return. Non-structured exits create multiple exit points that are hard to trace and make it difficult to reason about what state the function leaves behind.
+
+**LOC — Lines of Code**
+Physical line count. Used only for pattern detection (see Step 4), not for the risk score itself.
+
+See [Metrics Reference](/reference/metrics) for exact counting rules per language.
 
 ---
 
-## 2. Local Risk Score (LRS)
+## Step 2 — Transform to risk components
 
-Each raw metric is first passed through a monotonic, bounded transform:
+Raw metric values are not summed directly. Each one is first passed through a bounded, monotonic transform that shapes how it contributes to the final score:
 
 ```
-R_cc = min(log2(CC + 1), 6.0)    # logarithmic, cap 6
-R_nd = min(ND, 8.0)              # linear, cap 8
-R_fo = min(log2(FO + 1), 6.0)   # logarithmic, cap 6
-R_ns = min(NS, 6.0)              # linear, cap 6
+R_cc = min(log2(CC + 1), 6.0)    # logarithmic, capped at 6
+R_nd = min(ND, 8.0)              # linear, capped at 8
+R_fo = min(log2(FO + 1), 6.0)   # logarithmic, capped at 6
+R_ns = min(NS, 6.0)              # linear, capped at 6
 ```
 
-Logarithmic scaling for CC and FO means the jump from 1 to 4 counts more than the jump from 20 to 24 — early growth signals risk more reliably than marginal increases at high values.
+**Why logarithmic for CC and FO?**
+The difference between CC 1 and CC 4 is enormous — one path versus four. The difference between CC 40 and CC 44 is negligible — already completely untestable either way. Logarithmic scaling captures this: early growth counts a lot, marginal increases at high values contribute little. Fan-out follows the same logic.
 
-The four components combine into LRS:
+**Why linear for ND and NS?**
+Nesting depth and exit count grow more uniformly in practice. Each additional nesting level genuinely adds proportional cognitive load, and there is no diminishing-returns region to flatten.
+
+**Why caps?**
+Caps prevent a single catastrophically bad metric from drowning out the others. A function with CC 200 and ND 1 should not score higher than a function with CC 30 and ND 8 — both are severe, and the score should reflect overall structural complexity, not just one runaway dimension.
+
+---
+
+## Step 3 — Compute the Local Risk Score (LRS)
+
+The four risk components are combined into a single score using a weighted sum:
 
 ```
 LRS = 1.0 × R_cc  +  0.8 × R_nd  +  0.6 × R_fo  +  0.7 × R_ns
 ```
 
+**Why these weights?**
+- **CC gets the highest weight (1.0)** because control-flow complexity is the primary driver of defect density across empirical studies. It directly determines how many paths must be tested and how many branch combinations can interact.
+- **ND gets the second-highest weight (0.8)** because deep nesting compounds complexity in a way CC alone doesn't capture — a function can have moderate CC but be nearly unreadable due to nesting.
+- **NS gets a medium-high weight (0.7)** because non-structured exits create implicit control flow that is hard to reason about and makes postconditions difficult to state or enforce.
+- **FO gets the lowest weight (0.6)** because some fan-out is expected and healthy — functions that orchestrate other functions aren't inherently risky unless combined with other signals.
+
+LRS is always ≥ 1.0 (minimum for a trivial single-path function with no nesting, calls, or exits). The theoretical maximum is **22.0** (all four components pegged at their caps). Real-world functions rarely exceed 15.
+
 **Risk bands:**
 
-| Band     | LRS range | Interpretation |
-|----------|-----------|----------------|
-| Critical | ≥ 9.0     | Refactor now — highest-probability bug sources |
-| High     | 6.0–8.9   | Refactor the next time you touch this function |
-| Moderate | 3.0–5.9   | Monitor; block increases in CI |
-| Low      | < 3.0     | Not worth the risk of touching without a reason |
-
-Theoretical maximum LRS is **22.0** (all four metrics pegged at their caps). In practice, even the most complex real-world functions rarely exceed 15.
+| Band | LRS range | Meaning |
+|------|-----------|---------|
+| Critical | ≥ 9.0 | Refactor now — highest-probability bug sources |
+| High | 6.0–8.9 | Refactor the next time you touch this function |
+| Moderate | 3.0–5.9 | Monitor; block increases in CI |
+| Low | < 3.0 | Not worth the risk of touching without a reason |
 
 See [LRS Specification](/reference/lrs-spec) for the complete formula derivation, worked examples, and precision notes.
 
 ---
 
-## 3. Pattern classification
+## Step 4 — Classify patterns
 
-Patterns are named code-smell labels assigned before any git data is needed (Tier 1) or after enrichment (Tier 2). They appear as `patterns: [...]` in JSON output and `--format text`.
+Patterns are named labels that identify specific code smells. They complement LRS by naming *what kind* of problem a function has, not just *how bad* it is. A function can match multiple patterns simultaneously.
 
-### Tier 1 — structural (raw metrics only)
+### Tier 1 — structural (source code only)
 
-| Pattern | Trigger |
-|---------|---------|
-| `complex_branching` | CC ≥ 10 **and** ND ≥ 4 |
-| `deeply_nested` | ND ≥ 5 |
-| `exit_heavy` | NS ≥ 5 |
-| `god_function` | LOC ≥ 60 **and** FO ≥ 10 |
-| `long_function` | LOC ≥ 80 |
+These patterns are detected from raw metrics alone and are always computed:
 
-### Tier 2 — enriched (call graph + git)
+| Pattern | Trigger | What it means |
+|---------|---------|---------------|
+| `complex_branching` | CC ≥ 10 **and** ND ≥ 4 | High branching *and* deep nesting — two independent complexity signals reinforcing each other |
+| `deeply_nested` | ND ≥ 5 | Nesting so deep that the function almost certainly needs to be decomposed |
+| `exit_heavy` | NS ≥ 5 | So many exit points that control flow is genuinely hard to trace |
+| `god_function` | LOC ≥ 60 **and** FO ≥ 10 | Long *and* calls many things — a function that knows too much and does too much |
+| `long_function` | LOC ≥ 80 | Physically long regardless of complexity — a readability and reviewability problem |
 
-| Pattern | Trigger |
-|---------|---------|
-| `churn_magnet` | file churn ≥ 200 lines **and** CC ≥ 8 |
-| `cyclic_hub` | SCC size ≥ 2 **and** fan-in ≥ 6 |
-| `hub_function` | fan-in ≥ 10 **and** CC ≥ 8 |
-| `middle_man` | fan-in ≥ 8 **and** FO ≥ 8 **and** CC ≤ 4 |
-| `neighbor_risk` | neighbor churn ≥ 400 **and** FO ≥ 8 |
-| `shotgun_target` | fan-in ≥ 8 **and** file churn ≥ 150 |
-| `stale_complex` | CC ≥ 10 **and** LOC ≥ 60 **and** days since change ≥ 180 |
+### Tier 2 — enriched (call graph + git data)
 
-**Derived pattern:** `volatile_god` fires only when **both** `god_function` and `churn_magnet` are true.
+These patterns require git history and the call graph and are only computed when that data is available:
+
+| Pattern | Trigger | What it means |
+|---------|---------|---------------|
+| `churn_magnet` | file churn ≥ 200 lines **and** CC ≥ 8 | Complex *and* frequently changed — the highest-risk combination |
+| `cyclic_hub` | SCC size ≥ 2 **and** fan-in ≥ 6 | Part of a dependency cycle *and* widely called — hard to reason about ordering |
+| `hub_function` | fan-in ≥ 10 **and** CC ≥ 8 | Many callers depend on a complex function — wide blast radius |
+| `middle_man` | fan-in ≥ 8 **and** FO ≥ 8 **and** CC ≤ 4 | Called by many, calls many, but does very little itself — often a sign of unnecessary indirection |
+| `neighbor_risk` | neighbor churn ≥ 400 **and** FO ≥ 8 | The things this function calls are changing a lot — risk inherited from dependencies |
+| `shotgun_target` | fan-in ≥ 8 **and** file churn ≥ 150 | Many callers *and* the file changes frequently — changes here ripple widely |
+| `stale_complex` | CC ≥ 10 **and** LOC ≥ 60 **and** days since change ≥ 180 | Complex and old — institutional knowledge risk; the people who understood it may be gone |
+
+**Derived pattern:** `volatile_god` fires only when **both** `god_function` and `churn_magnet` are true — a large, widely-coupled function that is also actively changing.
 
 All thresholds are configurable in `.hotspotsrc.json`. See [Configuration](/guide/configuration).
 
 ---
 
-## 4. Activity Risk Score
+## Step 5 — Compute the Activity Risk Score
 
-When git history is available, Hotspots computes an activity-weighted risk score that combines LRS with change signals:
+When git history is available, Hotspots extends LRS with activity signals to produce a score that reflects not just how complex a function is, but how much risk that complexity is generating *right now*:
 
 ```
 Activity Risk = LRS
-             + (lines_added + lines_deleted) / 100 × 0.5   # churn
-             + min(touch_count / 10, 5.0) × 0.3            # touches in 30 days
-             + max(0, 5.0 − days_since_change / 7) × 0.2   # recency
-             + min(fan_in / 5, 10.0) × 0.4                 # call-graph fan-in
-             + (scc_size if > 1 else 0) × 0.3              # cycle membership
-             + min(dependency_depth / 3, 5.0) × 0.1        # call-chain depth
-             + neighbor_churn / 500 × 0.2                  # churn in callers/callees
+             + (lines_added + lines_deleted) / 100 × 0.5
+             + min(touch_count_30d / 10, 5.0) × 0.3
+             + max(0, 5.0 − days_since_change / 7) × 0.2
+             + min(fan_in / 5, 10.0) × 0.4
+             + (scc_size − 1, if in cycle, else 0) × 0.3
+             + min(dependency_depth / 3, 5.0) × 0.1
+             + neighbor_churn / 500 × 0.2
 ```
 
-**Weights at a glance:**
+Each modifier adds to LRS — Activity Risk is always ≥ LRS. When no git data is available, Activity Risk equals LRS.
 
-| Signal | Weight | Rationale |
-|--------|--------|-----------|
-| Churn | 0.5 | High change volume is a leading defect predictor |
-| Fan-in | 0.4 | Wide blast radius amplifies impact of any change |
-| Touch count | 0.3 | Frequent touches correlate with instability |
-| SCC membership | 0.3 | Cycles make reasoning about ordering impossible |
-| Recency | 0.2 | Recent changes haven't had time to stabilize |
-| Neighbor churn | 0.2 | Dependencies in flux transfer risk |
-| Dependency depth | 0.1 | Deep chains amplify cascading failures |
+**What each signal captures:**
 
-Activity Risk is always ≥ LRS (all modifiers are non-negative). When no git data is available, Activity Risk equals LRS.
-
----
-
-## 5. Driver labels
-
-Each function receives a primary **driver** label that names which dimension dominates its risk. This appears as `driver` in JSON output and is shown in the triage view.
-
-Labels are assigned by comparing each dimension against population percentiles (default: 75th percentile threshold):
-
-| Label | Condition |
-|-------|-----------|
-| `cyclic_dep` | SCC size > 1 (absolute, no percentile) |
-| `high_complexity` | CC above P75 |
-| `deep_nesting` | ND above P75 |
-| `high_fanout_churning` | FO above P75 **and** touch count above P50 |
-| `high_fanin_complex` | fan-in above P75 **and** CC above P50 |
-| `high_churn_low_cc` | touches above P75 **and** CC below P25 |
-| `composite` | no single dimension clearly dominates |
-
-Percentiles are computed independently per dimension across all functions in the current analysis scope, so thresholds adapt to each codebase.
+| Signal | Weight | Why it matters |
+|--------|--------|----------------|
+| Churn (lines added + deleted) | 0.5 | Volume of recent change is the strongest activity signal — high churn means the function is a live target |
+| Fan-in (call-graph callers) | 0.4 | Many callers means changes here have a wide blast radius |
+| Touch count (30-day commits) | 0.3 | Frequent commits suggest instability or active development — either way, the function is in motion |
+| SCC membership | 0.3 | Being part of a dependency cycle makes any change harder to reason about safely |
+| Recency (days since last change) | 0.2 | A function changed this week is more likely to be changed again than one stable for a year |
+| Neighbor churn | 0.2 | When the functions this one calls are changing a lot, risk transfers inward |
+| Dependency depth | 0.1 | Deep call chains amplify cascading failures — lower weight because structural depth is already captured partially by LRS |
 
 ---
 
-## 6. Quadrant assignment
+## Step 6 — Assign driver labels
 
-Every function is placed in one of four quadrants using a 2-D matrix of complexity vs. activity:
+Every function gets a single **driver** label that names the primary dimension responsible for its risk. This is computed after enrichment, using population-relative percentile thresholds so the labels adapt to each codebase rather than using fixed cutoffs.
+
+The label is assigned by checking dimensions in priority order:
+
+| Label | Condition | What it tells you |
+|-------|-----------|-------------------|
+| `cyclic_dep` | Function is part of a dependency cycle | The risk comes from circular dependencies, not just internal complexity |
+| `high_complexity` | CC is above the 75th percentile | Control-flow complexity is the dominant driver |
+| `deep_nesting` | ND is above the 75th percentile | Nesting depth is the dominant driver |
+| `high_fanout_churning` | FO above P75 **and** touches above P50 | Fan-out is high *and* the function is actively changing — dependencies in flux |
+| `high_fanin_complex` | Fan-in above P75 **and** CC above P50 | Many callers depend on a complex function |
+| `high_churn_low_cc` | Touches above P75 **and** CC below P25 | Unusually active for a simple function — worth investigating why |
+| `composite` | No single dimension clearly dominates | Multiple dimensions are elevated together |
+
+Percentiles are computed independently per dimension across all functions in the current analysis scope. A function in a mostly-simple codebase may be labeled `high_complexity` at CC 6; one in a complex codebase may need CC 20 to earn the same label.
+
+---
+
+## Step 7 — Assign quadrants
+
+Every function is placed in one of four quadrants by combining its risk band with its activity level. Quadrant is the primary triage signal — it tells you whether to act now, schedule work, monitor, or leave it alone.
 
 |  | Low activity | High activity |
 |--|---|---|
-| **High risk (High or Critical band)** | `debt` | `fire` |
-| **Low risk (Low or Moderate band)** | `ok` | `watch` |
+| **High or Critical band** | `debt` | `fire` |
+| **Low or Moderate band** | `ok` | `watch` |
 
-**Activity** is considered high when any of the following is true:
-- `touch_count` is above the population median for the analysis scope, **or**
-- `days_since_change` ≤ 30, **or**
-- Activity Risk is in the top 30% of the population (when a ranker has been applied)
+**What "active" means:**
+A function is considered active if any of the following is true:
+- Its 30-day touch count is above the population median, **or**
+- It was changed within the last 30 days
 
-**Interpreting the quadrants:**
+**What each quadrant means:**
 
-| Quadrant | Signal | Recommended action |
-|----------|--------|--------------------|
-| `fire` | Complex **and** actively changing | Highest priority — live regression risk |
-| `debt` | Complex but dormant | Schedule refactor; don't defer indefinitely |
-| `watch` | Active but not yet complex | Monitor; block LRS increases in CI |
-| `ok` | Simple and quiet | Leave it alone |
+| Quadrant | Signal | What to do |
+|----------|--------|------------|
+| `fire` | Complex **and** actively changing right now | Highest priority. Live regression risk — every change to this function is high-stakes. |
+| `debt` | Complex but dormant | Schedule a refactor. Not urgent today, but don't let it stay this way indefinitely. |
+| `watch` | Active but not yet complex | Monitor. Block LRS increases in CI so it doesn't drift into `fire`. |
+| `ok` | Simple and quiet | Leave it alone. Touching it introduces risk with no expected return. |
 
-A high Activity Risk score alone does **not** mean a function is in `fire`. Always check `quadrant` and `touches_30d` — a complex function that hasn't been touched in a year is `debt`, not `fire`.
+**Important:** A high Activity Risk score alone does **not** mean a function is in `fire`. Always check `quadrant` and `touches_30d` — a complex function that hasn't been touched in a year is `debt`, not `fire`. The quadrant is the more actionable signal.
 
 ---
 
-## 7. File risk score
+## Step 8 — Rank output
 
-Hotspots also aggregates function-level data into a per-file score for the file-risk view:
+**Default ranking (no trained ranker):**
+
+Functions are sorted by:
+1. LRS descending — highest structural risk first
+2. File path ascending — alphabetical tiebreak within the same LRS
+3. Line number ascending — earlier in the file wins ties within the same file
+4. Function name ascending — final tiebreak
+
+**With `--mode snapshot` triage view:**
+
+Functions are grouped by quadrant in priority order (`fire` → `debt` → `watch` → `ok`), then sorted by Activity Risk descending within each group.
+
+**With a trained ranker (`hotspots train`):**
+
+The ML ranker re-scores functions using a RandomForest model trained on your repo's bug-fix history. Output is sorted by the ranker's predicted bug probability descending. LRS, band, and quadrant remain in the output for context.
+
+---
+
+## File risk score
+
+In addition to per-function scoring, Hotspots aggregates function data into a per-file score for the file-risk view:
 
 ```
 File Risk Score = max_cc × 0.4
@@ -204,26 +251,7 @@ File Risk Score = max_cc × 0.4
                + min(file_churn / 100, 10.0) × 0.1
 ```
 
-Files are ranked descending by this score. Ties break alphabetically by path.
-
----
-
-## 8. Ranking
-
-**Default ranking (no ranker applied):**
-
-1. LRS descending (highest structural risk first)
-2. File path ascending (alphabetical tiebreak)
-3. Line number ascending
-4. Function name ascending
-
-**With `--mode snapshot` triage view:**
-
-Functions are grouped by quadrant (`fire` → `debt` → `watch` → `ok`), then sorted by Activity Risk descending within each group.
-
-**With a trained ranker (`hotspots rank`):**
-
-The ML ranker re-scores functions using a RandomForest model trained on your repo's bug-fix history. Output is sorted by the ranker's predicted bug probability descending. LRS and quadrant remain in the output for context. See [Training a Ranker](/guide/usage#training-a-ranker) for details.
+This weights the worst function in the file most heavily (max CC), considers the overall complexity distribution (avg CC), penalizes files with many functions (harder to navigate), and factors in recent change volume. Files are ranked descending by this score.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/reference/scoring.md` — full pipeline doc covering LRS, Activity Risk, patterns, driver labels, quadrants, file risk, and ranking
- Adds `docs/reference/scoring-changelog.md` — versioned record of scoring formula changes with baseline snapshot at v1.24.0
- Wires both pages into the VitePress sidebar nav
- Updates `docs/index.md`: adds "How scoring works" summary, marks Risk Hotspots as shipped
- Updates `README.md` docs link list

## Test plan

- [ ] `docs-ci.yml` VitePress build passes on merge to main
- [ ] Both new pages appear in sidebar under Reference
- [ ] Links between scoring.md ↔ scoring-changelog.md ↔ lrs-spec.md resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)