### PR TITLE
feat: add hotspots init --ci with GitHub Actions workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "is-terminal",
  "owo-colors",
  "rayon",
+ "tempfile",
 ]
 
 [[package]]

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,7 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" fill="#000"/>
-  <!-- baseline -->
-  <rect x="15" y="62" width="70" height="4.5" fill="#f97316"/>
-  <!-- spike -->
-  <polygon points="50,26 45.5,62 54.5,62" fill="#f97316"/>
+  <rect width="100" height="100" fill="#09090b"/>
+
+  <!-- internal grid lines only -->
+  <line x1="12" y1="50" x2="88" y2="50" stroke="#3f3f46" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="50" y1="12" x2="50" y2="88" stroke="#3f3f46" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- low-risk dots (bottom-left) -->
+  <circle cx="24" cy="68" r="3.5" fill="#3f3f46"/>
+  <circle cx="33" cy="74" r="3.5" fill="#3f3f46"/>
+  <circle cx="40" cy="64" r="3.5" fill="#3f3f46"/>
+
+  <!-- medium dots (bottom-right) -->
+  <circle cx="62" cy="62" r="3.5" fill="#52525b"/>
+  <circle cx="72" cy="68" r="3.5" fill="#52525b"/>
+
+  <!-- high-risk outlier (top-right) — HOTSPOT -->
+  <circle cx="74" cy="26" r="7" fill="#f97316"/>
+  <!-- glow -->
+  <circle cx="74" cy="26" r="11" fill="#f97316" opacity="0.15"/>
 </svg>

--- a/hotspots-cli/Cargo.toml
+++ b/hotspots-cli/Cargo.toml
@@ -25,5 +25,8 @@ is-terminal = "0.4"
 owo-colors = "4"
 rayon = "1"
 
+[dev-dependencies]
+tempfile = "3.8"
+
 [lints]
 workspace = true

--- a/hotspots-cli/src/cmd/init.rs
+++ b/hotspots-cli/src/cmd/init.rs
@@ -113,10 +113,12 @@ jobs:
 "#;
 
 fn write_ci_workflow() -> anyhow::Result<()> {
-    // Resolve relative to cwd so the command works from any subdirectory.
     let cwd = std::env::current_dir()?;
     let repo_root = find_repo_root(&cwd).unwrap_or(cwd);
+    write_ci_workflow_at(&repo_root)
+}
 
