### PR TITLE
fix: add --label-before to hotspots train

### DIFF
--- a/hotspots-cli/src/cmd/train.rs
+++ b/hotspots-cli/src/cmd/train.rs
@@ -14,6 +14,7 @@ pub(crate) struct TrainArgs {
     pub path: PathBuf,
     pub output: PathBuf,
     pub label_window_days: u32,
+    pub label_before: Option<String>,
     pub n_estimators: usize,
     pub max_depth: usize,
     pub blame_labels: bool,
@@ -36,6 +37,7 @@ pub(crate) fn handle_train(args: TrainArgs) -> Result<()> {
 
     let cfg = TrainConfig {
         label_window_days: args.label_window_days,
+        label_before: args.label_before.clone(),
         n_estimators: args.n_estimators,
         max_depth: args.max_depth,
         blame_labels: args.blame_labels,
@@ -143,7 +145,13 @@ pub(crate) fn handle_train(args: TrainArgs) -> Result<()> {
             model.save(&args.output)?;
             eprintln!("Model saved → {}", args.output.display());
             if args.eval {
-                run_eval(&model, &snapshot, &repo_root, args.label_window_days)?;
+                run_eval(
+                    &model,
+                    &snapshot,
+                    &repo_root,
+                    args.label_window_days,
+                    args.label_before.as_deref(),
+                )?;
             }
         }
     }
@@ -183,8 +191,9 @@ fn run_eval(
     snapshot: &Snapshot,
     repo_root: &Path,
     label_window_days: u32,
+    label_before: Option<&str>,
 ) -> Result<()> {
-    let fix_files = collect_fix_files(repo_root, label_window_days)?;
+    let fix_files = collect_fix_files(repo_root, label_window_days, label_before)?;
     let base_rate = snapshot.functions.len() as f64;
 
     let labels: std::collections::HashMap<FunctionId, bool> = snapshot

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -234,6 +234,12 @@ enum Commands {
         #[arg(long, default_value = "365")]
         label_window: u32,
 
+        /// Upper bound for the label window (ISO date, e.g. "2025-01-01").
+        /// When set, only fix commits before this date are used as training labels.
+        /// Useful for matching a specific benchmark label window exactly.
+        #[arg(long)]
+        label_before: Option<String>,
+
         /// Number of trees in the RandomForest
         #[arg(long, default_value = "200")]
         n_estimators: usize,
@@ -382,6 +388,7 @@ fn main() -> anyhow::Result<()> {
             path,
             output,
             label_window,
+            label_before,
             n_estimators,
             max_depth,
             blame,
@@ -393,6 +400,7 @@ fn main() -> anyhow::Result<()> {
             path,
             output,
             label_window_days: label_window,
+            label_before,
             n_estimators,
             max_depth,
             blame_labels: blame,

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -121,19 +121,28 @@ pub fn extract_features(func: &FunctionSnapshot) -> [f64; 10] {
 
 /// Returns the set of file paths touched by fix-keyword commits in the last
 /// `window_days` days.  Uses `git log` via subprocess; tolerates missing git.
-pub fn collect_fix_files(repo_root: &Path, window_days: u32) -> Result<HashSet<String>> {
+pub fn collect_fix_files(
+    repo_root: &Path,
+    window_days: u32,
+    before: Option<&str>,
+) -> Result<HashSet<String>> {
     use std::process::Command;
 
     let after = format!("{}.days.ago", window_days);
+    let mut git_args = vec![
+        "log",
+        "--after",
+        &after,
+        "--name-only",
+        "--pretty=format:%s",
+        "--diff-filter=M",
+    ];
+    if let Some(b) = before {
+        git_args.push("--before");
+        git_args.push(b);
+    }
     let out = Command::new("git")
-        .args([
-            "log",
-            "--after",
-            &after,
-            "--name-only",
-            "--pretty=format:%s",
-            "--diff-filter=M",
-        ])
+        .args(&git_args)
         .current_dir(repo_root)
         .output()
         .context("git log failed")?;
@@ -192,6 +201,7 @@ pub fn collect_fix_functions(
     snapshot: &Snapshot,
     repo_root: &Path,
     window_days: u32,
+    before: Option<&str>,
 ) -> Result<HashSet<(String, u32)>> {
     use std::process::Command;
 
@@ -218,15 +228,20 @@ pub fn collect_fix_functions(
     // Collect fix commit SHAs and their touched files in one git log pass.
     // Format: "<sha>|<subject>" followed by filenames, separated by blank lines.
     let after = format!("{}.days.ago", window_days);
+    let mut git_args = vec![
+        "log",
+        "--after",
+        &after,
+        "--name-only",
+        "--pretty=format:%H|%s",
+        "--diff-filter=M",
+    ];
+    if let Some(b) = before {
+        git_args.push("--before");
+        git_args.push(b);
+    }
     let out = Command::new("git")
-        .args([
-            "log",
-            "--after",
-            &after,
-            "--name-only",
-            "--pretty=format:%H|%s",
-            "--diff-filter=M",
-        ])
+        .args(&git_args)
         .current_dir(repo_root)
         .output()
         .context("git log failed")?;
@@ -341,6 +356,10 @@ pub struct TrainConfig {
     /// Use blame-based function-level labelling instead of file-level labelling.
     /// More precise labels but slower (one git diff-tree subprocess per fix commit).
     pub blame_labels: bool,
+    /// Optional upper bound for the label window (ISO date string, e.g. "2025-01-01").
+    /// When set, only commits before this date are used as training labels.
+    /// Useful for matching a specific benchmark label window.
+    pub label_before: Option<String>,
 }
 
 impl Default for TrainConfig {
@@ -351,6 +370,7 @@ impl Default for TrainConfig {
             max_depth: 6,
             seed: 42,
             blame_labels: false,
+            label_before: None,
         }
     }
 }
@@ -393,7 +413,12 @@ pub fn train(
     let mut rows: Vec<([f64; 10], bool)> = Vec::new();
 
     if cfg.blame_labels {
-        let fix_funcs = collect_fix_functions(&snapshot, repo_root, cfg.label_window_days)?;
+        let fix_funcs = collect_fix_functions(
+            &snapshot,
+            repo_root,
+            cfg.label_window_days,
+            cfg.label_before.as_deref(),
+        )?;
         let (prefix_can, prefix_raw) = repo_prefixes(repo_root);
         for func in &snapshot.functions {
             let rel = make_rel(&func.file, &prefix_can, &prefix_raw);
@@ -401,7 +426,11 @@ pub fn train(
             rows.push((extract_features(func), label));
         }
     } else {
-        let fix_files = collect_fix_files(repo_root, cfg.label_window_days)?;
+        let fix_files = collect_fix_files(
+            repo_root,
+            cfg.label_window_days,
+            cfg.label_before.as_deref(),
+        )?;
         for func in &snapshot.functions {
             let file_norm = func.file.replace('\\', "/");
             let label = fix_files.contains(&file_norm)

--- a/hotspots-core/tests/trainer_tests.rs
+++ b/hotspots-core/tests/trainer_tests.rs
@@ -163,7 +163,7 @@ fn extract_features_with_churn_and_callgraph() {
 fn collect_fix_files_no_fix_commits() {
     let dir = init_repo();
     commit_file(dir.path(), "readme.txt", "hello", "initial commit");
-    let files = collect_fix_files(dir.path(), 365).expect("collect_fix_files");
+    let files = collect_fix_files(dir.path(), 365, None).expect("collect_fix_files");
     assert!(files.is_empty());
 }
 
@@ -185,7 +185,7 @@ fn collect_fix_files_detects_fix_keyword() {
     );
     commit_file(p, "baz.rs", "fn baz() { 1 }", "chore: cleanup baz");
 
-    let files = collect_fix_files(p, 365).expect("collect_fix_files");
+    let files = collect_fix_files(p, 365, None).expect("collect_fix_files");
     assert!(
         files.contains("bar.rs"),
         "fix commit file should be labelled"
@@ -221,7 +221,7 @@ fn collect_fix_files_all_keywords() {
     ] {
         commit_file(p, file, "updated content", msg);
     }
-    let files = collect_fix_files(p, 365).expect("collect_fix_files");
+    let files = collect_fix_files(p, 365, None).expect("collect_fix_files");
     for f in &["a.rs", "b.rs", "c.rs", "d.rs", "e.rs"] {
         assert!(files.contains(*f), "{} should be labelled", f);
     }
@@ -255,7 +255,7 @@ fn collect_fix_functions_labels_correct_function() {
         make_func("mod.py", "beta", 4),
     ]);
 
-    let labelled = collect_fix_functions(&snapshot, p, 365).expect("collect_fix_functions");
+    let labelled = collect_fix_functions(&snapshot, p, 365, None).expect("collect_fix_functions");
 
     assert!(
         labelled.contains(&("mod.py".to_string(), 4)),
@@ -281,7 +281,7 @@ fn collect_fix_functions_ignores_non_fix_commits() {
     );
 
     let snapshot = make_snapshot(vec![make_func("mod.py", "foo", 1)]);
-    let labelled = collect_fix_functions(&snapshot, p, 365).expect("collect_fix_functions");
+    let labelled = collect_fix_functions(&snapshot, p, 365, None).expect("collect_fix_functions");
     assert!(labelled.is_empty());
 }
 


### PR DESCRIPTION
## Summary

- `hotspots train --label-window N` counts back N days from **today**, not from the snapshot date
- On benchmark repos checked out at a historical feature SHA but with post-cutoff commits fetched, the window spans 2024–2026 — labelling 88–98% of functions positive
- A near-degenerate label distribution collapses ρ (curl: +0.476 → -0.008) and destroys P@10 (curl: 1.00 → 0.20)
- Adds `--label-before <ISO date>` to bound the label window on both sides, matching the benchmark label protocol exactly

**Usage for benchmark:**
\`\`\`bash
hotspots train . --label-window 909 --label-before 2025-01-01
\`\`\`
Captures exactly 2024-01-01 → 2025-01-01 — the same window used by `label.py` and `score.py`.

## Test plan

- [ ] `cargo test` passes (418 tests)
- [ ] `hotspots train --help` shows `--label-before` option
- [ ] Training with `--label-before 2025-01-01` on a benchmark repo produces balanced labels (~30-50% positive vs 88-98% without the flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)