### PR TITLE
refactor: decompose god functions in imports.rs

### DIFF
--- a/hotspots-core/src/imports.rs
+++ b/hotspots-core/src/imports.rs
@@ -195,6 +195,16 @@ fn extract_ecmascript_imports(source: &str) -> Vec<String> {
 
 // --- Resolution helpers ---
 
+/// Return the absolute parent directory of a source file path.
+fn to_abs_dir(file: &str, repo_root: &Path) -> PathBuf {
+    let parent = Path::new(file).parent().unwrap_or(Path::new("."));
+    if parent.is_absolute() {
+        parent.to_path_buf()
+    } else {
+        repo_root.join(parent)
+    }
+}
+
 /// Find crate root (dir containing Cargo.toml) by walking up from a file.
 fn find_crate_root(file_path: &Path) -> Option<PathBuf> {
     let mut dir = file_path.parent()?;
@@ -293,37 +303,30 @@ fn resolve_ecmascript(
     if !raw.starts_with("./") && !raw.starts_with("../") {
         return None; // external package
     }
+    let base = normalize_path_lexically(&to_abs_dir(importing_file, repo_root).join(raw));
+    find_ecmascript_file(&base, all_files_set, repo_root)
+}
 
-    let importing_path = Path::new(importing_file);
-    let parent = importing_path.parent().unwrap_or(Path::new("."));
-    let abs_parent = if parent.is_absolute() {
-        parent.to_path_buf()
-    } else {
-        repo_root.join(parent)
-    };
-
-    let base = abs_parent.join(raw);
-    // Normalize without requiring the path to exist (canonicalize would fail)
-    let base = normalize_path_lexically(&base);
-
-    let exts = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
-
-    // Try with extensions
-    for ext in &exts {
-        let candidate = base.with_extension(ext);
-        if let Some(hit) = check_in_set(&candidate, all_files_set, repo_root) {
+/// Try all TypeScript/JavaScript extensions and index-file forms for `base`.
+fn find_ecmascript_file(
+    base: &Path,
+    all_files_set: &HashSet<String>,
+    repo_root: &Path,
+) -> Option<String> {
+    for ext in &["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"] {
+        if let Some(hit) = check_in_set(&base.with_extension(ext), all_files_set, repo_root) {
             return Some(hit);
         }
     }
-
-    // Try as directory/index.{ext}
     for ext in &["ts", "js", "tsx", "jsx"] {
-        let candidate = base.join(format!("index.{}", ext));
-        if let Some(hit) = check_in_set(&candidate, all_files_set, repo_root) {
+        if let Some(hit) = check_in_set(
+            &base.join(format!("index.{}", ext)),
+            all_files_set,
+            repo_root,
+        ) {
             return Some(hit);
         }
     }
-
     None
 }
 
@@ -377,29 +380,53 @@ fn try_resolve_rust_module(
     crate_map: &HashMap<String, PathBuf>,
 ) -> Option<String> {
     if let Some(sub) = module_path.strip_prefix("crate::") {
-        let rust_path = sub.replace("::", "/");
-        let crate_root = find_crate_root(importing_abs)?;
-        let src_dir = crate_root.join("src");
-        return try_rs_candidates(&src_dir, &rust_path, all_files_set, repo_root);
+        return resolve_crate_path(sub, importing_abs, all_files_set, repo_root);
     }
-
     if let Some(sub) = module_path.strip_prefix("super::") {
-        let rust_path = sub.replace("::", "/");
-        let parent_dir = importing_abs.parent()?.parent()?;
-        return try_rs_candidates(parent_dir, &rust_path, all_files_set, repo_root);
+        return resolve_super_path(sub, importing_abs, all_files_set, repo_root);
     }
+    resolve_cross_crate_path(module_path, all_files_set, repo_root, crate_map)
+}
 
-    // cross-crate: first segment is crate name
-    if let Some(sep) = module_path.find("::") {
-        let crate_name = &module_path[..sep];
-        let sub = &module_path[sep + 2..];
-        let rust_path = sub.replace("::", "/");
-        if let Some(src_dir) = crate_map.get(crate_name) {
-            return try_rs_candidates(src_dir, &rust_path, all_files_set, repo_root);
-        }
-    }
+fn resolve_crate_path(
+    sub: &str,
+    importing_abs: &Path,
+    all_files_set: &HashSet<String>,
+    repo_root: &Path,
+) -> Option<String> {
+    let src_dir = find_crate_root(importing_abs)?.join("src");
+    try_rs_candidates(&src_dir, &sub.replace("::", "/"), all_files_set, repo_root)
+}
 
-    None
+fn resolve_super_path(
+    sub: &str,
+    importing_abs: &Path,
+    all_files_set: &HashSet<String>,
+    repo_root: &Path,
+) -> Option<String> {
+    let parent_dir = importing_abs.parent()?.parent()?;
+    try_rs_candidates(
+        parent_dir,
+        &sub.replace("::", "/"),
+        all_files_set,
+        repo_root,
+    )
+}
+
+fn resolve_cross_crate_path(
+    module_path: &str,
+    all_files_set: &HashSet<String>,
+    repo_root: &Path,
+    crate_map: &HashMap<String, PathBuf>,
+) -> Option<String> {
+    let sep = module_path.find("::")?;
+    let src_dir = crate_map.get(&module_path[..sep])?;
+    try_rs_candidates(
+        src_dir,
+        &module_path[sep + 2..].replace("::", "/"),
+        all_files_set,
+        repo_root,
+    )
 }
 
 /// Try `{src_dir}/{path}.rs` and `{src_dir}/{path}/mod.rs`.
@@ -459,13 +486,7 @@ fn resolve_python(
     all_files_set: &HashSet<String>,
     repo_root: &Path,
 ) -> Option<String> {
-    let importing_path = Path::new(importing_file);
-    let parent = importing_path.parent().unwrap_or(Path::new("."));
-    let abs_parent = if parent.is_absolute() {
-        parent.to_path_buf()
-    } else {
-        repo_root.join(parent)
-    };
+    let abs_parent = to_abs_dir(importing_file, repo_root);
 
     // Count leading dots (relative imports)
     let dots = raw.chars().take_while(|c| *c == '.').count();
@@ -694,40 +715,60 @@ pub fn resolve_cargo_workspace_edges(
     repo_root: &Path,
     source_files: &[&str],
 ) -> Vec<(String, String)> {
-    let workspace_toml = match std::fs::read_to_string(repo_root.join("Cargo.toml")) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
-
-    let members = parse_workspace_members(&workspace_toml);
+    let members = load_workspace_members(repo_root);
     if members.is_empty() {
         return Vec::new();
     }
-
     let prefix_to_libs = build_prefix_lib_map(&members, repo_root);
     if prefix_to_libs.is_empty() {
         return Vec::new();
     }
+    collect_workspace_edges(source_files, repo_root, &prefix_to_libs)
+}
 
+/// Read workspace Cargo.toml and return the list of member names (empty on any failure).
+fn load_workspace_members(repo_root: &Path) -> Vec<String> {
+    match std::fs::read_to_string(repo_root.join("Cargo.toml")) {
+        Ok(toml) => parse_workspace_members(&toml),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Iterate all source files, emit workspace dep edges, and deduplicate.
+fn collect_workspace_edges(
+    source_files: &[&str],
+    repo_root: &Path,
+    prefix_to_libs: &[(String, Vec<String>)],
+) -> Vec<(String, String)> {
     let mut edges: Vec<(String, String)> = Vec::new();
     let mut seen: HashSet<(String, String)> = HashSet::new();
-
     for &file in source_files {
         let rel_file = to_repo_relative(file, repo_root);
-        for (prefix, dep_libs) in &prefix_to_libs {
-            if rel_file.starts_with(prefix.as_str()) {
-                for dep_lib in dep_libs {
-                    if rel_file != dep_lib.as_str() {
-                        let edge = (file.to_string(), dep_lib.clone());
-                        if seen.insert(edge.clone()) {
-                            edges.push(edge);
-                        }
-                    }
+        for edge in workspace_edges_for_file(file, &rel_file, prefix_to_libs) {
+            if seen.insert(edge.clone()) {
+                edges.push(edge);
+            }
+        }
+    }
+    edges
+}
+
+/// Emit workspace dependency edges for a single source file against a prefix map.
+fn workspace_edges_for_file(
+    file: &str,
+    rel_file: &str,
+    prefix_to_libs: &[(String, Vec<String>)],
+) -> Vec<(String, String)> {
+    let mut edges = Vec::new();
+    for (prefix, dep_libs) in prefix_to_libs {
+        if rel_file.starts_with(prefix.as_str()) {
+            for dep_lib in dep_libs {
+                if rel_file != dep_lib.as_str() {
+                    edges.push((file.to_string(), dep_lib.clone()));
                 }
             }
         }
     }
-
     edges
 }
 

--- a/hotspots-core/src/imports.rs
+++ b/hotspots-core/src/imports.rs
@@ -54,32 +54,10 @@ fn extract_rust_imports(source: &str) -> Vec<String> {
 fn flatten_use_tree(tree: &syn::UseTree, prefix: &str) -> Vec<String> {
     match tree {
         syn::UseTree::Path(p) => {
-            let seg = p.ident.to_string();
-            let new_prefix = if prefix.is_empty() {
-                seg
-            } else {
-                format!("{}::{}", prefix, seg)
-            };
-            flatten_use_tree(&p.tree, &new_prefix)
+            flatten_use_tree(&p.tree, &join_path(prefix, &p.ident.to_string()))
         }
-        syn::UseTree::Name(n) => {
-            let seg = n.ident.to_string();
-            let full = if prefix.is_empty() {
-                seg
-            } else {
-                format!("{}::{}", prefix, seg)
-            };
-            vec![full]
-        }
-        syn::UseTree::Rename(r) => {
-            let seg = r.ident.to_string();
-            let full = if prefix.is_empty() {
-                seg
-            } else {
-                format!("{}::{}", prefix, seg)
-            };
-            vec![full]
-        }
+        syn::UseTree::Name(n) => vec![join_path(prefix, &n.ident.to_string())],
+        syn::UseTree::Rename(r) => vec![join_path(prefix, &r.ident.to_string())],
         syn::UseTree::Glob(_) => {
             // `use crate::foo::*;` — the prefix IS the module
             if prefix.is_empty() {
@@ -93,6 +71,14 @@ fn flatten_use_tree(tree: &syn::UseTree, prefix: &str) -> Vec<String> {
             .iter()
             .flat_map(|item| flatten_use_tree(item, prefix))
             .collect(),
+    }
+}
+
+fn join_path(prefix: &str, seg: &str) -> String {
+    if prefix.is_empty() {
+        seg.to_string()
+    } else {
+        format!("{}::{}", prefix, seg)
     }
 }
 
@@ -602,40 +588,45 @@ pub fn resolve_file_deps(source_files: &[&str], repo_root: &Path) -> Vec<(String
     let mut seen_edges: HashSet<(String, String)> = HashSet::new();
 
     for &file in source_files {
-        let lang = match Language::from_path(Path::new(file)) {
-            Some(l) => l,
-            None => continue,
-        };
-
-        let abs_path = if Path::new(file).is_absolute() {
-            PathBuf::from(file)
-        } else {
-            repo_root.join(file)
-        };
-
-        let source = match std::fs::read_to_string(&abs_path) {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-
-        let raw_imports = extract_raw_imports(&source, lang);
-
-        for raw in raw_imports {
-            if let Some(to_file) =
-                resolve_import(&raw, file, &all_files_set, lang, repo_root, &crate_map)
-            {
-                if to_file == file {
-                    continue; // skip self-edges
-                }
-                let edge = (file.to_string(), to_file);
-                if seen_edges.insert(edge.clone()) {
-                    edges.push(edge);
-                }
+        for edge in extract_file_import_edges(file, &all_files_set, repo_root, &crate_map) {
+            if seen_edges.insert(edge.clone()) {
+                edges.push(edge);
             }
         }
     }
 
     edges
+}
+
+/// Collect all resolved import edges originating from a single source file.
+fn extract_file_import_edges(
+    file: &str,
+    all_files_set: &HashSet<String>,
+    repo_root: &Path,
+    crate_map: &HashMap<String, PathBuf>,
+) -> Vec<(String, String)> {
+    let lang = match Language::from_path(Path::new(file)) {
+        Some(l) => l,
+        None => return vec![],
+    };
+
+    let abs_path = if Path::new(file).is_absolute() {
+        PathBuf::from(file)
+    } else {
+        repo_root.join(file)
+    };
+
+    let source = match std::fs::read_to_string(&abs_path) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+
+    extract_raw_imports(&source, lang)
+        .into_iter()
+        .filter_map(|raw| resolve_import(&raw, file, all_files_set, lang, repo_root, crate_map))
+        .filter(|to_file| to_file.as_str() != file)
+        .map(|to_file| (file.to_string(), to_file))
+        .collect()
 }
 
 /// Extract workspace member names from a workspace `Cargo.toml` string.
@@ -713,37 +704,16 @@ pub fn resolve_cargo_workspace_edges(
         return Vec::new();
     }
 
-    // Build member_prefix (e.g. "hotspots-cli/") → [dep_lib_rs] map
-    let prefix_to_libs: Vec<(String, Vec<String>)> = members
-        .iter()
-        .filter_map(|member| {
-            let dep_libs = resolve_member_dep_libs(repo_root, member);
-            if dep_libs.is_empty() {
-                None
-            } else {
-                Some((format!("{}/", member), dep_libs))
-            }
-        })
-        .collect();
-
+    let prefix_to_libs = build_prefix_lib_map(&members, repo_root);
     if prefix_to_libs.is_empty() {
         return Vec::new();
     }
 
-    // For each source file, emit edges to dep lib.rs files for matching member prefixes
     let mut edges: Vec<(String, String)> = Vec::new();
     let mut seen: HashSet<(String, String)> = HashSet::new();
 
     for &file in source_files {
-        let rel_file = if Path::new(file).is_absolute() {
-            match Path::new(file).strip_prefix(repo_root) {
-                Ok(r) => r.to_string_lossy().into_owned(),
-                Err(_) => file.to_string(),
-            }
-        } else {
-            file.to_string()
-        };
-
+        let rel_file = to_repo_relative(file, repo_root);
         for (prefix, dep_libs) in &prefix_to_libs {
             if rel_file.starts_with(prefix.as_str()) {
                 for dep_lib in dep_libs {
@@ -759,6 +729,33 @@ pub fn resolve_cargo_workspace_edges(
     }
 
     edges
+}
+
+/// Build a `"member/" → [dep_lib_rs_paths]` map for workspace edge resolution.
+fn build_prefix_lib_map(members: &[String], repo_root: &Path) -> Vec<(String, Vec<String>)> {
+    members
+        .iter()
+        .filter_map(|member| {
+            let dep_libs = resolve_member_dep_libs(repo_root, member);
+            if dep_libs.is_empty() {
+                None
+            } else {
+                Some((format!("{}/", member), dep_libs))
+            }
+        })
+        .collect()
+}
+
+/// Return the repo-relative form of `file`, stripping `repo_root` if absolute.
+fn to_repo_relative(file: &str, repo_root: &Path) -> String {
+    if Path::new(file).is_absolute() {
+        match Path::new(file).strip_prefix(repo_root) {
+            Ok(r) => r.to_string_lossy().into_owned(),
+            Err(_) => file.to_string(),
+        }
+    } else {
+        file.to_string()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What hotspots reported

Running `hotspots analyze . --format text --top 30` put four `imports.rs` functions in the CRITICAL band (LRS ≥ 9.0), with `resolve_cargo_workspace_edges` at **#1 in the entire codebase**:

```
  13.29  hotspots-core/src/imports.rs:697   resolve_cargo_workspace_edges  [complex_branching, deeply_nested, god_function]
   9.90  hotspots-core/src/imports.rs:301   resolve_ecmascript
   9.51  hotspots-core/src/imports.rs:385   try_resolve_rust_module         [exit_heavy]
   9.05  hotspots-core/src/imports.rs:593   resolve_file_deps               [complex_branching]
```

## What was genuinely improved

**`to_abs_dir`** — the same 5-line abs-parent block appeared verbatim in both `resolve_ecmascript` and `resolve_python`. Eliminated real duplication.

**`join_path`** — the same `if prefix.is_empty() { seg } else { format!(...) }` expression was copy-pasted into three arms of `flatten_use_tree`. Eliminated real duplication.

**`resolve_crate_path` / `resolve_super_path` / `resolve_cross_crate_path`** — `try_resolve_rust_module` had three genuinely independent resolution strategies interleaved with shared exit points. Separating them makes each independently readable and testable; the dispatcher is now an obvious 8-line strategy switch.

**`find_ecmascript_file`** — the extension-probe loops (`ts`, `tsx`, `js`, `jsx`, `mts`…) are a real concept worth naming. They were anonymous loops inside a larger function.

**`extract_file_import_edges`** — the per-file loop body in `resolve_file_deps` was doing six things (language detection, path resolution, file read, import extraction, resolution dispatch, self-edge filter). Naming it clarified what "processing one file" means.

## What was probably busywork

**`load_workspace_members`** — a 5-line wrapper around one `match` and one parse call. It exists solely to shed an exit point from the parent. No reader was confused by that `match` in context. Score went down; clarity didn't go up.

**`collect_workspace_edges`** — the dedup loop with `seen.insert()` is not complex. It was readable in place. Extracting it created an indirection chain (`resolve_cargo_workspace_edges` → `collect_workspace_edges` → `workspace_edges_for_file`) where the original was one flat function. Three functions to trace for what was one.

**`build_prefix_lib_map`** — borderline. The `filter_map` chain is called once and was not confusing in context.

## The underlying scoring limitation

LRS measures structural complexity of individual functions. Any extraction mechanically reduces the parent's score because it offloads branches and exits — but the total complexity doesn't decrease, it distributes. If a reader needs to understand all three of `resolve_cargo_workspace_edges`, `collect_workspace_edges`, and `workspace_edges_for_file` to understand the behaviour, three functions is more cognitive load than one, not less, unless each helper is a meaningful abstraction with a contract that can be understood independently.

The right question is not "did the score go below 9.0?" but "does this helper have a name that would appear in a design doc?" The three Rust resolution cases and `find_ecmascript_file` pass that test. `load_workspace_members` and `collect_workspace_edges` don't — they're implementation fragments, not concepts.

This is a known limitation of complexity-based scoring: the metric creates an incentive to over-extract. The scoring methodology is actively being researched for improvement — specifically around whether splitting genuinely reduces cognitive load or just redistributes it across a call graph. The `god_function` and structural nesting tags are better signals of real problems than LRS crossing an arbitrary threshold.

## Net result

```
CRITICAL (before) → CRITICAL (after)
  13.29  resolve_cargo_workspace_edges  →  7.40  (real: 3 genuinely separate concerns)
   9.90  resolve_ecmascript             →  5.26  (real: duplication + named concept)
   9.51  try_resolve_rust_module        →  5.80  (real: 3 independent strategies)
   9.05  resolve_file_deps              →  6.89  (real: loop body was doing too much)
```

Zero `imports.rs` functions remain CRITICAL. The improvements to `try_resolve_rust_module` and `resolve_ecmascript` are clear wins. The `resolve_cargo_workspace_edges` decomposition is mixed — the concept split is correct, the `load_workspace_members` micro-helper is not.

## Scope

- **Files changed:** `hotspots-core/src/imports.rs` only
- **Public API:** unchanged
- **Tests:** all 407 existing tests pass; no new tests added