### PR TITLE
fix: use ./ prefix for npm publish local paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,14 +271,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish ./packages/hotspots-linux-x64 --access public
-          npm publish ./packages/hotspots-darwin-arm64 --access public
-          npm publish ./packages/hotspots-win32-x64 --access public
+          cd packages/hotspots-linux-x64 && npm publish --access public && cd ../..
+          cd packages/hotspots-darwin-arm64 && npm publish --access public && cd ../..
+          cd packages/hotspots-win32-x64 && npm publish --access public && cd ../..
 
       - name: Publish wrapper package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish ./packages/hotspots --access public
+        run: cd packages/hotspots && npm publish --access public
 
   publish-pypi:
     name: Publish to PyPI (${{ matrix.target }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,14 +271,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish packages/hotspots-linux-x64 --access public
-          npm publish packages/hotspots-darwin-arm64 --access public
-          npm publish packages/hotspots-win32-x64 --access public
+          npm publish ./packages/hotspots-linux-x64 --access public
+          npm publish ./packages/hotspots-darwin-arm64 --access public
+          npm publish ./packages/hotspots-win32-x64 --access public
 
       - name: Publish wrapper package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish packages/hotspots --access public
+        run: npm publish ./packages/hotspots --access public
 
   publish-pypi:
     name: Publish to PyPI (${{ matrix.target }})


### PR DESCRIPTION
## Summary
- npm was interpreting `packages/hotspots-linux-x64` as a GitHub shorthand (`<org>/<repo>`) instead of a local directory path, causing a git SSH permission error on publish
- Fix: prefix all `npm publish` paths with `./` to force local directory resolution

## Test plan
- [ ] Trigger a patch release and confirm `publish-npm` job completes without the git SSH error

🤖 Generated with [Claude Code](https://claude.com/claude-code)