### PR TITLE
feat: add npm and PyPI distribution channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,46 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish packages/hotspots --access public
 
+  publish-pypi:
+    name: Publish to PyPI (${{ matrix.target }})
+    needs: bump-and-tag
+    if: inputs.dry_run != true
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.bump-and-tag.outputs.tag }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build and publish wheel
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: maturin publish --target ${{ matrix.target }} --no-sdist
+
   publish-crates:
     name: Publish to crates.io
     needs: bump-and-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,75 @@ jobs:
           echo "**Artifacts:**" >> $GITHUB_STEP_SUMMARY
           ls -lh artifacts/ >> $GITHUB_STEP_SUMMARY
 
+  publish-npm:
+    name: Publish to npm
+    needs: [bump-and-tag, build-binaries]
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.bump-and-tag.outputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Unpack binaries into platform packages
+        run: |
+          mkdir -p packages/hotspots-linux-x64/bin
+          mkdir -p packages/hotspots-darwin-arm64/bin
+          mkdir -p packages/hotspots-win32-x64/bin
+
+          tar -xzf artifacts/hotspots-linux-x86_64.tar.gz -C packages/hotspots-linux-x64/bin/
+          tar -xzf artifacts/hotspots-darwin-aarch64.tar.gz -C packages/hotspots-darwin-arm64/bin/
+          unzip -o artifacts/hotspots-windows-x86_64.zip -d packages/hotspots-win32-x64/bin/
+
+          chmod +x packages/hotspots-linux-x64/bin/hotspots
+          chmod +x packages/hotspots-darwin-arm64/bin/hotspots
+
+      - name: Set versions
+        run: |
+          TAG="${{ needs.bump-and-tag.outputs.tag }}"
+          VERSION="${TAG#v}"
+          for pkg in packages/hotspots-linux-x64 packages/hotspots-darwin-arm64 packages/hotspots-win32-x64 packages/hotspots; do
+            node -e "
+              const fs = require('fs');
+              const p = fs.readFileSync('$pkg/package.json', 'utf8');
+              const j = JSON.parse(p);
+              j.version = '$VERSION';
+              if (j.optionalDependencies) {
+                for (const k of Object.keys(j.optionalDependencies)) {
+                  j.optionalDependencies[k] = '$VERSION';
+                }
+              }
+              fs.writeFileSync('$pkg/package.json', JSON.stringify(j, null, 2) + '\n');
+            "
+          done
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish packages/hotspots-linux-x64 --access public
+          npm publish packages/hotspots-darwin-arm64 --access public
+          npm publish packages/hotspots-win32-x64 --access public
+
+      - name: Publish wrapper package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish packages/hotspots --access public
+
   publish-crates:
     name: Publish to crates.io
     needs: bump-and-tag

--- a/packages/hotspots-darwin-arm64/package.json
+++ b/packages/hotspots-darwin-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@stephencollinstech/hotspots-darwin-arm64",
+  "version": "0.0.0",
+  "description": "macOS arm64 binary for hotspots",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["bin/hotspots"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Stephen-Collins-tech/hotspots.git",
+    "directory": "packages/hotspots-darwin-arm64"
+  },
+  "homepage": "https://hotspots.dev"
+}

--- a/packages/hotspots-linux-x64/package.json
+++ b/packages/hotspots-linux-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@stephencollinstech/hotspots-linux-x64",
+  "version": "0.0.0",
+  "description": "Linux x64 binary for hotspots",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["bin/hotspots"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Stephen-Collins-tech/hotspots.git",
+    "directory": "packages/hotspots-linux-x64"
+  },
+  "homepage": "https://hotspots.dev"
+}

--- a/packages/hotspots-win32-x64/package.json
+++ b/packages/hotspots-win32-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@stephencollinstech/hotspots-win32-x64",
+  "version": "0.0.0",
+  "description": "Windows x64 binary for hotspots",
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "files": ["bin/hotspots.exe"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Stephen-Collins-tech/hotspots.git",
+    "directory": "packages/hotspots-win32-x64"
+  },
+  "homepage": "https://hotspots.dev"
+}

