### PR TITLE
fix: scope wrapper npm package to @stephencollinstech/hotspots

### DIFF
--- a/packages/hotspots/package.json
+++ b/packages/hotspots/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hotspots",
+  "name": "@stephencollinstech/hotspots",
   "version": "0.0.0",
   "description": "Static analysis CLI for TypeScript that computes Local Risk Score (LRS)",
   "bin": {


### PR DESCRIPTION
## Summary
- `hotspots` on npm is taken — rename wrapper package to `@stephencollinstech/hotspots`
- Users install with: `npm install -g @stephencollinstech/hotspots`
- Also includes subshell fix for `cd` isolation in publish steps (landed on main directly, this PR carries it forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)