### PR TITLE
docs: document --screen flag and TS/TSX function naming

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -502,6 +502,18 @@ hotspots train . --blame --label-window 180
 **Optional.** Output path for the trained model JSON.
 **Default:** `.hotspots/ranker.json`
 
+##### `--screen`
+**Optional.** Run a pre-flight check before training to verify the repo has enough signal for a useful model.
+
+`--screen` inspects the repo's git history and snapshot without fitting any model. It checks three things: whether there are enough fix commits in the label window, whether the snapshot has enough labeled functions, and whether the positive/negative label ratio is workable. If any check fails it prints a clear reason and exits without training.
+
+Use it when you're not sure whether a repo is a good candidate for training, or to diagnose why a previous `hotspots train` produced a poor model.
+
+```bash
+hotspots train . --screen            # check only, no model written
+hotspots train . --blame --screen    # blame-mode label scan, then check
+```
+
 ##### `--eval`
 **Optional.** After training, evaluate the model using Precision@K and print a table.
 

--- a/docs/reference/language-support.md
+++ b/docs/reference/language-support.md
@@ -22,6 +22,8 @@ Hotspots supports seven languages. All produce the same metrics (CC, ND, FO, NS,
 
 JSX and TSX are fully supported. Short-circuit operators (`&&`, `||`) and ternaries count toward CC. Arrow functions, class methods, and standalone functions are all analyzed.
 
+Arrow functions and function expressions assigned to a variable or property are named after their binding — `const validate = (x) => …` appears in output as `validate`, not as an anonymous function. This applies to `.ts`, `.tsx`, `.mts`, and `.cts` files.
+
 ### Go
 
 Goroutines, defer, select, and channel operations are supported. Each `case` in a `select` counts toward CC.


### PR DESCRIPTION
Documents the two features shipped in v1.25.0:

- `--screen` option added to `hotspots train` section in cli.md
- TS/TSX variable-assigned function naming noted in language-support.md