### PR TITLE
fix: name TS/TSX functions from their assigned variable

### DIFF
--- a/hotspots-core/src/discover.rs
+++ b/hotspots-core/src/discover.rs
@@ -36,6 +36,7 @@ pub fn discover_functions(
         functions: Vec::new(),
         local_index: 0,
         source_map,
+        pending_name: None,
     };
 
     module.visit_with(&mut collector);
@@ -67,9 +68,23 @@ struct FunctionCollector<'a> {
     functions: Vec<FunctionNode>,
     local_index: usize,
     source_map: &'a swc_common::SourceMap,
+    /// Name of the variable a function/arrow expression is being assigned to
+    /// (e.g. `const Foo = () => {...}`), set while visiting the declarator's
+    /// init expression so the function picks it up instead of `<anonymous>`.
+    pending_name: Option<String>,
 }
 
 impl<'a> Visit for FunctionCollector<'a> {
+    fn visit_var_declarator(&mut self, decl: &VarDeclarator) {
+        if let (Pat::Ident(ident), Some(init)) = (&decl.name, &decl.init) {
+            if matches!(&**init, Expr::Fn(_) | Expr::Arrow(_)) {
+                self.pending_name = Some(ident.id.sym.to_string());
+            }
+        }
+        decl.visit_children_with(self);
+        self.pending_name = None;
+    }
+
     fn visit_fn_decl(&mut self, decl: &FnDecl) {
         // Extract function name from declaration
         let name = Some(decl.ident.sym.to_string());
@@ -96,8 +111,13 @@ impl<'a> Visit for FunctionCollector<'a> {
     }
 
     fn visit_fn_expr(&mut self, expr: &FnExpr) {
-        // Extract function name (may be None for anonymous)
-        let name = expr.ident.as_ref().map(|id| id.sym.to_string());
+        // Extract function name; fall back to the variable it's assigned to
+        // (e.g. `const Foo = function() {...}`)
+        let name = expr
+            .ident
+            .as_ref()
+            .map(|id| id.sym.to_string())
+            .or_else(|| self.pending_name.take());
 
         // Extract body
         let body = expr.function.body.clone();
@@ -121,8 +141,9 @@ impl<'a> Visit for FunctionCollector<'a> {
     }
 
     fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
-        // Generate synthetic name for anonymous arrow function
-        let name = None; // Will be set to <anonymous>@file:line in the name extraction
+        // Use the variable it's assigned to (e.g. `const Foo = () => {...}`),
+        // falling back to <anonymous>@file:line in the name extraction
+        let name = self.pending_name.take();
 
         match &*arrow.body {
             BlockStmtOrExpr::BlockStmt(ref body) => {

--- a/hotspots-core/src/discover/tests.rs
+++ b/hotspots-core/src/discover/tests.rs
@@ -32,12 +32,36 @@ mod discover_tests {
 
     #[test]
     fn test_discover_anonymous_arrow_function() {
-        let src = "const foo = () => { return 42; };";
+        let src = "setTimeout(() => { return 42; });";
         let functions = parse_and_discover(src, 0);
         assert_eq!(functions.len(), 1, "Should discover arrow function");
         assert_eq!(
             functions[0].name, None,
             "Arrow function should have no name"
+        );
+    }
+
+    #[test]
+    fn test_discover_arrow_function_named_from_variable() {
+        let src = "const foo = () => { return 42; };";
+        let functions = parse_and_discover(src, 0);
+        assert_eq!(functions.len(), 1, "Should discover arrow function");
+        assert_eq!(
+            functions[0].name,
+            Some("foo".to_string()),
+            "Arrow function should take its name from the assigned variable"
+        );
+    }
+
+    #[test]
+    fn test_discover_fn_expr_named_from_variable() {
+        let src = "const Foo = function() { return 42; };";
+        let functions = parse_and_discover(src, 0);
+        assert_eq!(functions.len(), 1, "Should discover function expression");
+        assert_eq!(
+            functions[0].name,
+            Some("Foo".to_string()),
+            "Function expression should take its name from the assigned variable"
         );
     }
 


### PR DESCRIPTION
## Summary
- Function expressions and arrow functions assigned to a variable (e.g. `const Foo = () => {...}`, `const Foo = function() {...}`) now take their name from the assigned identifier instead of falling back to `<anonymous>@file:line`.
- This fixes naming for React function components written in `.tsx`, since that's the dominant pattern, but the fix is general (applies to `.ts`/`.js`/`.jsx` too) — it resolves the name from the AST identifier on the `VarDeclarator`, not from any TSX-specific logic.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (full suite, 409+ tests passing)
- [x] Added `test_discover_arrow_function_named_from_variable` and `test_discover_fn_expr_named_from_variable`
- [x] Updated `test_discover_anonymous_arrow_function` to use a truly anonymous case (`setTimeout(() => {...})`)