### PR TITLE
feat: add hotspots coordinate subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,8 @@ dependencies = [
  "is-terminal",
  "owo-colors",
  "rayon",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/docs/guide/claude-code-integration.md
+++ b/docs/guide/claude-code-integration.md
@@ -1,0 +1,31 @@
+# Claude Code Integration
+
+Add the following to your repo's `CLAUDE.md` to give Claude Code automatic access to coordination signals before splitting work across agents.
+
+## CLAUDE.md snippet
+
+```markdown
+## Multi-agent coordination
+
+Before splitting work across sub-agents or parallel tasks, run:
+
+```bash
+hotspots coordinate --files <comma-separated list of files to be modified>
+```
+
+Rules:
+- Files listed under `serialize` must be worked sequentially — do not assign them to concurrent agents
+- Files listed under `parallel_safe` can be worked concurrently
+- Files listed under `hidden_dependencies` are outside your task set but historically change alongside your files — flag them to the user before proceeding
+- If you discover additional files mid-task, re-run `hotspots coordinate` with the expanded file list before continuing
+```
+
+## Prerequisites
+
+`hotspots` must be installed and on `PATH`. Verify with:
+
+```bash
+hotspots --version
+```
+
+See [installation](https://github.com/Stephen-Collins-tech/hotspots) for setup instructions.

--- a/docs/guide/claude-code-integration.md
+++ b/docs/guide/claude-code-integration.md
@@ -1,8 +1,28 @@
-# Claude Code Integration
+# Coding Agent Integration
 
-Add the following to your repo's `CLAUDE.md` to give Claude Code automatic access to coordination signals before splitting work across agents.
+Give any AI coding agent automatic access to codebase coordination signals before it splits work across files or sub-agents.
 
-## CLAUDE.md snippet
+## Prerequisites
+
+`hotspots` must be installed and on `PATH`:
+
+```bash
+hotspots --version
+```
+
+If not installed, see [installation](https://github.com/Stephen-Collins-tech/hotspots).
+
+## The snippet
+
+The content is the same for every agent. Add it to whichever file your agent reads for repo-level instructions:
+
+| Agent | File |
+|---|---|
+| Claude Code | `CLAUDE.md` |
+| GitHub Copilot | `.github/copilot-instructions.md` |
+| Cursor | `.cursorrules` |
+| Windsurf | `.windsurfrules` |
+| Aider | pass via `--read CONVENTIONS.md` (or any file you `--read`) |
 
 ```markdown
 ## Multi-agent coordination
@@ -20,12 +40,21 @@ Rules:
 - If you discover additional files mid-task, re-run `hotspots coordinate` with the expanded file list before continuing
 ```
 
-## Prerequisites
+## What happens
 
-`hotspots` must be installed and on `PATH`. Verify with:
+The snippet gives agents two things, at two levels:
 
-```bash
-hotspots --version
-```
+### Context awareness (all agents)
 
-See [installation](https://github.com/Stephen-Collins-tech/hotspots) for setup instructions.
+Before touching any files, the agent runs `hotspots coordinate` and learns:
+- **hidden_dependencies** — files outside the task set that historically move with the input files. The agent flags these to the developer before starting: *"session.rs is frequently modified alongside auth.rs — should I include it?"*
+
+This is useful for any agent, even one working sequentially. Surfacing a hidden dependency before work starts is better than discovering it mid-task or in a broken build.
+
+### Parallelism (agents that support sub-agent spawning)
+
+For agents that can split work across concurrent sub-agents (Claude Code today; others as they evolve), the partition recommendation drives how work is divided:
+- **parallel_safe** — files that rarely co-change; safe to assign to concurrent agents
+- **serialize** — files that co-change frequently; must be worked sequentially
+
+If the agent discovers additional files mid-task, it re-runs `hotspots coordinate` with the expanded file list before continuing.

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -238,6 +238,36 @@ hotspots analyze . --mode snapshot --per-function-touches
 
 ---
 
+## Coordination Pre-flight (`hotspots coordinate`)
+
+Before splitting a task across multiple agents or developers, run `hotspots coordinate` to discover hidden co-change dependencies and get a partition recommendation.
+
+```bash
+hotspots coordinate --files auth.rs,session.rs,middleware.rs
+```
+
+This reads co-change history and ownership signals already computed by Hotspots — no new data sources, no analysis pass required.
+
+**What it tells you:**
+
+- Which file pairs within your set co-change frequently (with raw `coupling_ratio`)
+- Which files *outside* your set are strong co-change partners (hidden dependencies you didn't plan for)
+- Which files are safe to modify in parallel vs which should be serialised
+
+**JSON output for scripts and orchestrators:**
+
+```bash
+hotspots coordinate --files auth.rs,session.rs --json
+```
+
+The JSON schema is stable — `pairs`, `hidden_dependencies`, `ownership`, `parallel_safe`, and `serialize` fields are consistent across versions.
+
+**No risk labels.** `coordinate` outputs raw signal values. The caller decides what a `coupling_ratio` of 0.7 means in their context — a human can read the table, a script can apply its own threshold.
+
+See [CLI reference](../reference/cli.md#hotspots-coordinate) for the full field reference and threshold documentation.
+
+---
+
 ## Common Workflows
 
 ### Daily Development

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -254,10 +254,15 @@ This reads co-change history and ownership signals already computed by Hotspots 
 - Which files *outside* your set are strong co-change partners (hidden dependencies you didn't plan for)
 - Which files are safe to modify in parallel vs which should be serialised
 
-**JSON output for scripts and orchestrators:**
+**Output format:** JSON is emitted automatically when stdout is not a TTY (piped to a script, LLM tool call, etc.). Force it explicitly with `--json`; force human-readable text with `--text`.
 
 ```bash
+# JSON — auto when piped; force explicitly with --json
+hotspots coordinate --files auth.rs,session.rs | jq .serialize
 hotspots coordinate --files auth.rs,session.rs --json
+
+# Human-readable text even when piped
+hotspots coordinate --files auth.rs,session.rs --text | tee report.txt
 ```
 
 The JSON schema is stable — `pairs`, `hidden_dependencies`, `ownership`, `parallel_safe`, and `serialize` fields are consistent across versions.

--- a/docs/plans/coordinate-function-level-scope.md
+++ b/docs/plans/coordinate-function-level-scope.md
@@ -1,0 +1,83 @@
+# Scope: Function-level coordinate (`--level function`)
+
+_Created: 2026-06-14_
+
+## What it does
+
+`hotspots coordinate --files auth.rs,user.rs --level function` partitions at function granularity instead of file granularity. Two agents can safely work on the same file if their function scopes don't co-change. The output shape is identical to `--level file` except `parallel_safe` and `serialize` contain FQNs (`auth.rs::validate_token`) instead of file paths.
+
+## Approach
+
+### Function identity
+
+Fully-qualified name: `file::function` or `file::Type::method`. This is already what the existing parsers produce (`FunctionNode.name`). No new identity scheme needed.
+
+Rename tracking is out of scope for v1 — FQN breaks on rename, which is an accepted limitation shared by the rest of hotspots' function-level analysis.
+
+### Parsing — reuse existing infrastructure
+
+`hotspots-core` already has:
+- `LanguageParser` / `ParsedModule` traits with implementations for Rust (syn), Go, Python, Java, C#, C, JS/TS (SWC/tree-sitter)
+- `discover_functions()` returns `Vec<FunctionNode>`, each with a name and `SourceSpan { start_line, end_line }`
+- `Language::from_path()` for language detection
+- `create_parser()` in `analysis.rs` dispatches to the right parser
+
+The parsers operate on the *current* file state. This is a known limitation: historical commits are attributed to whatever function occupies those lines today. Acceptable for v1.
+
+ECMAScript parsers require an SWC `SourceMap`. A new `create_parser_simple(language)` helper that constructs one internally keeps the coordinate path clean without leaking SWC types into `coordinate.rs`.
+
+### Git mining — new function in `git.rs`
+
+New: `extract_function_co_change_pairs(repo_root, files, window_days, min_count)`
+
+Steps:
+1. Run `git log --name-only --format=COMMIT:%H --diff-filter=AM --since=<window>` — same as `extract_co_change_pairs`, filtered to the input files only
+2. For each commit, run `git diff-tree --no-commit-id -p --unified=0 <sha> -- <files>` to get changed line ranges (hunk headers: `@@ -old +new,count @@`)
+3. Parse each input file with the existing parser to get `FunctionNode` list (done once per file, cached across commits)
+4. For each changed hunk, find which functions overlap the changed line range → collect FQNs touched in this commit
+5. Build commit → `[fqn, fqn, ...]` sets; mine pairs using the same algorithm as `extract_co_change_pairs`
+
+Output type: `CoChangePair` but with `file_a` / `file_b` replaced by FQNs. Either reuse `CoChangePair` with a note that fields contain FQNs, or introduce `FunctionCoChangePair` — TBD at implementation time based on how much the types diverge.
+
+### Coordinate layer — new function in `coordinate.rs`
+
+New: `coordinate_functions(repo_root, files)` — same shape as `coordinate()`:
+- Calls `extract_function_co_change_pairs`
+- Runs `partition_pairs` (reused as-is — it operates on string identifiers, doesn't care if they're file paths or FQNs)
+- `parallel_safe` / `serialize` contain FQNs
+- Ownership signals remain at file level (no change)
+- Hidden deps remain at file level (cross-file coupling is still file-granularity)
+
+### CLI — `--level` flag
+
+In `hotspots-cli/src/cmd/coordinate.rs` and `main.rs`:
+- Add `--level <file|function>` flag, default `file`
+- `handle_coordinate` dispatches to `coordinate()` or `coordinate_functions()` based on flag
+- JSON and text output shapes are the same; FQNs appear where file paths did
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `hotspots-core/src/git.rs` | Add `extract_function_co_change_pairs` |
+| `hotspots-core/src/coordinate.rs` | Add `coordinate_functions`; extract `create_parser_simple` or import from analysis |
+| `hotspots-core/src/analysis.rs` | Possibly expose `create_parser` or extract a shared helper |
+| `hotspots-cli/src/cmd/coordinate.rs` | Add `--level` flag, dispatch |
+| `hotspots-cli/src/main.rs` | Wire `--level` into `CoordinateArgs` |
+| `hotspots-core/tests/coordinate_tests.rs` | Add function-level integration tests |
+
+## Known limitations / decisions deferred
+
+- Parsers use current file state, not historical — renames cause misattribution
+- `create_parser` exposes SWC `SourceMap`; coordinate needs a clean internal wrapper
+- `CoChangePair` reuse vs. new `FunctionCoChangePair` type — decide at implementation
+- Hidden deps and ownership stay at file level for now
+- Languages with no parser (unsupported extensions) are silently skipped at function level, same as existing behavior for file-level analysis
+
+## Acceptance criteria
+
+1. `hotspots coordinate --files auth.rs,user.rs --level function` produces output with FQNs in `parallel_safe` / `serialize`
+2. Two functions in the same file that don't co-change appear in different partitions
+3. `--level file` (default) behavior is unchanged
+4. JSON and text output both work
+5. Integration tests cover: same-file split, cross-file coupling, unsupported language graceful skip

--- a/docs/plans/coordinate-status.md
+++ b/docs/plans/coordinate-status.md
@@ -1,0 +1,68 @@
+# Coordinate Subcommand — Status
+
+_Last updated: 2026-06-14 (WAL design notes added)_
+
+## What shipped (PR #97, branch `feat/coordinate-subcommand`)
+
+- `hotspots coordinate --files a.rs,b.rs` — pre-flight coordination signal tool
+- Outputs: within-set co-change pairs, hidden dependencies (files outside the set that co-change with input files), ownership signals (90-day author concentration), parallel/serialize partition recommendation
+- JSON auto-selected when stdout is not a TTY; `--json` / `--text` force explicitly
+- Hidden deps filtered to coupling_ratio ≥ 0.7 and capped at 10 in JSON (`hidden_dependencies_omitted` count for overflow) — high-signal only, keeps token footprint small
+- 13 integration tests covering partition logic, hidden dep detection, real git history, edge cases
+- `docs/guide/claude-code-integration.md` — CLAUDE.md snippet for drop-in Claude Code adoption
+
+## Why it matters
+
+Current agent orchestration frameworks decompose tasks by capability. Nobody uses **codebase topology as a parallelization constraint**. Hotspots already has the signals (co-change, ownership, defect history) — `coordinate` exposes them to an orchestration layer. See `resummarize_crdt.txt` for the full framing.
+
+## Drop-in adoption path (current)
+
+Users paste the snippet from `docs/guide/claude-code-integration.md` into their repo's `CLAUDE.md`. Claude Code reads it and calls `hotspots coordinate` before splitting work. No MCP server needed — hotspots is already a CLI tool people install.
+
+## Next steps (not started, rough priority order)
+
+### 1. Function-level coordinate
+`hotspots coordinate --files auth.rs --level function` — partition at function granularity, not file. Two agents could safely work on the same file if their function scopes don't co-change. Requires per-function co-change mining (precedent: `--per-function-touches` already exists).
+
+**Function identity**: use fully-qualified name (`module::function`) as the primary key — already what hotspots mines. Rename tracking is a future concern; FQN breaks on rename but renames are rare compared to edits.
+
+### 2. Local WAL for in-flight claims
+`.hotspots/coordinate.wal` — append-only log of agent claims/releases on function/file scopes. Orchestrator writes claims before spawning agents, reads WAL on mid-task discovery to re-partition. Entries are hotspots primitives only (function IDs, file paths, coupling ratios).
+
+Format sketch:
+```json
+{"ts": 1718123456, "agent": "agent-1", "op": "claim", "scope": "auth.rs::validate_token"}
+{"ts": 1718123489, "agent": "agent-1", "op": "release", "scope": "auth.rs::validate_token"}
+```
+
+`hotspots coordinate --check-wal` factors live claims into the partition recommendation.
+
+**Expiry**: v1 uses explicit release only + `--reset-wal` escape hatch. Lease TTL (`expires_at`) can be added once we see what failure modes actually appear in practice.
+
+**Read model**: the partition is derived state, computed at read time — never stored. On `--check-wal`, read all entries → filter released/expired → build `scope → agent` map → subtract claimed scopes from the hotspots partition recommendation. The store is dumb append + read; conflict resolution happens in the reader.
+
+**`WalStore` abstraction** (the key design decision): the store exposes two operations only:
+```rust
+trait WalStore {
+    fn append(&mut self, entry: WalEntry) -> Result<()>;
+    fn entries(&self) -> Result<Vec<WalEntry>>;
+}
+```
+`LocalWalStore` writes line-delimited JSON to `.hotspots/coordinate.wal` with `O_APPEND`. A remote backend is a drop-in swap — the partition logic doesn't change.
+
+### 3. Remote WAL / multi-machine
+Same protocol, pluggable backend via `WalStore`. WAL entries need to be mergeable without a central lock — grow-only set per function ID is the minimal CRDT that fits. Relevant when agents run on separate machines.
+
+**Concurrent claim race**: two agents can both see a scope as unclaimed and both claim it. Options: compare-and-swap at the store layer (Redis SET NX), or optimistic retry in the coordinator (re-read WAL after claiming, back off on conflict). Decision deferred until we have a real workload to test against.
+
+### 4. Partition explainability
+A `reason` field (or `--explain` flag) on the partition output — which coupling signal drove two files into the same partition. Makes the output debuggable and builds trust. Low effort once the WAL read model is in place.
+
+### 5. MCP server
+Expose `coordinate` as an MCP tool so Claude Code picks it up from `.mcp.json` without any CLAUDE.md configuration. Better drop-in story for wider adoption. Only worth the effort when there are users asking for it.
+
+## Deferred / out of scope for now
+
+- Encryption on WAL entries (add after compression/transport layer is settled)
+- General-purpose message bus (coordinate is scoped to hotspots primitives only)
+- Live broadcast / push mode (re-check is pull-based; push requires agent-to-agent protocol hotspots doesn't own)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -435,6 +435,147 @@ hotspots analyze src/ --mode snapshot --format json --explain-patterns
 
 ---
 
+### `hotspots coordinate`
+
+Assess coordination risk for a set of files before multi-agent or multi-developer work begins.
+
+Reads co-change history, file ownership, and coupling signals that Hotspots already computes — no new data sources, no cloud dependency. Outputs raw signal values so the caller can decide what they mean; no risk tier label is applied.
+
+**Intended use:** run once before decomposing a task across agents or developers to discover hidden co-change dependencies and determine which files are safe to modify in parallel.
+
+#### Usage
+
+```bash
+hotspots coordinate --files <file1,file2,...> [--path <repo>] [--json]
+```
+
+#### Options
+
+##### `--files <list>`
+
+**Required.** Comma-separated list of files to assess, relative to the repo root.
+
+```bash
+hotspots coordinate --files auth.rs,session.rs,middleware.rs
+```
+
+##### `--path <dir>`
+
+Path to the repository root. Defaults to the current directory.
+
+```bash
+hotspots coordinate --files auth.rs --path /path/to/repo
+```
+
+##### `--json`
+
+Emit machine-readable JSON instead of human-readable text. The schema is stable and suitable for scripted or orchestrator consumption.
+
+#### Output (text)
+
+```
+Coordination Signal Report
+============================================================
+
+Input files (3)
+  auth.rs
+  session.rs
+  middleware.rs
+
+Co-change pairs (within set)
+  pair                                               count    ratio
+  -----------------------------------------------------------------
+  auth.rs ↔ session.rs                                   8     0.89
+
+Hidden dependencies (outside input set)
+  input file                partner                    count    ratio
+  -------------------------------------------------------------------
+  auth.rs                   token.rs                       5     0.71
+
+Ownership (last 90 days)
+  file                                      authors  top author %
+  -----------------------------------------------------------------
+  auth.rs                                         1          100%
+  session.rs                                      2           75%
+  middleware.rs                                   1          100%
+
+Partition recommendation
+  Parallel-safe:
+    middleware.rs
+  Serialize (coupling ratio ≥ 40%):
+    auth.rs
+    session.rs
+```
+
+#### Output (JSON, `--json`)
+
+```json
+{
+  "input_files": ["auth.rs", "session.rs", "middleware.rs"],
+  "pairs": [
+    {
+      "files": ["auth.rs", "session.rs"],
+      "co_change_count": 8,
+      "coupling_ratio": 0.89,
+      "has_static_dep": false
+    }
+  ],
+  "hidden_dependencies": [
+    {
+      "input_file": "auth.rs",
+      "partner": "token.rs",
+      "co_change_count": 5,
+      "coupling_ratio": 0.71
+    }
+  ],
+  "ownership": [
+    { "file": "auth.rs", "author_count": 1, "top_author_pct": 1.0 },
+    { "file": "session.rs", "author_count": 2, "top_author_pct": 0.75 },
+    { "file": "middleware.rs", "author_count": 1, "top_author_pct": 1.0 }
+  ],
+  "parallel_safe": ["middleware.rs"],
+  "serialize": ["auth.rs", "session.rs"]
+}
+```
+
+#### Field reference
+
+| Field | Description |
+|---|---|
+| `pairs` | Co-change pairs where **both** files are in the input set, sorted by `coupling_ratio` descending |
+| `pairs[].coupling_ratio` | `co_change_count / min(total_touches_a, total_touches_b)` — fraction of the less-active file's commits that include the partner |
+| `pairs[].has_static_dep` | `true` if a direct import exists between the two files (co-change is structurally expected) |
+| `hidden_dependencies` | Co-change partners that are **outside** the input set, sorted by `coupling_ratio` descending |
+| `ownership[].author_count` | Distinct commit-author emails for this file in the last 90 days |
+| `ownership[].top_author_pct` | Fraction of those commits owned by the single most active author |
+| `parallel_safe` | Input files with no within-set pair at or above the serialize threshold (40%) |
+| `serialize` | Input files that share a high-coupling within-set pair — coordinate these changes sequentially |
+
+#### Signals and thresholds
+
+| Signal | Source | Window |
+|---|---|---|
+| Co-change pairs | `git log --name-only` | 180 days |
+| Ownership | `git log --format=%ae` per file | 90 days |
+| Serialize threshold | `coupling_ratio ≥ 0.40` | — |
+
+The serialize threshold is a partition heuristic, not a risk score. A pair at 0.40 means 40% of the less-touched file's commits also touched the other — high enough that uncoordinated parallel edits carry meaningful collision risk.
+
+#### Examples
+
+```bash
+# Human-readable pre-flight check
+hotspots coordinate --files auth.rs,session.rs,middleware.rs
+
+# JSON output for an orchestrator script
+hotspots coordinate --files auth.rs,session.rs --json
+
+# Run against a different repo
+hotspots coordinate --files src/db.go,src/cache.go --path /repos/myservice --json
+```
+
+---
+
 ### `hotspots train`
 
 Fit a local RandomForest ranker from the repo's own fix-commit git history.

--- a/hotspots-cli/Cargo.toml
+++ b/hotspots-cli/Cargo.toml
@@ -20,6 +20,8 @@ path = "src/main.rs"
 hotspots-core = { version = "1.24.0", path = "../hotspots-core" }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 indicatif = "0.17"
 is-terminal = "0.4"
 owo-colors = "4"

--- a/hotspots-cli/src/cmd/coordinate.rs
+++ b/hotspots-cli/src/cmd/coordinate.rs
@@ -1,0 +1,289 @@
+use anyhow::Context;
+use hotspots_core::git::{extract_co_change_pairs, CoChangePair};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::process::Command;
+
+const CO_CHANGE_WINDOW_DAYS: u64 = 180;
+const CO_CHANGE_MIN_COUNT: usize = 2;
+/// coupling_ratio above this → serialize recommendation
+const SERIALIZE_THRESHOLD: f64 = 0.4;
+/// Author window for ownership computation
+const OWNERSHIP_WINDOW_DAYS: u64 = 90;
+
+pub(crate) struct CoordinateArgs {
+    pub path: PathBuf,
+    pub files: Vec<String>,
+    pub json: bool,
+}
+
+#[derive(Serialize)]
+struct PairSignal {
+    files: [String; 2],
+    co_change_count: usize,
+    coupling_ratio: f64,
+    has_static_dep: bool,
+}
+
+#[derive(Serialize)]
+struct HiddenDep {
+    input_file: String,
+    partner: String,
+    co_change_count: usize,
+    coupling_ratio: f64,
+}
+
+#[derive(Serialize)]
+struct OwnershipSignal {
+    file: String,
+    author_count: usize,
+    top_author_pct: f64,
+}
+
+#[derive(Serialize)]
+struct CoordinateOutput {
+    input_files: Vec<String>,
+    pairs: Vec<PairSignal>,
+    hidden_dependencies: Vec<HiddenDep>,
+    ownership: Vec<OwnershipSignal>,
+    parallel_safe: Vec<String>,
+    serialize: Vec<String>,
+}
+
+pub(crate) fn handle_coordinate(args: CoordinateArgs) -> anyhow::Result<()> {
+    let repo_root = crate::util::find_repo_root(&args.path)?;
+
+    let input: HashSet<String> = args.files.iter().cloned().collect();
+
+    let all_pairs = extract_co_change_pairs(&repo_root, CO_CHANGE_WINDOW_DAYS, CO_CHANGE_MIN_COUNT)
+        .context("failed to extract co-change pairs")?;
+
+    let (within, hidden) = partition_pairs(&all_pairs, &input);
+
+    let ownership = compute_ownership(&repo_root, &args.files)?;
+
+    // Files that appear in any serialize-worthy pair
+    let mut must_serialize: HashSet<&str> = HashSet::new();
+    for p in &within {
+        if p.coupling_ratio >= SERIALIZE_THRESHOLD {
+            must_serialize.insert(p.file_a.as_str());
+            must_serialize.insert(p.file_b.as_str());
+        }
+    }
+
+    let mut parallel_safe: Vec<String> = args
+        .files
+        .iter()
+        .filter(|f| !must_serialize.contains(f.as_str()))
+        .cloned()
+        .collect();
+    let mut serialize: Vec<String> = args
+        .files
+        .iter()
+        .filter(|f| must_serialize.contains(f.as_str()))
+        .cloned()
+        .collect();
+    parallel_safe.sort();
+    serialize.sort();
+
+    let pairs: Vec<PairSignal> = within
+        .iter()
+        .map(|p| PairSignal {
+            files: [p.file_a.clone(), p.file_b.clone()],
+            co_change_count: p.co_change_count,
+            coupling_ratio: p.coupling_ratio,
+            has_static_dep: p.has_static_dep,
+        })
+        .collect();
+
+    let hidden_deps: Vec<HiddenDep> = hidden
+        .iter()
+        .map(|(input_file, partner, pair)| HiddenDep {
+            input_file: input_file.clone(),
+            partner: partner.clone(),
+            co_change_count: pair.co_change_count,
+            coupling_ratio: pair.coupling_ratio,
+        })
+        .collect();
+
+    let output = CoordinateOutput {
+        input_files: args.files.clone(),
+        pairs,
+        hidden_dependencies: hidden_deps,
+        ownership,
+        parallel_safe,
+        serialize,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_text(&output);
+    }
+
+    Ok(())
+}
+
+/// Split all co-change pairs into:
+/// - within: both files in input set
+/// - hidden: exactly one file in input set (the tuple is (input_file, partner, pair))
+fn partition_pairs<'a>(
+    pairs: &'a [CoChangePair],
+    input: &HashSet<String>,
+) -> (
+    Vec<&'a CoChangePair>,
+    Vec<(String, String, &'a CoChangePair)>,
+) {
+    let mut within = Vec::new();
+    let mut hidden = Vec::new();
+
+    for pair in pairs {
+        let a_in = input.contains(&pair.file_a);
+        let b_in = input.contains(&pair.file_b);
+        match (a_in, b_in) {
+            (true, true) => within.push(pair),
+            (true, false) => hidden.push((pair.file_a.clone(), pair.file_b.clone(), pair)),
+            (false, true) => hidden.push((pair.file_b.clone(), pair.file_a.clone(), pair)),
+            (false, false) => {}
+        }
+    }
+
+    within.sort_by(|a, b| b.coupling_ratio.partial_cmp(&a.coupling_ratio).unwrap());
+    hidden.sort_by(|a, b| b.2.coupling_ratio.partial_cmp(&a.2.coupling_ratio).unwrap());
+
+    (within, hidden)
+}
+
+/// Compute per-file ownership signals from git log over the last OWNERSHIP_WINDOW_DAYS.
+fn compute_ownership(
+    repo_root: &std::path::Path,
+    files: &[String],
+) -> anyhow::Result<Vec<OwnershipSignal>> {
+    let mut result = Vec::new();
+    let since = format!("{} days ago", OWNERSHIP_WINDOW_DAYS);
+
+    for file in files {
+        let out = Command::new("git")
+            .args([
+                "--git-dir",
+                repo_root.join(".git").to_string_lossy().as_ref(),
+                "--work-tree",
+                repo_root.to_string_lossy().as_ref(),
+                "log",
+                "--format=%ae",
+                &format!("--since={}", since),
+                "--",
+                file,
+            ])
+            .output();
+
+        let emails: Vec<String> = match out {
+            Ok(o) if !o.stdout.is_empty() => String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.to_lowercase())
+                .collect(),
+            _ => vec![],
+        };
+
+        if emails.is_empty() {
+            result.push(OwnershipSignal {
+                file: file.clone(),
+                author_count: 0,
+                top_author_pct: 0.0,
+            });
+            continue;
+        }
+
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for email in &emails {
+            *counts.entry(email.clone()).or_insert(0) += 1;
+        }
+        let author_count = counts.len();
+        let top = counts.values().copied().max().unwrap_or(0);
+        let top_author_pct = top as f64 / emails.len() as f64;
+
+        result.push(OwnershipSignal {
+            file: file.clone(),
+            author_count,
+            top_author_pct,
+        });
+    }
+
+    Ok(result)
+}
+
+fn print_text(out: &CoordinateOutput) {
+    println!("Coordination Signal Report");
+    println!("{}", "=".repeat(60));
+
+    println!("\nInput files ({})", out.input_files.len());
+    for f in &out.input_files {
+        println!("  {}", f);
+    }
+
+    if out.pairs.is_empty() {
+        println!("\nCo-change pairs (within set): none");
+    } else {
+        println!("\nCo-change pairs (within set)");
+        println!("  {:<45} {:>8}  {:>8}", "pair", "count", "ratio");
+        println!("  {}", "-".repeat(65));
+        for p in &out.pairs {
+            let pair_str = format!("{} ↔ {}", p.files[0], p.files[1]);
+            let dep_note = if p.has_static_dep { " [import]" } else { "" };
+            println!(
+                "  {:<45} {:>8}  {:>7.2}{}",
+                pair_str, p.co_change_count, p.coupling_ratio, dep_note
+            );
+        }
+    }
+
+    if out.hidden_dependencies.is_empty() {
+        println!("\nHidden dependencies: none");
+    } else {
+        println!("\nHidden dependencies (outside input set)");
+        println!(
+            "  {:<25} {:<25} {:>8}  {:>8}",
+            "input file", "partner", "count", "ratio"
+        );
+        println!("  {}", "-".repeat(70));
+        for h in &out.hidden_dependencies {
+            println!(
+                "  {:<25} {:<25} {:>8}  {:>7.2}",
+                h.input_file, h.partner, h.co_change_count, h.coupling_ratio
+            );
+        }
+    }
+
+    println!("\nOwnership (last 90 days)");
+    println!("  {:<40} {:>8}  {:>12}", "file", "authors", "top author %");
+    println!("  {}", "-".repeat(65));
+    for o in &out.ownership {
+        println!(
+            "  {:<40} {:>8}  {:>11.0}%",
+            o.file,
+            o.author_count,
+            o.top_author_pct * 100.0
+        );
+    }
+
+    println!("\nPartition recommendation");
+    if out.serialize.is_empty() {
+        println!("  All files appear safe to modify in parallel.");
+    } else {
+        if !out.parallel_safe.is_empty() {
+            println!("  Parallel-safe:");
+            for f in &out.parallel_safe {
+                println!("    {}", f);
+            }
+        }
+        println!(
+            "  Serialize (high coupling ratio ≥ {:.0}%):",
+            SERIALIZE_THRESHOLD * 100.0
+        );
+        for f in &out.serialize {
+            println!("    {}", f);
+        }
+    }
+}

--- a/hotspots-cli/src/cmd/coordinate.rs
+++ b/hotspots-cli/src/cmd/coordinate.rs
@@ -1,3 +1,4 @@
+use crate::CoordinateLevel;
 use hotspots_core::coordinate::{CoordinateReport, HIDDEN_JSON_CAP, SERIALIZE_THRESHOLD};
 use serde::Serialize;
 use std::path::PathBuf;
@@ -5,6 +6,7 @@ use std::path::PathBuf;
 pub(crate) struct CoordinateArgs {
     pub path: PathBuf,
     pub files: Vec<String>,
+    pub level: CoordinateLevel,
     pub json: bool,
 }
 
@@ -49,7 +51,12 @@ fn is_zero(n: &usize) -> bool {
 
 pub(crate) fn handle_coordinate(args: CoordinateArgs) -> anyhow::Result<()> {
     let repo_root = crate::util::find_repo_root(&args.path)?;
-    let report = hotspots_core::coordinate::coordinate(&repo_root, &args.files)?;
+    let report = match args.level {
+        CoordinateLevel::File => hotspots_core::coordinate::coordinate(&repo_root, &args.files)?,
+        CoordinateLevel::Function => {
+            hotspots_core::coordinate::coordinate_functions(&repo_root, &args.files)?
+        }
+    };
 
     if args.json {
         println!("{}", to_json(&report)?);

--- a/hotspots-cli/src/cmd/coordinate.rs
+++ b/hotspots-cli/src/cmd/coordinate.rs
@@ -92,85 +92,156 @@ fn to_json(r: &CoordinateReport) -> anyhow::Result<String> {
     Ok(serde_json::to_string_pretty(&out)?)
 }
 
+const HIDDEN_TEXT_CAP: usize = 15;
+const MAX_PATH_WIDTH: usize = 50;
+
+fn sep(width: usize) {
+    println!("{}", "─".repeat(width));
+}
+
 fn print_text(out: &CoordinateReport) {
     println!("Coordination Signal Report");
-    println!("{}", "=".repeat(60));
+    sep(60);
 
-    println!("\nInput files ({})", out.input_files.len());
-    for f in &out.input_files {
-        println!("  {}", f);
-    }
-
+    // ── co-change pairs (within set) ─────────────────────────────
+    println!();
     if out.pairs.is_empty() {
-        println!("\nCo-change pairs (within set): none");
+        println!("Co-change pairs     none");
     } else {
-        println!("\nCo-change pairs (within set)");
-        println!("  {:<45} {:>8}  {:>8}", "pair", "count", "ratio");
-        println!("  {}", "-".repeat(65));
+        let pair_w = out
+            .pairs
+            .iter()
+            .map(|p| {
+                crate::util::truncate_string(
+                    &format!("{} ↔ {}", p.file_a, p.file_b),
+                    MAX_PATH_WIDTH * 2 + 3,
+                )
+                .len()
+            })
+            .max()
+            .unwrap_or(4)
+            .max("pair".len());
+        let total_w = pair_w + 8 + 7 + 6; // pair + count + ratio + spacing
+        println!("Co-change pairs");
+        println!(
+            "  {:<pair_w$}  {:>5}  {:>5}  dep",
+            "pair",
+            "count",
+            "ratio",
+            pair_w = pair_w
+        );
+        sep(total_w + 2);
         for p in &out.pairs {
-            let pair_str = format!("{} ↔ {}", p.file_a, p.file_b);
-            let dep_note = if p.has_static_dep { " [import]" } else { "" };
+            let pair_str = crate::util::truncate_string(
+                &format!("{} ↔ {}", p.file_a, p.file_b),
+                MAX_PATH_WIDTH * 2 + 3,
+            );
+            let dep = if p.has_static_dep { "import" } else { "" };
             println!(
-                "  {:<45} {:>8}  {:>7.2}{}",
-                pair_str, p.co_change_count, p.coupling_ratio, dep_note
+                "  {:<pair_w$}  {:>5}  {:>5.2}  {}",
+                pair_str,
+                p.co_change_count,
+                p.coupling_ratio,
+                dep,
+                pair_w = pair_w
             );
         }
     }
 
-    const HIDDEN_TEXT_CAP: usize = 15;
+    // ── hidden dependencies ──────────────────────────────────────
+    println!();
+    let shown_deps = out.hidden_dependencies.len().min(HIDDEN_TEXT_CAP);
+    let overflow = out
+        .hidden_dependencies
+        .len()
+        .saturating_sub(HIDDEN_TEXT_CAP);
     if out.hidden_dependencies.is_empty() {
-        println!("\nHidden dependencies: none");
+        println!("Hidden dependencies  none");
     } else {
-        let shown = out.hidden_dependencies.len().min(HIDDEN_TEXT_CAP);
-        let overflow = out
-            .hidden_dependencies
-            .len()
-            .saturating_sub(HIDDEN_TEXT_CAP);
-        println!("\nHidden dependencies (outside input set)");
+        let visible = &out.hidden_dependencies[..shown_deps];
+        let input_w = visible
+            .iter()
+            .map(|h| crate::util::truncate_string(&h.input_file, MAX_PATH_WIDTH).len())
+            .max()
+            .unwrap_or(10)
+            .max("input file".len());
+        let partner_w = visible
+            .iter()
+            .map(|h| crate::util::truncate_string(&h.partner, MAX_PATH_WIDTH).len())
+            .max()
+            .unwrap_or(7)
+            .max("partner".len());
+        let total_w = input_w + partner_w + 8 + 7 + 6;
+        println!("Hidden dependencies  (co-change partners outside input set)");
         println!(
-            "  {:<25} {:<25} {:>8}  {:>8}",
-            "input file", "partner", "count", "ratio"
+            "  {:<input_w$}  {:<partner_w$}  {:>5}  {:>5}",
+            "input file",
+            "partner",
+            "count",
+            "ratio",
+            input_w = input_w,
+            partner_w = partner_w
         );
-        println!("  {}", "-".repeat(70));
-        for h in &out.hidden_dependencies[..shown] {
+        sep(total_w + 2);
+        for h in visible {
             println!(
-                "  {:<25} {:<25} {:>8}  {:>7.2}",
-                h.input_file, h.partner, h.co_change_count, h.coupling_ratio
+                "  {:<input_w$}  {:<partner_w$}  {:>5}  {:>5.2}",
+                crate::util::truncate_string(&h.input_file, MAX_PATH_WIDTH),
+                crate::util::truncate_string(&h.partner, MAX_PATH_WIDTH),
+                h.co_change_count,
+                h.coupling_ratio,
+                input_w = input_w,
+                partner_w = partner_w
             );
         }
         if overflow > 0 {
-            println!("  ... {} more — use --json for full list", overflow);
+            println!("  … {} more  (--json for full list)", overflow);
         }
     }
 
-    println!("\nOwnership (last 90 days)");
-    println!("  {:<40} {:>8}  {:>12}", "file", "authors", "top author %");
-    println!("  {}", "-".repeat(65));
+    // ── ownership ────────────────────────────────────────────────
+    println!();
+    let file_w = out
+        .ownership
+        .iter()
+        .map(|o| crate::util::truncate_string(&o.file, MAX_PATH_WIDTH).len())
+        .max()
+        .unwrap_or(4)
+        .max("file".len());
+    let total_w = file_w + 8 + 13 + 6;
+    println!("Ownership  (last 90 days)");
+    println!(
+        "  {:<file_w$}  {:>7}  {:>11}",
+        "file",
+        "authors",
+        "top author %",
+        file_w = file_w
+    );
+    sep(total_w + 2);
     for o in &out.ownership {
         println!(
-            "  {:<40} {:>8}  {:>11.0}%",
-            o.file,
+            "  {:<file_w$}  {:>7}  {:>10.0}%",
+            crate::util::truncate_string(&o.file, MAX_PATH_WIDTH),
             o.author_count,
-            o.top_author_pct * 100.0
+            o.top_author_pct * 100.0,
+            file_w = file_w
         );
     }
 
-    println!("\nPartition recommendation");
+    // ── partition recommendation ─────────────────────────────────
+    println!();
+    println!("Partition recommendation");
+    sep(60);
     if out.serialize.is_empty() {
-        println!("  All files appear safe to modify in parallel.");
+        println!("  All input files are safe to modify in parallel.");
     } else {
         if !out.parallel_safe.is_empty() {
-            println!("  Parallel-safe:");
-            for f in &out.parallel_safe {
-                println!("    {}", f);
-            }
+            println!("  parallel   {}", out.parallel_safe.join("  "));
         }
         println!(
-            "  Serialize (coupling ratio ≥ {:.0}%):",
+            "  serialize  {}  (coupling ≥ {:.0}%)",
+            out.serialize.join("  "),
             SERIALIZE_THRESHOLD * 100.0
         );
-        for f in &out.serialize {
-            println!("    {}", f);
-        }
     }
 }

--- a/hotspots-cli/src/cmd/coordinate.rs
+++ b/hotspots-cli/src/cmd/coordinate.rs
@@ -1,4 +1,4 @@
-use hotspots_core::coordinate::{CoordinateReport, SERIALIZE_THRESHOLD};
+use hotspots_core::coordinate::{CoordinateReport, HIDDEN_JSON_CAP, SERIALIZE_THRESHOLD};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -36,9 +36,15 @@ struct JsonOutput {
     input_files: Vec<String>,
     pairs: Vec<PairSignal>,
     hidden_dependencies: Vec<HiddenDep>,
+    #[serde(skip_serializing_if = "is_zero")]
+    hidden_dependencies_omitted: usize,
     ownership: Vec<OwnershipSignal>,
     parallel_safe: Vec<String>,
     serialize: Vec<String>,
+}
+
+fn is_zero(n: &usize) -> bool {
+    *n == 0
 }
 
 pub(crate) fn handle_coordinate(args: CoordinateArgs) -> anyhow::Result<()> {
@@ -55,6 +61,8 @@ pub(crate) fn handle_coordinate(args: CoordinateArgs) -> anyhow::Result<()> {
 }
 
 fn to_json(r: &CoordinateReport) -> anyhow::Result<String> {
+    let hidden_cap = r.hidden_dependencies.len().min(HIDDEN_JSON_CAP);
+    let hidden_omitted = r.hidden_dependencies.len().saturating_sub(HIDDEN_JSON_CAP);
     let out = JsonOutput {
         input_files: r.input_files.clone(),
         pairs: r
@@ -67,8 +75,7 @@ fn to_json(r: &CoordinateReport) -> anyhow::Result<String> {
                 has_static_dep: p.has_static_dep,
             })
             .collect(),
-        hidden_dependencies: r
-            .hidden_dependencies
+        hidden_dependencies: r.hidden_dependencies[..hidden_cap]
             .iter()
             .map(|h| HiddenDep {
                 input_file: h.input_file.clone(),
@@ -77,6 +84,7 @@ fn to_json(r: &CoordinateReport) -> anyhow::Result<String> {
                 coupling_ratio: h.coupling_ratio,
             })
             .collect(),
+        hidden_dependencies_omitted: hidden_omitted,
         ownership: r
             .ownership
             .iter()

--- a/hotspots-cli/src/cmd/coordinate.rs
+++ b/hotspots-cli/src/cmd/coordinate.rs
@@ -117,20 +117,29 @@ fn print_text(out: &CoordinateReport) {
         }
     }
 
+    const HIDDEN_TEXT_CAP: usize = 15;
     if out.hidden_dependencies.is_empty() {
         println!("\nHidden dependencies: none");
     } else {
+        let shown = out.hidden_dependencies.len().min(HIDDEN_TEXT_CAP);
+        let overflow = out
+            .hidden_dependencies
+            .len()
+            .saturating_sub(HIDDEN_TEXT_CAP);
         println!("\nHidden dependencies (outside input set)");
         println!(
             "  {:<25} {:<25} {:>8}  {:>8}",
             "input file", "partner", "count", "ratio"
         );
         println!("  {}", "-".repeat(70));
-        for h in &out.hidden_dependencies {
+        for h in &out.hidden_dependencies[..shown] {
             println!(
                 "  {:<25} {:<25} {:>8}  {:>7.2}",
                 h.input_file, h.partner, h.co_change_count, h.coupling_ratio
             );
+        }
+        if overflow > 0 {
+            println!("  ... {} more — use --json for full list", overflow);
         }
     }
 

--- a/hotspots-cli/src/cmd/coordinate.rs
+++ b/hotspots-cli/src/cmd/coordinate.rs
@@ -1,16 +1,6 @@
-use anyhow::Context;
-use hotspots_core::git::{extract_co_change_pairs, CoChangePair};
+use hotspots_core::coordinate::{CoordinateReport, SERIALIZE_THRESHOLD};
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::process::Command;
-
-const CO_CHANGE_WINDOW_DAYS: u64 = 180;
-const CO_CHANGE_MIN_COUNT: usize = 2;
-/// coupling_ratio above this → serialize recommendation
-const SERIALIZE_THRESHOLD: f64 = 0.4;
-/// Author window for ownership computation
-const OWNERSHIP_WINDOW_DAYS: u64 = 90;
 
 pub(crate) struct CoordinateArgs {
     pub path: PathBuf,
@@ -42,7 +32,7 @@ struct OwnershipSignal {
 }
 
 #[derive(Serialize)]
-struct CoordinateOutput {
+struct JsonOutput {
     input_files: Vec<String>,
     pairs: Vec<PairSignal>,
     hidden_dependencies: Vec<HiddenDep>,
@@ -53,168 +43,56 @@ struct CoordinateOutput {
 
 pub(crate) fn handle_coordinate(args: CoordinateArgs) -> anyhow::Result<()> {
     let repo_root = crate::util::find_repo_root(&args.path)?;
-
-    let input: HashSet<String> = args.files.iter().cloned().collect();
-
-    let all_pairs = extract_co_change_pairs(&repo_root, CO_CHANGE_WINDOW_DAYS, CO_CHANGE_MIN_COUNT)
-        .context("failed to extract co-change pairs")?;
-
-    let (within, hidden) = partition_pairs(&all_pairs, &input);
-
-    let ownership = compute_ownership(&repo_root, &args.files)?;
-
-    // Files that appear in any serialize-worthy pair
-    let mut must_serialize: HashSet<&str> = HashSet::new();
-    for p in &within {
-        if p.coupling_ratio >= SERIALIZE_THRESHOLD {
-            must_serialize.insert(p.file_a.as_str());
-            must_serialize.insert(p.file_b.as_str());
-        }
-    }
-
-    let mut parallel_safe: Vec<String> = args
-        .files
-        .iter()
-        .filter(|f| !must_serialize.contains(f.as_str()))
-        .cloned()
-        .collect();
-    let mut serialize: Vec<String> = args
-        .files
-        .iter()
-        .filter(|f| must_serialize.contains(f.as_str()))
-        .cloned()
-        .collect();
-    parallel_safe.sort();
-    serialize.sort();
-
-    let pairs: Vec<PairSignal> = within
-        .iter()
-        .map(|p| PairSignal {
-            files: [p.file_a.clone(), p.file_b.clone()],
-            co_change_count: p.co_change_count,
-            coupling_ratio: p.coupling_ratio,
-            has_static_dep: p.has_static_dep,
-        })
-        .collect();
-
-    let hidden_deps: Vec<HiddenDep> = hidden
-        .iter()
-        .map(|(input_file, partner, pair)| HiddenDep {
-            input_file: input_file.clone(),
-            partner: partner.clone(),
-            co_change_count: pair.co_change_count,
-            coupling_ratio: pair.coupling_ratio,
-        })
-        .collect();
-
-    let output = CoordinateOutput {
-        input_files: args.files.clone(),
-        pairs,
-        hidden_dependencies: hidden_deps,
-        ownership,
-        parallel_safe,
-        serialize,
-    };
+    let report = hotspots_core::coordinate::coordinate(&repo_root, &args.files)?;
 
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        println!("{}", to_json(&report)?);
     } else {
-        print_text(&output);
+        print_text(&report);
     }
 
     Ok(())
 }
 
-/// Split all co-change pairs into:
-/// - within: both files in input set
-/// - hidden: exactly one file in input set (the tuple is (input_file, partner, pair))
-fn partition_pairs<'a>(
-    pairs: &'a [CoChangePair],
-    input: &HashSet<String>,
-) -> (
-    Vec<&'a CoChangePair>,
-    Vec<(String, String, &'a CoChangePair)>,
-) {
-    let mut within = Vec::new();
-    let mut hidden = Vec::new();
-
-    for pair in pairs {
-        let a_in = input.contains(&pair.file_a);
-        let b_in = input.contains(&pair.file_b);
-        match (a_in, b_in) {
-            (true, true) => within.push(pair),
-            (true, false) => hidden.push((pair.file_a.clone(), pair.file_b.clone(), pair)),
-            (false, true) => hidden.push((pair.file_b.clone(), pair.file_a.clone(), pair)),
-            (false, false) => {}
-        }
-    }
-
-    within.sort_by(|a, b| b.coupling_ratio.partial_cmp(&a.coupling_ratio).unwrap());
-    hidden.sort_by(|a, b| b.2.coupling_ratio.partial_cmp(&a.2.coupling_ratio).unwrap());
-
-    (within, hidden)
+fn to_json(r: &CoordinateReport) -> anyhow::Result<String> {
+    let out = JsonOutput {
+        input_files: r.input_files.clone(),
+        pairs: r
+            .pairs
+            .iter()
+            .map(|p| PairSignal {
+                files: [p.file_a.clone(), p.file_b.clone()],
+                co_change_count: p.co_change_count,
+                coupling_ratio: p.coupling_ratio,
+                has_static_dep: p.has_static_dep,
+            })
+            .collect(),
+        hidden_dependencies: r
+            .hidden_dependencies
+            .iter()
+            .map(|h| HiddenDep {
+                input_file: h.input_file.clone(),
+                partner: h.partner.clone(),
+                co_change_count: h.co_change_count,
+                coupling_ratio: h.coupling_ratio,
+            })
+            .collect(),
+        ownership: r
+            .ownership
+            .iter()
+            .map(|o| OwnershipSignal {
+                file: o.file.clone(),
+                author_count: o.author_count,
+                top_author_pct: o.top_author_pct,
+            })
+            .collect(),
+        parallel_safe: r.parallel_safe.clone(),
+        serialize: r.serialize.clone(),
+    };
+    Ok(serde_json::to_string_pretty(&out)?)
 }
 
-/// Compute per-file ownership signals from git log over the last OWNERSHIP_WINDOW_DAYS.
-fn compute_ownership(
-    repo_root: &std::path::Path,
-    files: &[String],
-) -> anyhow::Result<Vec<OwnershipSignal>> {
-    let mut result = Vec::new();
-    let since = format!("{} days ago", OWNERSHIP_WINDOW_DAYS);
-
-    for file in files {
-        let out = Command::new("git")
-            .args([
-                "--git-dir",
-                repo_root.join(".git").to_string_lossy().as_ref(),
-                "--work-tree",
-                repo_root.to_string_lossy().as_ref(),
-                "log",
-                "--format=%ae",
-                &format!("--since={}", since),
-                "--",
-                file,
-            ])
-            .output();
-
-        let emails: Vec<String> = match out {
-            Ok(o) if !o.stdout.is_empty() => String::from_utf8_lossy(&o.stdout)
-                .lines()
-                .filter(|l| !l.trim().is_empty())
-                .map(|l| l.to_lowercase())
-                .collect(),
-            _ => vec![],
-        };
-
-        if emails.is_empty() {
-            result.push(OwnershipSignal {
-                file: file.clone(),
-                author_count: 0,
-                top_author_pct: 0.0,
-            });
-            continue;
-        }
-
-        let mut counts: HashMap<String, usize> = HashMap::new();
-        for email in &emails {
-            *counts.entry(email.clone()).or_insert(0) += 1;
-        }
-        let author_count = counts.len();
-        let top = counts.values().copied().max().unwrap_or(0);
-        let top_author_pct = top as f64 / emails.len() as f64;
-
-        result.push(OwnershipSignal {
-            file: file.clone(),
-            author_count,
-            top_author_pct,
-        });
-    }
-
-    Ok(result)
-}
-
-fn print_text(out: &CoordinateOutput) {
+fn print_text(out: &CoordinateReport) {
     println!("Coordination Signal Report");
     println!("{}", "=".repeat(60));
 
@@ -230,7 +108,7 @@ fn print_text(out: &CoordinateOutput) {
         println!("  {:<45} {:>8}  {:>8}", "pair", "count", "ratio");
         println!("  {}", "-".repeat(65));
         for p in &out.pairs {
-            let pair_str = format!("{} ↔ {}", p.files[0], p.files[1]);
+            let pair_str = format!("{} ↔ {}", p.file_a, p.file_b);
             let dep_note = if p.has_static_dep { " [import]" } else { "" };
             println!(
                 "  {:<45} {:>8}  {:>7.2}{}",
@@ -279,7 +157,7 @@ fn print_text(out: &CoordinateOutput) {
             }
         }
         println!(
-            "  Serialize (high coupling ratio ≥ {:.0}%):",
+            "  Serialize (coupling ratio ≥ {:.0}%):",
             SERIALIZE_THRESHOLD * 100.0
         );
         for f in &out.serialize {

--- a/hotspots-cli/src/cmd/mod.rs
+++ b/hotspots-cli/src/cmd/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod analyze;
 pub(crate) mod compact;
 pub(crate) mod config;
+pub(crate) mod coordinate;
 pub(crate) mod diff;
 pub(crate) mod init;
 pub(crate) mod prune;

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -217,6 +217,20 @@ enum Commands {
         #[arg(long)]
         auto_analyze: bool,
     },
+    /// Assess coordination risk for a set of files before multi-agent or multi-developer work
+    Coordinate {
+        /// Comma-separated list of files to assess (relative to repo root)
+        #[arg(long, value_delimiter = ',', num_args = 1..)]
+        files: Vec<String>,
+
+        /// Path to repository root (default: current directory)
+        #[arg(long, default_value = ".")]
+        path: std::path::PathBuf,
+
+        /// Emit JSON output instead of human-readable text
+        #[arg(long)]
+        json: bool,
+    },
     /// Train a local RandomForest ranker from fix-commit history
     Train {
         /// Path to repository root
@@ -361,6 +375,13 @@ fn main() -> anyhow::Result<()> {
             config_path: config,
             auto_analyze,
         })?,
+        Commands::Coordinate { files, path, json } => {
+            cmd::coordinate::handle_coordinate(cmd::coordinate::CoordinateArgs {
+                path,
+                files,
+                json,
+            })?
+        }
         Commands::Train {
             path,
             output,

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -227,9 +227,13 @@ enum Commands {
         #[arg(long, default_value = ".")]
         path: std::path::PathBuf,
 
-        /// Emit JSON output instead of human-readable text
-        #[arg(long)]
+        /// Force JSON output (default when stdout is not a TTY)
+        #[arg(long, conflicts_with = "text")]
         json: bool,
+
+        /// Force human-readable text output (default when stdout is a TTY)
+        #[arg(long, conflicts_with = "json")]
+        text: bool,
     },
     /// Train a local RandomForest ranker from fix-commit history
     Train {
@@ -375,11 +379,17 @@ fn main() -> anyhow::Result<()> {
             config_path: config,
             auto_analyze,
         })?,
-        Commands::Coordinate { files, path, json } => {
+        Commands::Coordinate {
+            files,
+            path,
+            json,
+            text,
+        } => {
+            let use_json = json || (!text && !std::io::IsTerminal::is_terminal(&std::io::stdout()));
             cmd::coordinate::handle_coordinate(cmd::coordinate::CoordinateArgs {
                 path,
                 files,
-                json,
+                json: use_json,
             })?
         }
         Commands::Train {

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -227,6 +227,10 @@ enum Commands {
         #[arg(long, default_value = ".")]
         path: std::path::PathBuf,
 
+        /// Partition granularity: file (default) or function
+        #[arg(long, default_value = "file")]
+        level: CoordinateLevel,
+
         /// Force JSON output (default when stdout is not a TTY)
         #[arg(long, conflicts_with = "text")]
         json: bool,
@@ -291,6 +295,12 @@ pub(crate) enum OutputMode {
 pub(crate) enum OutputLevel {
     File,
     Module,
+}
+
+#[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
+pub(crate) enum CoordinateLevel {
+    File,
+    Function,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -382,6 +392,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Coordinate {
             files,
             path,
+            level,
             json,
             text,
         } => {
@@ -389,6 +400,7 @@ fn main() -> anyhow::Result<()> {
             cmd::coordinate::handle_coordinate(cmd::coordinate::CoordinateArgs {
                 path,
                 files,
+                level,
                 json: use_json,
             })?
         }

--- a/hotspots-core/src/analysis.rs
+++ b/hotspots-core/src/analysis.rs
@@ -119,6 +119,15 @@ fn looks_vendored(path: &Path) -> bool {
     })
 }
 
+/// Instantiates a parser for a file path, constructing any required internal state.
+/// Used by callers that don't already have a SourceMap (e.g. coordinate).
+pub(crate) fn parser_for_path(path: &Path) -> Result<Box<dyn LanguageParser>> {
+    let language = Language::from_path(path)
+        .ok_or_else(|| anyhow::anyhow!("unsupported file type: {}", path.display()))?;
+    let source_map = Lrc::new(SourceMap::default());
+    create_parser(language, &source_map)
+}
+
 /// Instantiates the correct parser for the given language.
 fn create_parser(
     language: Language,

--- a/hotspots-core/src/coordinate.rs
+++ b/hotspots-core/src/coordinate.rs
@@ -9,6 +9,8 @@ pub const CO_CHANGE_MIN_COUNT: usize = 2;
 /// coupling_ratio at or above this → serialize recommendation
 pub const SERIALIZE_THRESHOLD: f64 = 0.4;
 pub const OWNERSHIP_WINDOW_DAYS: u64 = 90;
+/// Hidden deps with fewer co-changes than this are likely mass-commit artifacts
+pub const HIDDEN_DEP_MIN_COUNT: usize = 3;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PairSignal {
@@ -83,6 +85,10 @@ pub fn coordinate(repo_root: &Path, files: &[String]) -> Result<CoordinateReport
 }
 
 /// Split co-change pairs into within-set and hidden-dep sets.
+///
+/// Hidden deps are filtered to source-like files with at least HIDDEN_DEP_MIN_COUNT
+/// co-changes. Low-count pairs at ratio 1.0 are typically mass-commit artifacts
+/// (release bumps, reformats) that touch non-source files alongside everything else.
 pub fn partition_pairs(
     pairs: &[CoChangePair],
     input: &HashSet<&str>,
@@ -101,26 +107,66 @@ pub fn partition_pairs(
                 coupling_ratio: pair.coupling_ratio,
                 has_static_dep: pair.has_static_dep,
             }),
-            (true, false) => hidden.push(HiddenDep {
-                input_file: pair.file_a.clone(),
-                partner: pair.file_b.clone(),
-                co_change_count: pair.co_change_count,
-                coupling_ratio: pair.coupling_ratio,
-            }),
-            (false, true) => hidden.push(HiddenDep {
-                input_file: pair.file_b.clone(),
-                partner: pair.file_a.clone(),
-                co_change_count: pair.co_change_count,
-                coupling_ratio: pair.coupling_ratio,
-            }),
+            (true, false) => {
+                if pair.co_change_count >= HIDDEN_DEP_MIN_COUNT && is_source_file(&pair.file_b) {
+                    hidden.push(HiddenDep {
+                        input_file: pair.file_a.clone(),
+                        partner: pair.file_b.clone(),
+                        co_change_count: pair.co_change_count,
+                        coupling_ratio: pair.coupling_ratio,
+                    });
+                }
+            }
+            (false, true) => {
+                if pair.co_change_count >= HIDDEN_DEP_MIN_COUNT && is_source_file(&pair.file_a) {
+                    hidden.push(HiddenDep {
+                        input_file: pair.file_b.clone(),
+                        partner: pair.file_a.clone(),
+                        co_change_count: pair.co_change_count,
+                        coupling_ratio: pair.coupling_ratio,
+                    });
+                }
+            }
             (false, false) => {}
         }
     }
 
     within.sort_by(|a, b| b.coupling_ratio.partial_cmp(&a.coupling_ratio).unwrap());
-    hidden.sort_by(|a, b| b.coupling_ratio.partial_cmp(&a.coupling_ratio).unwrap());
+    // Secondary sort by count so ties are deterministic
+    hidden.sort_by(|a, b| {
+        b.coupling_ratio
+            .partial_cmp(&a.coupling_ratio)
+            .unwrap()
+            .then(b.co_change_count.cmp(&a.co_change_count))
+    });
 
     (within, hidden)
+}
+
+/// Returns false for file extensions that are never meaningful coupling partners:
+/// data files, docs, scripts, lock files, CI config, and generated assets.
+fn is_source_file(path: &str) -> bool {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    !matches!(
+        ext,
+        "json"
+            | "md"
+            | "toml"
+            | "lock"
+            | "yaml"
+            | "yml"
+            | "sh"
+            | "txt"
+            | "png"
+            | "svg"
+            | "html"
+            | "css"
+            | "map"
+            | "d.ts"
+    ) && !path.ends_with(".d.ts")
 }
 
 /// Compute per-file ownership signals from git log over OWNERSHIP_WINDOW_DAYS.

--- a/hotspots-core/src/coordinate.rs
+++ b/hotspots-core/src/coordinate.rs
@@ -1,0 +1,181 @@
+use crate::git::{extract_co_change_pairs, CoChangePair};
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::process::Command;
+
+pub const CO_CHANGE_WINDOW_DAYS: u64 = 180;
+pub const CO_CHANGE_MIN_COUNT: usize = 2;
+/// coupling_ratio at or above this → serialize recommendation
+pub const SERIALIZE_THRESHOLD: f64 = 0.4;
+pub const OWNERSHIP_WINDOW_DAYS: u64 = 90;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PairSignal {
+    pub file_a: String,
+    pub file_b: String,
+    pub co_change_count: usize,
+    pub coupling_ratio: f64,
+    pub has_static_dep: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HiddenDep {
+    pub input_file: String,
+    pub partner: String,
+    pub co_change_count: usize,
+    pub coupling_ratio: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OwnershipSignal {
+    pub file: String,
+    pub author_count: usize,
+    pub top_author_pct: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoordinateReport {
+    pub input_files: Vec<String>,
+    pub pairs: Vec<PairSignal>,
+    pub hidden_dependencies: Vec<HiddenDep>,
+    pub ownership: Vec<OwnershipSignal>,
+    pub parallel_safe: Vec<String>,
+    pub serialize: Vec<String>,
+}
+
+pub fn coordinate(repo_root: &Path, files: &[String]) -> Result<CoordinateReport> {
+    let input: HashSet<&str> = files.iter().map(|s| s.as_str()).collect();
+
+    let all_pairs = extract_co_change_pairs(repo_root, CO_CHANGE_WINDOW_DAYS, CO_CHANGE_MIN_COUNT)
+        .unwrap_or_default();
+
+    let (pairs, hidden) = partition_pairs(&all_pairs, &input);
+    let ownership = compute_ownership(repo_root, files)?;
+
+    let must_serialize: HashSet<&str> = pairs
+        .iter()
+        .filter(|p| p.coupling_ratio >= SERIALIZE_THRESHOLD)
+        .flat_map(|p| [p.file_a.as_str(), p.file_b.as_str()])
+        .collect();
+
+    let mut parallel_safe: Vec<String> = files
+        .iter()
+        .filter(|f| !must_serialize.contains(f.as_str()))
+        .cloned()
+        .collect();
+    let mut serialize: Vec<String> = files
+        .iter()
+        .filter(|f| must_serialize.contains(f.as_str()))
+        .cloned()
+        .collect();
+    parallel_safe.sort();
+    serialize.sort();
+
+    Ok(CoordinateReport {
+        input_files: files.to_vec(),
+        pairs,
+        hidden_dependencies: hidden,
+        ownership,
+        parallel_safe,
+        serialize,
+    })
+}
+
+/// Split co-change pairs into within-set and hidden-dep sets.
+pub fn partition_pairs(
+    pairs: &[CoChangePair],
+    input: &HashSet<&str>,
+) -> (Vec<PairSignal>, Vec<HiddenDep>) {
+    let mut within: Vec<PairSignal> = Vec::new();
+    let mut hidden: Vec<HiddenDep> = Vec::new();
+
+    for pair in pairs {
+        let a_in = input.contains(pair.file_a.as_str());
+        let b_in = input.contains(pair.file_b.as_str());
+        match (a_in, b_in) {
+            (true, true) => within.push(PairSignal {
+                file_a: pair.file_a.clone(),
+                file_b: pair.file_b.clone(),
+                co_change_count: pair.co_change_count,
+                coupling_ratio: pair.coupling_ratio,
+                has_static_dep: pair.has_static_dep,
+            }),
+            (true, false) => hidden.push(HiddenDep {
+                input_file: pair.file_a.clone(),
+                partner: pair.file_b.clone(),
+                co_change_count: pair.co_change_count,
+                coupling_ratio: pair.coupling_ratio,
+            }),
+            (false, true) => hidden.push(HiddenDep {
+                input_file: pair.file_b.clone(),
+                partner: pair.file_a.clone(),
+                co_change_count: pair.co_change_count,
+                coupling_ratio: pair.coupling_ratio,
+            }),
+            (false, false) => {}
+        }
+    }
+
+    within.sort_by(|a, b| b.coupling_ratio.partial_cmp(&a.coupling_ratio).unwrap());
+    hidden.sort_by(|a, b| b.coupling_ratio.partial_cmp(&a.coupling_ratio).unwrap());
+
+    (within, hidden)
+}
+
+/// Compute per-file ownership signals from git log over OWNERSHIP_WINDOW_DAYS.
+pub fn compute_ownership(repo_root: &Path, files: &[String]) -> Result<Vec<OwnershipSignal>> {
+    let git_dir = repo_root.join(".git");
+    let since = format!("{} days ago", OWNERSHIP_WINDOW_DAYS);
+    let mut result = Vec::new();
+
+    for file in files {
+        let out = Command::new("git")
+            .args([
+                "--git-dir",
+                git_dir.to_string_lossy().as_ref(),
+                "--work-tree",
+                repo_root.to_string_lossy().as_ref(),
+                "log",
+                "--format=%ae",
+                &format!("--since={}", since),
+                "--",
+                file,
+            ])
+            .output();
+
+        let emails: Vec<String> = match out {
+            Ok(o) if !o.stdout.is_empty() => String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.to_lowercase())
+                .collect(),
+            _ => vec![],
+        };
+
+        if emails.is_empty() {
+            result.push(OwnershipSignal {
+                file: file.clone(),
+                author_count: 0,
+                top_author_pct: 0.0,
+            });
+            continue;
+        }
+
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for email in &emails {
+            *counts.entry(email.clone()).or_insert(0) += 1;
+        }
+        let author_count = counts.len();
+        let top = counts.values().copied().max().unwrap_or(0);
+        let top_author_pct = top as f64 / emails.len() as f64;
+
+        result.push(OwnershipSignal {
+            file: file.clone(),
+            author_count,
+            top_author_pct,
+        });
+    }
+
+    Ok(result)
+}

--- a/hotspots-core/src/coordinate.rs
+++ b/hotspots-core/src/coordinate.rs
@@ -11,6 +11,10 @@ pub const SERIALIZE_THRESHOLD: f64 = 0.4;
 pub const OWNERSHIP_WINDOW_DAYS: u64 = 90;
 /// Hidden deps with fewer co-changes than this are likely mass-commit artifacts
 pub const HIDDEN_DEP_MIN_COUNT: usize = 3;
+/// Hidden deps below this coupling ratio are noise — omit from output
+pub const HIDDEN_DEP_MIN_RATIO: f64 = 0.7;
+/// Max hidden deps emitted in JSON output; remainder reported as omitted_count
+pub const HIDDEN_JSON_CAP: usize = 10;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PairSignal {
@@ -108,7 +112,10 @@ pub fn partition_pairs(
                 has_static_dep: pair.has_static_dep,
             }),
             (true, false) => {
-                if pair.co_change_count >= HIDDEN_DEP_MIN_COUNT && is_source_file(&pair.file_b) {
+                if pair.co_change_count >= HIDDEN_DEP_MIN_COUNT
+                    && pair.coupling_ratio >= HIDDEN_DEP_MIN_RATIO
+                    && is_source_file(&pair.file_b)
+                {
                     hidden.push(HiddenDep {
                         input_file: pair.file_a.clone(),
                         partner: pair.file_b.clone(),
@@ -118,7 +125,10 @@ pub fn partition_pairs(
                 }
             }
             (false, true) => {
-                if pair.co_change_count >= HIDDEN_DEP_MIN_COUNT && is_source_file(&pair.file_a) {
+                if pair.co_change_count >= HIDDEN_DEP_MIN_COUNT
+                    && pair.coupling_ratio >= HIDDEN_DEP_MIN_RATIO
+                    && is_source_file(&pair.file_a)
+                {
                     hidden.push(HiddenDep {
                         input_file: pair.file_b.clone(),
                         partner: pair.file_a.clone(),

--- a/hotspots-core/src/coordinate.rs
+++ b/hotspots-core/src/coordinate.rs
@@ -1,4 +1,4 @@
-use crate::git::{extract_co_change_pairs, CoChangePair};
+use crate::git::{extract_co_change_pairs, extract_function_co_change_pairs, CoChangePair};
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -82,6 +82,95 @@ pub fn coordinate(repo_root: &Path, files: &[String]) -> Result<CoordinateReport
         input_files: files.to_vec(),
         pairs,
         hidden_dependencies: hidden,
+        ownership,
+        parallel_safe,
+        serialize,
+    })
+}
+
+/// Function-level coordinate: partitions at FQN granularity (`file::function`).
+/// Two functions in the same file can appear in different partitions if they
+/// don't co-change. Hidden deps and ownership remain at file level.
+pub fn coordinate_functions(repo_root: &Path, files: &[String]) -> Result<CoordinateReport> {
+    let pairs = extract_function_co_change_pairs(
+        repo_root,
+        files,
+        CO_CHANGE_WINDOW_DAYS,
+        CO_CHANGE_MIN_COUNT,
+    )
+    .unwrap_or_default();
+
+    // Collect all FQNs that appear in any pair
+    let all_fqns: std::collections::HashSet<String> = pairs
+        .iter()
+        .flat_map(|p| [p.file_a.clone(), p.file_b.clone()])
+        .collect();
+
+    // Also include FQNs from files with no co-change pairs (parse them directly)
+    let mut input_fqns: Vec<String> = {
+        use crate::analysis::parser_for_path;
+        let mut fqns = Vec::new();
+        for file in files {
+            let abs_path = repo_root.join(file);
+            if !abs_path.exists() {
+                continue;
+            }
+            let Ok(parser) = parser_for_path(&abs_path) else {
+                continue;
+            };
+            let Ok(source) = std::fs::read_to_string(&abs_path) else {
+                continue;
+            };
+            let Ok(module) = parser.parse(&source, file) else {
+                continue;
+            };
+            for f in module.discover_functions(0, &source) {
+                if let Some(name) = f.name {
+                    fqns.push(format!("{}::{}", file, name));
+                }
+            }
+        }
+        fqns
+    };
+    // Add any FQNs from pairs not already in input_fqns (shouldn't happen but be safe)
+    for fqn in &all_fqns {
+        if !input_fqns.contains(fqn) {
+            input_fqns.push(fqn.clone());
+        }
+    }
+    input_fqns.sort();
+    input_fqns.dedup();
+
+    let input_set: std::collections::HashSet<&str> =
+        input_fqns.iter().map(|s| s.as_str()).collect();
+
+    let (within_pairs, _hidden) = partition_pairs(&pairs, &input_set);
+
+    let must_serialize: std::collections::HashSet<&str> = within_pairs
+        .iter()
+        .filter(|p| p.coupling_ratio >= SERIALIZE_THRESHOLD)
+        .flat_map(|p| [p.file_a.as_str(), p.file_b.as_str()])
+        .collect();
+
+    let mut parallel_safe: Vec<String> = input_fqns
+        .iter()
+        .filter(|f| !must_serialize.contains(f.as_str()))
+        .cloned()
+        .collect();
+    let mut serialize: Vec<String> = input_fqns
+        .iter()
+        .filter(|f| must_serialize.contains(f.as_str()))
+        .cloned()
+        .collect();
+    parallel_safe.sort();
+    serialize.sort();
+
+    let ownership = compute_ownership(repo_root, files)?;
+
+    Ok(CoordinateReport {
+        input_files: files.to_vec(),
+        pairs: within_pairs,
+        hidden_dependencies: Vec::new(), // hidden deps stay at file level
         ownership,
         parallel_safe,
         serialize,

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -1120,6 +1120,207 @@ pub fn extract_co_change_pairs(
     Ok(pairs)
 }
 
+/// Parse unified diff output into `(file, changed_line_ranges)` pairs.
+/// Only considers added/context lines (lines starting with '+' or ' ') to map
+/// to functions that were actually touched.
+fn parse_diff_hunks(diff: &str) -> Vec<(String, Vec<(u32, u32)>)> {
+    let mut result: Vec<(String, Vec<(u32, u32)>)> = Vec::new();
+    let mut current_file: Option<String> = None;
+    let mut current_ranges: Vec<(u32, u32)> = Vec::new();
+
+    for line in diff.lines() {
+        if let Some(stripped) = line.strip_prefix("+++ b/") {
+            if let Some(file) = current_file.take() {
+                result.push((file, std::mem::take(&mut current_ranges)));
+            }
+            current_file = Some(stripped.to_string());
+        } else if line.starts_with("@@ ") {
+            // @@ -old_start,old_count +new_start,new_count @@
+            if let Some(new_part) = line.split('+').nth(1) {
+                let nums: Vec<&str> = new_part.split(',').collect();
+                if let Ok(start) = nums[0].trim().parse::<u32>() {
+                    let count = nums
+                        .get(1)
+                        .and_then(|s| s.split_whitespace().next())
+                        .and_then(|s| s.parse::<u32>().ok())
+                        .unwrap_or(1);
+                    if count > 0 {
+                        current_ranges.push((start, start + count - 1));
+                    }
+                }
+            }
+        }
+    }
+    if let Some(file) = current_file {
+        result.push((file, current_ranges));
+    }
+    result
+}
+
+/// Mine function-level co-change pairs from git history over `window_days`.
+///
+/// Returns pairs of FQNs (`file::function`) that co-changed at least `min_count`
+/// times. Uses the same `CoChangePair` type as `extract_co_change_pairs` — the
+/// `file_a` / `file_b` fields contain FQNs rather than file paths.
+///
+/// Parsing uses the current file state to map changed line ranges to function
+/// names. Functions renamed in history will be misattributed; this is a known
+/// v1 limitation shared by the rest of hotspots' function-level analysis.
+pub fn extract_function_co_change_pairs(
+    repo_root: &Path,
+    files: &[String],
+    window_days: u64,
+    min_count: usize,
+) -> Result<Vec<CoChangePair>> {
+    use crate::analysis::parser_for_path;
+
+    // Build function map for each supported input file: file -> Vec<(fqn, start_line, end_line)>
+    let mut file_functions: std::collections::HashMap<String, Vec<(String, u32, u32)>> =
+        std::collections::HashMap::new();
+
+    for file in files {
+        let abs_path = repo_root.join(file);
+        if !abs_path.exists() {
+            continue;
+        }
+        let Ok(parser) = parser_for_path(&abs_path) else {
+            continue; // unsupported language — skip silently
+        };
+        let Ok(source) = std::fs::read_to_string(&abs_path) else {
+            continue;
+        };
+        let Ok(module) = parser.parse(&source, file) else {
+            continue;
+        };
+        let fns: Vec<(String, u32, u32)> = module
+            .discover_functions(0, &source)
+            .into_iter()
+            .filter_map(|f| {
+                f.name.map(|name| {
+                    let fqn = format!("{}::{}", file, name);
+                    (fqn, f.span.start_line, f.span.end_line)
+                })
+            })
+            .collect();
+        if !fns.is_empty() {
+            file_functions.insert(file.clone(), fns);
+        }
+    }
+
+    if file_functions.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let input_files: std::collections::HashSet<&str> = files.iter().map(|s| s.as_str()).collect();
+
+    // Walk git log to get commits that touched any input file
+    let file_args: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
+    let since_flag = format!("--since={} days ago", window_days);
+    let mut log_args2: Vec<&str> = vec![
+        "log",
+        "--format=COMMIT:%H",
+        &since_flag,
+        "--diff-filter=AM",
+        "--",
+    ];
+    log_args2.extend(file_args.iter().copied());
+
+    let log_output = git_at(repo_root, &log_args2).unwrap_or_default();
+    let commit_hashes: Vec<String> = log_output
+        .lines()
+        .filter(|l| l.starts_with("COMMIT:"))
+        .map(|l| l[7..].to_string())
+        .collect();
+
+    let mut fqn_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut pair_counts: std::collections::HashMap<(String, String), usize> =
+        std::collections::HashMap::new();
+
+    for sha in &commit_hashes {
+        // Get unified diff for this commit, restricted to input files
+        let mut diff_args = vec![
+            "diff-tree",
+            "--no-commit-id",
+            "-p",
+            "--unified=0",
+            sha,
+            "--",
+        ];
+        diff_args.extend(file_args.iter().copied());
+        let diff = git_at(repo_root, &diff_args).unwrap_or_default();
+
+        let hunks = parse_diff_hunks(&diff);
+
+        // Collect FQNs touched in this commit
+        let mut touched: Vec<String> = Vec::new();
+        for (diff_file, ranges) in &hunks {
+            if !input_files.contains(diff_file.as_str()) {
+                continue;
+            }
+            let Some(fns) = file_functions.get(diff_file) else {
+                continue;
+            };
+            for (fqn, fn_start, fn_end) in fns {
+                for (hunk_start, hunk_end) in ranges {
+                    // Overlap: hunk touches this function's line range
+                    if hunk_start <= fn_end && hunk_end >= fn_start {
+                        touched.push(fqn.clone());
+                        break;
+                    }
+                }
+            }
+        }
+
+        touched.sort();
+        touched.dedup();
+
+        for fqn in &touched {
+            *fqn_counts.entry(fqn.clone()).or_insert(0) += 1;
+        }
+        for i in 0..touched.len() {
+            for j in (i + 1)..touched.len() {
+                let key = (touched[i].clone(), touched[j].clone());
+                *pair_counts.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let mut pairs: Vec<CoChangePair> = pair_counts
+        .into_iter()
+        .filter(|(_, count)| *count >= min_count)
+        .map(|((fqn_a, fqn_b), co_change_count)| {
+            let count_a = fqn_counts.get(&fqn_a).copied().unwrap_or(1);
+            let count_b = fqn_counts.get(&fqn_b).copied().unwrap_or(1);
+            let coupling_ratio = co_change_count as f64 / count_a.min(count_b) as f64;
+            let risk = if coupling_ratio > 0.5 {
+                "high".to_string()
+            } else if coupling_ratio > 0.25 {
+                "moderate".to_string()
+            } else {
+                "low".to_string()
+            };
+            CoChangePair {
+                file_a: fqn_a,
+                file_b: fqn_b,
+                co_change_count,
+                coupling_ratio: (coupling_ratio * 1000.0).round() / 1000.0,
+                risk,
+                has_static_dep: false,
+            }
+        })
+        .collect();
+
+    pairs.sort_by(|a, b| {
+        b.coupling_ratio
+            .partial_cmp(&a.coupling_ratio)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.file_a.cmp(&b.file_a))
+            .then(a.file_b.cmp(&b.file_b))
+    });
+
+    Ok(pairs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod callgraph;
 pub mod cfg;
 pub mod compact;
 pub mod config;
+pub mod coordinate;
 pub mod coupling;
 pub mod db;
 pub mod delta;

--- a/hotspots-core/tests/coordinate_tests.rs
+++ b/hotspots-core/tests/coordinate_tests.rs
@@ -85,7 +85,7 @@ fn within_pair_both_in_set() {
 
 #[test]
 fn hidden_dep_when_one_file_outside_set() {
-    let pairs = vec![make_pair("auth.rs", "token.rs", 3, 0.6)];
+    let pairs = vec![make_pair("auth.rs", "token.rs", 3, 0.8)];
     let input: HashSet<&str> = ["auth.rs"].into();
     let (within, hidden) = partition_pairs(&pairs, &input);
     assert!(within.is_empty());
@@ -97,7 +97,7 @@ fn hidden_dep_when_one_file_outside_set() {
 #[test]
 fn hidden_dep_direction_normalised_when_b_is_input() {
     // file_b is in the input set — partner should still be file_a
-    let pairs = vec![make_pair("token.rs", "session.rs", 3, 0.6)];
+    let pairs = vec![make_pair("token.rs", "session.rs", 3, 0.8)];
     let input: HashSet<&str> = ["session.rs"].into();
     let (_, hidden) = partition_pairs(&pairs, &input);
     assert_eq!(hidden[0].input_file, "session.rs");
@@ -130,13 +130,13 @@ fn within_pairs_sorted_by_coupling_ratio_descending() {
 #[test]
 fn hidden_deps_sorted_by_coupling_ratio_descending() {
     let pairs = vec![
-        make_pair("auth.rs", "x.rs", 3, 0.2),
+        make_pair("auth.rs", "x.rs", 3, 0.7),
         make_pair("auth.rs", "y.rs", 5, 0.8),
     ];
     let input: HashSet<&str> = ["auth.rs"].into();
     let (_, hidden) = partition_pairs(&pairs, &input);
     assert_eq!(hidden[0].coupling_ratio, 0.8);
-    assert_eq!(hidden[1].coupling_ratio, 0.2);
+    assert_eq!(hidden[1].coupling_ratio, 0.7);
 }
 
 // ── serialize / parallel_safe split ──────────────────────────────────────────

--- a/hotspots-core/tests/coordinate_tests.rs
+++ b/hotspots-core/tests/coordinate_tests.rs
@@ -130,7 +130,7 @@ fn within_pairs_sorted_by_coupling_ratio_descending() {
 #[test]
 fn hidden_deps_sorted_by_coupling_ratio_descending() {
     let pairs = vec![
-        make_pair("auth.rs", "x.rs", 2, 0.2),
+        make_pair("auth.rs", "x.rs", 3, 0.2),
         make_pair("auth.rs", "y.rs", 5, 0.8),
     ];
     let input: HashSet<&str> = ["auth.rs"].into();

--- a/hotspots-core/tests/coordinate_tests.rs
+++ b/hotspots-core/tests/coordinate_tests.rs
@@ -1,0 +1,303 @@
+//! Integration tests for `hotspots coordinate`
+//!
+//! Uses real temp git repos with scripted commit histories so assertions
+//! are against deterministic co-change signals, not heuristics.
+
+use hotspots_core::coordinate::{coordinate, partition_pairs, SERIALIZE_THRESHOLD};
+use hotspots_core::git::CoChangePair;
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn create_temp_git_repo() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let p = tmp.path();
+    git(p, &["init", "--initial-branch=main"]);
+    git(p, &["config", "user.name", "Test User"]);
+    git(p, &["config", "user.email", "test@example.com"]);
+    git(p, &["config", "commit.gpgsign", "false"]);
+    tmp
+}
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .unwrap_or_else(|_| panic!("git {:?}", args));
+    if !out.status.success() {
+        panic!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn touch(repo: &Path, path: &str, content: &str) {
+    let full = repo.join(path);
+    if let Some(parent) = full.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&full, content).unwrap();
+}
+
+fn commit(repo: &Path, msg: &str, files: &[&str]) {
+    for f in files {
+        touch(repo, f, &format!("{}\n{}", f, msg));
+    }
+    git(repo, &["add", "."]);
+    git(repo, &["commit", "-m", msg]);
+}
+
+fn make_pair(a: &str, b: &str, count: usize, ratio: f64) -> CoChangePair {
+    CoChangePair {
+        file_a: a.to_string(),
+        file_b: b.to_string(),
+        co_change_count: count,
+        coupling_ratio: ratio,
+        risk: if ratio >= 0.5 {
+            "high".into()
+        } else if ratio >= 0.25 {
+            "moderate".into()
+        } else {
+            "low".into()
+        },
+        has_static_dep: false,
+    }
+}
+
+// ── partition_pairs ───────────────────────────────────────────────────────────
+
+#[test]
+fn within_pair_both_in_set() {
+    let pairs = vec![make_pair("auth.rs", "session.rs", 5, 0.8)];
+    let input: HashSet<&str> = ["auth.rs", "session.rs"].into();
+    let (within, hidden) = partition_pairs(&pairs, &input);
+    assert_eq!(within.len(), 1);
+    assert_eq!(within[0].file_a, "auth.rs");
+    assert!(hidden.is_empty());
+}
+
+#[test]
+fn hidden_dep_when_one_file_outside_set() {
+    let pairs = vec![make_pair("auth.rs", "token.rs", 3, 0.6)];
+    let input: HashSet<&str> = ["auth.rs"].into();
+    let (within, hidden) = partition_pairs(&pairs, &input);
+    assert!(within.is_empty());
+    assert_eq!(hidden.len(), 1);
+    assert_eq!(hidden[0].input_file, "auth.rs");
+    assert_eq!(hidden[0].partner, "token.rs");
+}
+
+#[test]
+fn hidden_dep_direction_normalised_when_b_is_input() {
+    // file_b is in the input set — partner should still be file_a
+    let pairs = vec![make_pair("token.rs", "session.rs", 3, 0.6)];
+    let input: HashSet<&str> = ["session.rs"].into();
+    let (_, hidden) = partition_pairs(&pairs, &input);
+    assert_eq!(hidden[0].input_file, "session.rs");
+    assert_eq!(hidden[0].partner, "token.rs");
+}
+
+#[test]
+fn pairs_both_outside_set_are_ignored() {
+    let pairs = vec![make_pair("x.rs", "y.rs", 10, 0.9)];
+    let input: HashSet<&str> = ["auth.rs"].into();
+    let (within, hidden) = partition_pairs(&pairs, &input);
+    assert!(within.is_empty());
+    assert!(hidden.is_empty());
+}
+
+#[test]
+fn within_pairs_sorted_by_coupling_ratio_descending() {
+    let pairs = vec![
+        make_pair("a.rs", "b.rs", 2, 0.3),
+        make_pair("a.rs", "c.rs", 5, 0.9),
+        make_pair("b.rs", "c.rs", 3, 0.6),
+    ];
+    let input: HashSet<&str> = ["a.rs", "b.rs", "c.rs"].into();
+    let (within, _) = partition_pairs(&pairs, &input);
+    assert_eq!(within.len(), 3);
+    assert!(within[0].coupling_ratio >= within[1].coupling_ratio);
+    assert!(within[1].coupling_ratio >= within[2].coupling_ratio);
+}
+
+#[test]
+fn hidden_deps_sorted_by_coupling_ratio_descending() {
+    let pairs = vec![
+        make_pair("auth.rs", "x.rs", 2, 0.2),
+        make_pair("auth.rs", "y.rs", 5, 0.8),
+    ];
+    let input: HashSet<&str> = ["auth.rs"].into();
+    let (_, hidden) = partition_pairs(&pairs, &input);
+    assert_eq!(hidden[0].coupling_ratio, 0.8);
+    assert_eq!(hidden[1].coupling_ratio, 0.2);
+}
+
+// ── serialize / parallel_safe split ──────────────────────────────────────────
+
+#[test]
+fn high_coupling_pair_drives_serialize() {
+    let pairs = vec![make_pair("auth.rs", "session.rs", 5, SERIALIZE_THRESHOLD)];
+    let input: HashSet<&str> = ["auth.rs", "session.rs", "middleware.rs"].into();
+    let (within, _) = partition_pairs(&pairs, &input);
+
+    let must_serialize: HashSet<&str> = within
+        .iter()
+        .filter(|p| p.coupling_ratio >= SERIALIZE_THRESHOLD)
+        .flat_map(|p| [p.file_a.as_str(), p.file_b.as_str()])
+        .collect();
+
+    assert!(must_serialize.contains("auth.rs"));
+    assert!(must_serialize.contains("session.rs"));
+    assert!(!must_serialize.contains("middleware.rs"));
+}
+
+#[test]
+fn low_coupling_pair_is_parallel_safe() {
+    let pairs = vec![make_pair("auth.rs", "session.rs", 2, 0.1)];
+    let input: HashSet<&str> = ["auth.rs", "session.rs"].into();
+    let (within, _) = partition_pairs(&pairs, &input);
+
+    let must_serialize: HashSet<&str> = within
+        .iter()
+        .filter(|p| p.coupling_ratio >= SERIALIZE_THRESHOLD)
+        .flat_map(|p| [p.file_a.as_str(), p.file_b.as_str()])
+        .collect();
+
+    assert!(must_serialize.is_empty());
+}
+
+// ── coordinate() end-to-end with real git repo ────────────────────────────────
+
+#[test]
+fn coordinate_surfaces_within_pair_from_real_git_history() {
+    let repo = create_temp_git_repo();
+    let root = repo.path();
+
+    // auth.rs and session.rs co-change 3 times — enough to exceed MIN_COUNT=2
+    for i in 0..3 {
+        commit(
+            root,
+            &format!("feat: change {}", i),
+            &["auth.rs", "session.rs"],
+        );
+    }
+    // middleware.rs changes alone — no co-change relationship
+    commit(root, "chore: standalone middleware", &["middleware.rs"]);
+
+    let files = vec![
+        "auth.rs".to_string(),
+        "session.rs".to_string(),
+        "middleware.rs".to_string(),
+    ];
+    let report = coordinate(root, &files).expect("coordinate failed");
+
+    let within_pair = report
+        .pairs
+        .iter()
+        .find(|p| {
+            (p.file_a == "auth.rs" && p.file_b == "session.rs")
+                || (p.file_a == "session.rs" && p.file_b == "auth.rs")
+        })
+        .expect("auth.rs ↔ session.rs pair should appear");
+
+    assert!(within_pair.co_change_count >= 3);
+    assert!(within_pair.coupling_ratio > 0.0);
+}
+
+#[test]
+fn coordinate_surfaces_hidden_dep() {
+    let repo = create_temp_git_repo();
+    let root = repo.path();
+
+    // auth.rs and token.rs co-change — token.rs is NOT in the input set
+    for i in 0..3 {
+        commit(
+            root,
+            &format!("feat: auth+token {}", i),
+            &["auth.rs", "token.rs"],
+        );
+    }
+    commit(root, "feat: auth alone", &["auth.rs"]);
+
+    let files = vec!["auth.rs".to_string()];
+    let report = coordinate(root, &files).expect("coordinate failed");
+
+    let hidden = report
+        .hidden_dependencies
+        .iter()
+        .find(|h| h.input_file == "auth.rs" && h.partner == "token.rs")
+        .expect("token.rs should appear as hidden dep for auth.rs");
+
+    assert!(hidden.co_change_count >= 3);
+}
+
+#[test]
+fn coordinate_parallel_safe_excludes_high_coupling_files() {
+    let repo = create_temp_git_repo();
+    let root = repo.path();
+
+    // Make auth.rs and session.rs co-change many times so coupling_ratio is high
+    for i in 0..10 {
+        commit(root, &format!("feat: {}", i), &["auth.rs", "session.rs"]);
+    }
+    // middleware.rs only changes alone — low/no coupling
+    for i in 0..5 {
+        commit(root, &format!("chore: mw {}", i), &["middleware.rs"]);
+    }
+
+    let files = vec![
+        "auth.rs".to_string(),
+        "session.rs".to_string(),
+        "middleware.rs".to_string(),
+    ];
+    let report = coordinate(root, &files).expect("coordinate failed");
+
+    // middleware should be parallel-safe; auth+session should serialize
+    assert!(
+        report.parallel_safe.contains(&"middleware.rs".to_string()),
+        "middleware.rs should be parallel_safe"
+    );
+    assert!(
+        report.serialize.contains(&"auth.rs".to_string())
+            || report.serialize.contains(&"session.rs".to_string()),
+        "auth.rs or session.rs should be in serialize"
+    );
+    assert!(
+        !report.parallel_safe.contains(&"auth.rs".to_string())
+            || !report.parallel_safe.contains(&"session.rs".to_string()),
+        "auth.rs and session.rs should not both be parallel_safe"
+    );
+}
+
+#[test]
+fn coordinate_empty_file_list_returns_empty_report() {
+    let repo = create_temp_git_repo();
+    commit(repo.path(), "init", &["README.md"]);
+
+    let report = coordinate(repo.path(), &[]).expect("coordinate failed");
+    assert!(report.pairs.is_empty());
+    assert!(report.hidden_dependencies.is_empty());
+    assert!(report.ownership.is_empty());
+    assert!(report.parallel_safe.is_empty());
+    assert!(report.serialize.is_empty());
+}
+
+#[test]
+fn coordinate_file_not_in_history_has_zero_ownership() {
+    let repo = create_temp_git_repo();
+    commit(repo.path(), "init", &["other.rs"]);
+
+    let files = vec!["nonexistent.rs".to_string()];
+    let report = coordinate(repo.path(), &files).expect("coordinate failed");
+
+    let o = &report.ownership[0];
+    assert_eq!(o.author_count, 0);
+    assert_eq!(o.top_author_pct, 0.0);
+}


### PR DESCRIPTION
## Summary

- Adds `hotspots coordinate` — pre-flight coordination signal tool for multi-agent and multi-developer work
- Takes a comma-separated file list, returns co-change pairs, hidden dependencies, ownership signals, and a parallel/serialize partition recommendation
- JSON auto-selected when stdout is not a TTY; `--json` and `--text` force explicitly
- Hidden dep output filtered to coupling_ratio ≥ 0.7 and capped at 10 entries in JSON (high-signal only); `hidden_dependencies_omitted` count indicates overflow
- Integration tests cover partition logic, hidden dep detection, real git history, and edge cases

## Test plan

- [ ] `cargo test -p hotspots-core` passes (13 coordinate tests)
- [ ] `hotspots coordinate --files <files>` renders human table at TTY
- [ ] `hotspots coordinate --files <files> | cat` emits JSON automatically
- [ ] `hotspots coordinate --files <files> --json` forces JSON
- [ ] `hotspots coordinate --files <files> --text` forces human text when piped

🤖 Generated with [Claude Code](https://claude.com/claude-code)