--- a/packages/hotspots/bin/hotspots.js
+++ b/packages/hotspots/bin/hotspots.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+const os = require("os");
+
+function getBinaryPath() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  let pkgName;
+  let binName;
+
+  if (platform === "linux" && arch === "x64") {
+    pkgName = "@stephencollinstech/hotspots-linux-x64";
+    binName = "hotspots";
+  } else if (platform === "darwin" && arch === "arm64") {
+    pkgName = "@stephencollinstech/hotspots-darwin-arm64";
+    binName = "hotspots";
+  } else if (platform === "win32" && arch === "x64") {
+    pkgName = "@stephencollinstech/hotspots-win32-x64";
+    binName = "hotspots.exe";
+  } else {
+    console.error(
+      `hotspots: unsupported platform ${platform}/${arch}\n` +
+        `Supported: linux/x64, darwin/arm64, win32/x64\n` +
+        `Install from source: cargo install hotspots-cli`
+    );
+    process.exit(1);
+  }
+
+  try {
+    return require.resolve(`${pkgName}/bin/${binName}`);
+  } catch {
+    console.error(
+      `hotspots: could not find binary package ${pkgName}\n` +
+        `Try reinstalling: npm install hotspots`
+    );
+    process.exit(1);
+  }
+}
+
+const bin = getBinaryPath();
+
+try {
+  execFileSync(bin, process.argv.slice(2), { stdio: "inherit" });
+} catch (err) {
+  process.exit(err.status ?? 1);
+}

--- a/packages/hotspots/package.json
+++ b/packages/hotspots/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "hotspots",
+  "version": "0.0.0",
+  "description": "Static analysis CLI for TypeScript that computes Local Risk Score (LRS)",
+  "bin": {
+    "hotspots": "./bin/hotspots.js"
+  },
+  "files": ["bin/hotspots.js"],
+  "scripts": {
+    "postinstall": "node bin/hotspots.js --version > /dev/null 2>&1 || true"
+  },
+  "optionalDependencies": {
+    "@stephencollinstech/hotspots-linux-x64": "0.0.0",
+    "@stephencollinstech/hotspots-darwin-arm64": "0.0.0",
+    "@stephencollinstech/hotspots-win32-x64": "0.0.0"
+  },
+  "keywords": [
+    "hotspots",
+    "complexity",
+    "static-analysis",
+    "typescript",
+    "code-quality",
+    "lrs",
+    "cyclomatic-complexity"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Stephen-Collins-tech/hotspots.git",
+    "directory": "packages/hotspots"
+  },
+  "bugs": {
+    "url": "https://github.com/Stephen-Collins-tech/hotspots/issues"
+  },
+  "homepage": "https://hotspots.dev"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.5,<2"]
 build-backend = "maturin"
 
 [project]
-name = "hotspots"
+name = "hotspots-cli"
 description = "Static analysis CLI for TypeScript, JavaScript, Go, Python, Rust, and Java that computes Local Risk Score (LRS)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["maturin>=1.5,<2"]
+build-backend = "maturin"
+
+[project]
+name = "hotspots"
+description = "Static analysis CLI for TypeScript, JavaScript, Go, Python, Rust, and Java that computes Local Risk Score (LRS)"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.8"
+keywords = [
+  "hotspots",
+  "complexity",
+  "static-analysis",
+  "typescript",
+  "code-quality",
+  "lrs",
+  "cyclomatic-complexity",
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Rust",
+  "Topic :: Software Development :: Quality Assurance",
+]
+
+[project.urls]
+Homepage = "https://hotspots.dev"
+Repository = "https://github.com/Stephen-Collins-tech/hotspots"
+Issues = "https://github.com/Stephen-Collins-tech/hotspots/issues"
+
+[tool.maturin]
+manifest-path = "hotspots-cli/Cargo.toml"
+strip = true


### PR DESCRIPTION
## Summary
- Adds `hotspots` wrapper package + 3 platform packages (`@stephencollinstech/hotspots-linux-x64`, `@stephencollinstech/hotspots-darwin-arm64`, `@stephencollinstech/hotspots-win32-x64`) for npm distribution
- Adds `pyproject.toml` for PyPI distribution via maturin as `hotspots-cli` (binary stays `hotspots`)
- Adds `publish-npm` and `publish-pypi` jobs to `release.yml`, running after `build-binaries`

## Test plan
- [ ] Add `NPM_TOKEN` and `PYPI_TOKEN` to GitHub Actions secrets (already done)
- [ ] Trigger a dry-run release to verify workflow jobs appear and pass quality gates
- [ ] On first real release, confirm `hotspots` appears on npmjs.com and `hotspots-cli` appears on pypi.org
- [ ] Verify `npm install -g hotspots` and `pip install hotspots-cli` install a working binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)