+fn write_ci_workflow_at(repo_root: &Path) -> anyhow::Result<()> {
     let workflows_dir = repo_root.join(".github").join("workflows");
     let workflow_path = workflows_dir.join("hotspots.yml");
 
@@ -151,5 +153,60 @@ fn find_repo_root(start: &Path) -> Option<std::path::PathBuf> {
         if !dir.pop() {
             return None;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn find_repo_root_finds_git_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        let nested = root.join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+
+        let found = find_repo_root(&nested);
+        assert_eq!(found.as_deref(), Some(root));
+    }
+
+    #[test]
+    fn find_repo_root_returns_none_without_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        // no .git directory — must return None
+        assert!(find_repo_root(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn write_ci_workflow_creates_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ci_workflow_at(tmp.path()).unwrap();
+
+        let workflow_path = tmp
+            .path()
+            .join(".github")
+            .join("workflows")
+            .join("hotspots.yml");
+        assert!(workflow_path.exists(), "workflow file should be created");
+
+        let content = fs::read_to_string(&workflow_path).unwrap();
+        assert!(content.contains("name: Hotspots"));
+        assert!(content.contains("--mode snapshot"));
+        assert!(content.contains("--mode delta --policy"));
+    }
+
+    #[test]
+    fn write_ci_workflow_fails_if_already_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ci_workflow_at(tmp.path()).unwrap();
+
+        let err = write_ci_workflow_at(tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "expected 'already exists' error, got: {err}"
+        );
     }
 }

--- a/hotspots-cli/src/cmd/init.rs
+++ b/hotspots-cli/src/cmd/init.rs
@@ -106,7 +106,9 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             hotspots analyze . --mode delta --policy
           else
-            hotspots analyze . --mode snapshot
+            # --mode snapshot requires --format json (or --explain) when not
+            # printing text; the snapshot is persisted to .hotspots/ either way.
+            hotspots analyze . --mode snapshot --format json > /dev/null
           fi
 "#;
 

--- a/hotspots-cli/src/cmd/init.rs
+++ b/hotspots-cli/src/cmd/init.rs
@@ -1,10 +1,12 @@
 //! `hotspots init` — project setup helpers
 
-pub(crate) fn handle_init(hooks: bool) -> anyhow::Result<()> {
-    if hooks {
-        print_hooks();
-    } else {
-        eprintln!("Nothing to do. Try: hotspots init --hooks");
+use std::path::Path;
+
+pub(crate) fn handle_init(hooks: bool, ci: bool) -> anyhow::Result<()> {
+    match (hooks, ci) {
+        (true, _) => print_hooks(),
+        (_, true) => write_ci_workflow()?,
+        _ => eprintln!("Nothing to do. Try: hotspots init --hooks  or  hotspots init --ci"),
     }
     Ok(())
 }
@@ -45,4 +47,107 @@ repos:
 set -e
 hotspots analyze . --mode delta --policy --format text"#
     );
+}
+
+/// The GitHub Actions workflow content.
+///
+/// Strategy:
+///   - Push to main/master → snapshot mode: analyzes the full tree and persists
+///     the snapshot. The cache is saved under `hotspots-{sha}`.
+///   - Pull request → delta mode: restores the cache for the PR base branch
+///     commit (the snapshot built when that commit landed on main), then runs
+///     delta + policy against it.
+///
+/// On the very first run there is no warm cache yet. The delta run will report
+/// "no parent snapshot" and skip policy gating; policy kicks in from the second
+/// PR onward once the main-branch snapshot is cached.
+const GITHUB_WORKFLOW: &str = r#"name: Hotspots
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  hotspots:
+    name: Analyze code hotspots
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Hotspots CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/Stephen-Collins-tech/hotspots/main/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # On push-to-main we save the snapshot under hotspots-{sha}.
+      # On a PR we restore the snapshot for the base-branch commit so that
+      # delta mode has a baseline to diff against.
+      - name: Restore snapshot cache
+        uses: actions/cache@v4
+        with:
+          path: .hotspots/
+          key: hotspots-${{ github.sha }}
+          restore-keys: |
+            hotspots-${{ github.event.pull_request.base.sha }}
+            hotspots-
+
+      - name: Analyze (snapshot on main, delta on PR)
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            hotspots analyze . --mode delta --policy
+          else
+            hotspots analyze . --mode snapshot
+          fi
+"#;
+
+fn write_ci_workflow() -> anyhow::Result<()> {
+    // Resolve relative to cwd so the command works from any subdirectory.
+    let cwd = std::env::current_dir()?;
+    let repo_root = find_repo_root(&cwd).unwrap_or(cwd);
+
+    let workflows_dir = repo_root.join(".github").join("workflows");
+    let workflow_path = workflows_dir.join("hotspots.yml");
+
+    if workflow_path.exists() {
+        anyhow::bail!(
+            "{} already exists. Remove it first or edit it manually.",
+            workflow_path.display()
+        );
+    }
+
+    std::fs::create_dir_all(&workflows_dir)?;
+    std::fs::write(&workflow_path, GITHUB_WORKFLOW)?;
+
+    eprintln!("Wrote {}", workflow_path.display());
+    eprintln!();
+    eprintln!("How it works:");
+    eprintln!("  push to main  →  hotspots analyze --mode snapshot  (builds the baseline)");
+    eprintln!("  pull request  →  hotspots analyze --mode delta --policy  (gates on risk)");
+    eprintln!();
+    eprintln!("Commit the file and push to enable the check on your next PR.");
+
+    Ok(())
+}
+
+/// Walk up from `start` until a `.git` directory is found.
+fn find_repo_root(start: &Path) -> Option<std::path::PathBuf> {
+    let mut dir = start.to_path_buf();
+    loop {
+        if dir.join(".git").exists() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
 }

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -184,6 +184,9 @@ enum Commands {
         /// Print pre-commit framework and raw shell hook templates to stdout
         #[arg(long)]
         hooks: bool,
+        /// Write a GitHub Actions workflow to .github/workflows/hotspots.yml
+        #[arg(long)]
+        ci: bool,
     },
     /// Compare analysis snapshots between two git refs
     Diff {
@@ -341,7 +344,7 @@ fn main() -> anyhow::Result<()> {
             window,
             top,
         } => cmd::trends::handle_trends(path, format, window, top)?,
-        Commands::Init { hooks } => cmd::init::handle_init(hooks)?,
+        Commands::Init { hooks, ci } => cmd::init::handle_init(hooks, ci)?,
         Commands::Diff {
             base,
             head,

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -1247,4 +1247,30 @@ mod tests {
         let result = resolve_ref_to_sha(&cwd, "refs/heads/this-branch-definitely-does-not-exist");
         assert!(result.is_err(), "invalid ref should return an error");
     }
+
+    #[test]
+    fn resolve_merge_base_auto_does_not_panic() {
+        // This function returns None when no common branch exists — that is
+        // the expected outcome in environments where the repo has no main/master
+        // branch (e.g., a detached shallow clone with only origin/* refs).
+        // The important invariant: it must not panic regardless of git state.
+        let _result: Option<String> = resolve_merge_base_auto();
+        // No assertion on value — just verifying no panic and correct return type.
+    }
+
+    #[test]
+    fn resolve_merge_base_auto_returns_none_in_no_git_repo() {
+        // In a tempdir with no git repo every merge-base attempt fails → None.
+        let tmp = tempfile::tempdir().unwrap();
+        let old_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let result = resolve_merge_base_auto();
+
+        std::env::set_current_dir(old_dir).unwrap();
+        assert!(
+            result.is_none(),
+            "should return None when not in a git repo"
+        );
+    }
 }

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -305,13 +305,20 @@ pub fn resolve_merge_base(target_branch: &str) -> Result<Option<String>> {
 
 /// Resolve merge-base with common target branches
 ///
-/// Tries common branch names (main, master, develop) to find merge-base.
-/// Returns first successful merge-base, or None if all fail.
+/// Tries local and remote-tracking names (main, origin/main, master, …) so
+/// this works both locally (where `main` is checked out) and in CI shallow
+/// clones (where only `origin/main` exists as a remote-tracking ref).
 pub fn resolve_merge_base_auto() -> Option<String> {
-    let common_branches = ["main", "master", "develop", "trunk"];
+    let base_names = ["main", "master", "develop", "trunk"];
 
-    for branch in &common_branches {
-        if let Ok(Some(sha)) = resolve_merge_base(branch) {
+    for base in &base_names {
+        if let Ok(Some(sha)) = resolve_merge_base(base) {
+            return Some(sha);
+        }
+        // In CI (GitHub Actions), local branch refs don't exist; only
+        // remote-tracking refs like origin/main are available.
+        let remote = format!("origin/{base}");
+        if let Ok(Some(sha)) = resolve_merge_base(&remote) {
             return Some(sha);
         }
     }


### PR DESCRIPTION
## Summary
- Adds `hotspots init --ci` command that writes a ready-to-use GitHub Actions workflow to `.github/workflows/hotspots.yml`
- Workflow runs snapshot mode on push to main/master and delta + policy mode on PRs, using the Actions cache as a snapshot store
- Fixes `resolve_merge_base_auto` to also try `origin/<branch>` refs so delta mode finds the correct base in CI shallow clones (where local branch refs don't exist)
- Updates the README/repo favicon to the hotspots.dev icon

## Test plan
- [ ] `cargo test` passes (6 new tests added)
- [ ] `hotspots init --ci` in a git repo creates `.github/workflows/hotspots.yml`
- [ ] Running `hotspots init --ci` a second time returns an "already exists" error
- [ ] `find_repo_root` walks up nested dirs and returns `None` when no `.git` found
- [ ] `resolve_merge_base_auto` returns `None` gracefully outside a git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)