### PR TITLE
Per-repo policy severity config + fix GIT_DIR cwd bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -349,7 +349,12 @@ Validate: `hotspots config validate` / Inspect resolved: `hotspots config show`
   "co_change_window_days": 90,
   "co_change_min_count": 3,
   "driver_threshold_percentile": 75,
-  "per_function_touches": true
+  "per_function_touches": true,
+  "policy": {
+    "critical_introduction": "warn",
+    "critical_introduction_reason": "research repo — new one-shot eval scripts routinely score Critical on introduction; see docs/REFERENCE.md#policy",
+    "excessive_risk_regression": "block"
+  }
 }
 ```
 
@@ -357,7 +362,27 @@ Validate: `hotspots config validate` / Inspect resolved: `hotspots config show`
 - `moderate < high < critical` (all positive)
 - `watch_min < watch_max ≤ moderate < attention_min < attention_max ≤ high`
 - All weights non-negative; at least one positive; none > 10.0
+- `policy.*` values must be one of `"block"`, `"warn"`, `"off"`
+- `policy.<name>_reason` is **required** (non-empty) whenever `policy.<name>` is not `"block"`
 - Unknown fields are rejected (to catch typos)
+
+**`policy`:** severity overrides for the two blocking CI policies. Both default to
+`"block"`. `critical-introduction` fires identically whether a function is brand-new or
+an existing function that regressed to Critical — a Critical function needs review
+either way, so there is no separate new-vs-regressed knob, only overall severity.
+Set to `"warn"` to report without failing CI (e.g. a research repo where new
+one-shot scripts are expected to score high on introduction), or `"off"` to disable
+the policy entirely. Raising `thresholds.critical` instead changes what counts as
+Critical repo-wide (affecting reporting too); `policy` only changes what happens
+once something *is* Critical.
+
+Downgrading a policy below `"block"` requires a `<name>_reason` string — mirroring the
+`// hotspots-ignore: <reason>` convention for per-function suppression — so that anyone
+reviewing a `.hotspotsrc.json` diff sees *why* a blocking gate was weakened, not just
+that it was. `hotspots config validate` rejects a downgrade with a missing or
+whitespace-only reason. This does not make the override unbypassable — anyone with
+commit access to the config can still weaken it, the same as anyone with access to a CI
+workflow file can remove a required check — but it does mean the change can't be silent.
 
 **`driver_threshold_percentile`:** default 75 means a function must be in the top 25% of its metric to receive a specific driver label. Lower (50–60) for small/uniform repos; higher (85–90) for large repos with high median complexity.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -352,7 +352,7 @@ Validate: `hotspots config validate` / Inspect resolved: `hotspots config show`
   "per_function_touches": true,
   "policy": {
     "critical_introduction": "warn",
-    "critical_introduction_reason": "research repo — new one-shot eval scripts routinely score Critical on introduction; see docs/REFERENCE.md#policy",
+    "critical_introduction_reason": "eval/ scripts are one-shot research code reviewed case-by-case, not shipped services — approved by @teamlead 2026-07-06",
     "excessive_risk_regression": "block"
   }
 }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -352,7 +352,7 @@ Validate: `hotspots config validate` / Inspect resolved: `hotspots config show`
   "per_function_touches": true,
   "policy": {
     "critical_introduction": "warn",
-    "critical_introduction_reason": "eval/ scripts are one-shot research code reviewed case-by-case, not shipped services — approved by @teamlead 2026-07-06",
+    "critical_introduction_reason": "eval/ scripts are one-shot research code reviewed case-by-case, not shipped services — approved by @stephenc222 2026-07-06",
     "excessive_risk_regression": "block"
   }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -84,7 +84,7 @@ hotspots diff main HEAD
 
 The policy engine runs in delta mode (`--mode delta --policy` or `hotspots diff ... --policy`).
 
-**Blocking (exit code 1):**
+**Blocking by default (exit code 1) — severity configurable, see below:**
 - `critical-introduction` — new or existing function crosses LRS ≥ 9.0
 - `excessive-risk-regression` — LRS increases by ≥ 1.0 on a modified function
 
@@ -107,6 +107,41 @@ Configure thresholds in `.hotspotsrc.json`:
   }
 }
 ```
+
+### Downgrading a blocking policy for your repo
+
+`critical-introduction` fires the same way whether a function is brand-new or an
+existing function that regressed — a Critical function needs review either way. But
+some repos have a legitimately different baseline: a research repo shipping dense,
+one-shot experiment scripts will routinely introduce Critical-scoring functions on
+day one, and blocking CI on every one of them is noise, not signal.
+
+If that's your repo, downgrade the policy in `.hotspotsrc.json` instead of annotating
+every function with `// hotspots-ignore` or excluding files forever (which also loses
+future regression detection on them):
+
+```json
+{
+  "policy": {
+    "critical_introduction": "warn",
+    "critical_introduction_reason": "eval/ scripts are one-shot research code reviewed case-by-case, not shipped services — approved by @yourhandle 2026-07-06"
+  }
+}
+```
+
+Each policy accepts `"block"` (default), `"warn"` (report, exit 0), or `"off"`
+(skip entirely). Downgrading below `"block"` **requires** a `<name>_reason` string —
+`hotspots config validate` rejects a missing or blank one. This mirrors the
+`// hotspots-ignore: <reason>` convention: the point isn't to make the gate
+unbypassable (anyone with commit access to `.hotspotsrc.json` can weaken it, same as
+anyone with access to a CI workflow file can remove a required check) — it's to make
+sure the change can't be silent. A reviewer of the config diff sees *why* the gate was
+weakened, in the same place they see *that* it was.
+
+The same `"block"`/`"warn"`/`"off"` + `_reason` pattern applies to
+`excessive_risk_regression` via `policy.excessive_risk_regression` /
+`policy.excessive_risk_regression_reason`. Full field reference:
+[Configuration → `policy`](/REFERENCE#configuration).
 
 ## CI/CD Setup
 

--- a/hotspots-cli/src/cmd/config.rs
+++ b/hotspots-cli/src/cmd/config.rs
@@ -1,5 +1,21 @@
 use anyhow::Context;
 use hotspots_core::config;
+use hotspots_core::config::PolicyMode;
+
+fn policy_mode_str(mode: PolicyMode) -> &'static str {
+    match mode {
+        PolicyMode::Block => "block",
+        PolicyMode::Warn => "warn",
+        PolicyMode::Off => "off",
+    }
+}
+
+fn reason_suffix(reason: Option<&str>) -> String {
+    match reason {
+        Some(r) => format!(" ({r})"),
+        None => String::new(),
+    }
+}
 
 #[derive(clap::Subcommand)]
 pub(crate) enum ConfigAction {
@@ -89,6 +105,18 @@ pub(crate) fn handle_config(action: ConfigAction) -> anyhow::Result<()> {
                 } else {
                     "default"
                 }
+            );
+            println!();
+            println!("Policy:");
+            println!(
+                "  critical-introduction: {}{}",
+                policy_mode_str(resolved.critical_introduction_mode),
+                reason_suffix(resolved.critical_introduction_reason.as_deref())
+            );
+            println!(
+                "  excessive-risk-regression: {}{}",
+                policy_mode_str(resolved.excessive_risk_regression_mode),
+                reason_suffix(resolved.excessive_risk_regression_reason.as_deref())
             );
         }
     }

--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -159,6 +159,64 @@ pub struct HotspotsConfig {
     /// Pattern detection thresholds. Overrides defaults from `docs/patterns.md`.
     #[serde(default)]
     pub patterns: Option<PatternThresholdsConfig>,
+
+    /// Per-repo severity overrides for blocking policies.
+    #[serde(default)]
+    pub policy: Option<PolicyConfig>,
+}
+
+/// Severity for a blocking policy, as configured per-repo.
+///
+/// A repo whose baseline LRS naturally runs high (e.g. a research repo with
+/// dense, one-shot scripts) can downgrade a policy from `block` to `warn`, or
+/// disable it with `off`, without changing what counts as Critical (see
+/// `thresholds.critical`) or which findings are reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyMode {
+    Block,
+    Warn,
+    Off,
+}
+
+impl PolicyMode {
+    fn parse(field: &str, s: &str) -> Result<Self> {
+        match s {
+            "block" => Ok(PolicyMode::Block),
+            "warn" => Ok(PolicyMode::Warn),
+            "off" => Ok(PolicyMode::Off),
+            other => anyhow::bail!(
+                "policy.{} must be one of \"block\", \"warn\", \"off\" (got \"{}\")",
+                field,
+                other
+            ),
+        }
+    }
+}
+
+/// Per-repo severity overrides for blocking policies.
+///
+/// Both `critical-introduction` (a function becomes Critical) and
+/// `excessive-risk-regression` (an existing function jumps by >= 1.0 LRS)
+/// default to `block`. Note: `critical-introduction` fires identically
+/// whether the function is brand-new or an existing function regressed —
+/// a Critical function needs review either way, so there is deliberately
+/// no separate "new vs. regressed" knob here, only an overall severity.
+///
+/// Downgrading either policy below `block` requires a `_reason` string
+/// (mirroring the `// hotspots-ignore: <reason>` convention for per-function
+/// suppression), so a reviewer of the `.hotspotsrc.json` diff sees *why* a
+/// blocking gate was weakened, not just that it was.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyConfig {
+    /// Severity for `critical-introduction`: "block" | "warn" | "off" (default: "block")
+    pub critical_introduction: Option<String>,
+    /// Required when `critical_introduction` is not "block"
+    pub critical_introduction_reason: Option<String>,
+    /// Severity for `excessive-risk-regression`: "block" | "warn" | "off" (default: "block")
+    pub excessive_risk_regression: Option<String>,
+    /// Required when `excessive_risk_regression` is not "block"
+    pub excessive_risk_regression_reason: Option<String>,
 }
 
 /// Custom risk band thresholds
@@ -296,6 +354,14 @@ pub struct ResolvedConfig {
     pub scoring_weights: crate::scoring::ScoringWeights,
     /// Pattern detection thresholds
     pub pattern_thresholds: crate::patterns::Thresholds,
+    /// Severity for the `critical-introduction` policy (default: Block)
+    pub critical_introduction_mode: PolicyMode,
+    /// Reason given for downgrading `critical_introduction_mode` below Block (None if Block)
+    pub critical_introduction_reason: Option<String>,
+    /// Severity for the `excessive-risk-regression` policy (default: Block)
+    pub excessive_risk_regression_mode: PolicyMode,
+    /// Reason given for downgrading `excessive_risk_regression_mode` below Block (None if Block)
+    pub excessive_risk_regression_reason: Option<String>,
     /// Path the config was loaded from (None if defaults)
     pub config_path: Option<PathBuf>,
 }
@@ -317,6 +383,9 @@ impl HotspotsConfig {
         }
         if let Some(ref p) = self.patterns {
             validate_pattern_thresholds(p)?;
+        }
+        if let Some(ref p) = self.policy {
+            validate_policy_config(p)?;
         }
         validate_scalar_fields(self)?;
         validate_glob_patterns(&self.include, &self.exclude)
@@ -393,6 +462,42 @@ fn validate_thresholds(t: &ThresholdConfig) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn validate_policy_config(p: &PolicyConfig) -> Result<()> {
+    if let Some(ref s) = p.critical_introduction {
+        let mode = PolicyMode::parse("critical_introduction", s)?;
+        require_reason_if_downgraded(
+            "critical_introduction",
+            mode,
+            p.critical_introduction_reason.as_deref(),
+        )?;
+    }
+    if let Some(ref s) = p.excessive_risk_regression {
+        let mode = PolicyMode::parse("excessive_risk_regression", s)?;
+        require_reason_if_downgraded(
+            "excessive_risk_regression",
+            mode,
+            p.excessive_risk_regression_reason.as_deref(),
+        )?;
+    }
+    Ok(())
+}
+
+/// A policy downgraded below `block` must carry a non-empty `<field>_reason`,
+/// mirroring the `// hotspots-ignore: <reason>` convention — so a reviewer of
+/// the config diff sees why a blocking gate was weakened.
+fn require_reason_if_downgraded(field: &str, mode: PolicyMode, reason: Option<&str>) -> Result<()> {
+    if mode == PolicyMode::Block {
+        return Ok(());
+    }
+    match reason {
+        Some(r) if !r.trim().is_empty() => Ok(()),
+        _ => anyhow::bail!(
+            "policy.{field}_reason is required when policy.{field} is not \"block\" (explain why this gate is downgraded)",
+            field = field
+        ),
+    }
 }
 
 fn validate_weights(w: &WeightConfig) -> Result<()> {
@@ -634,6 +739,27 @@ impl HotspotsConfig {
             None => crate::patterns::Thresholds::default(),
         };
 
+        let (
+            critical_introduction_mode,
+            critical_introduction_reason,
+            excessive_risk_regression_mode,
+            excessive_risk_regression_reason,
+        ) = match &self.policy {
+            Some(p) => (
+                match &p.critical_introduction {
+                    Some(s) => PolicyMode::parse("critical_introduction", s)?,
+                    None => PolicyMode::Block,
+                },
+                p.critical_introduction_reason.clone(),
+                match &p.excessive_risk_regression {
+                    Some(s) => PolicyMode::parse("excessive_risk_regression", s)?,
+                    None => PolicyMode::Block,
+                },
+                p.excessive_risk_regression_reason.clone(),
+            ),
+            None => (PolicyMode::Block, None, PolicyMode::Block, None),
+        };
+
         Ok(ResolvedConfig {
             include,
             exclude,
@@ -653,6 +779,10 @@ impl HotspotsConfig {
             top_n: self.top,
             scoring_weights,
             pattern_thresholds,
+            critical_introduction_mode,
+            critical_introduction_reason,
+            excessive_risk_regression_mode,
+            excessive_risk_regression_reason,
             co_change_window_days: self.co_change_window_days.unwrap_or(90),
             co_change_min_count: self.co_change_min_count.unwrap_or(3),
             per_function_touches: self.per_function_touches.unwrap_or(false),

--- a/hotspots-core/src/git.rs
+++ b/hotspots-core/src/git.rs
@@ -61,12 +61,23 @@ pub struct BatchedTouchMetrics {
     pub days_since_last_change: std::collections::HashMap<String, u32>,
 }
 
+/// Environment variables git uses to locate a repository, bypassing normal
+/// cwd-based discovery entirely when set. If the calling process inherits
+/// these (e.g. hotspots-core is invoked from within a git hook, where git
+/// sets `GIT_DIR` for the hook subprocess), a bare `git` invocation silently
+/// operates on whatever repo `GIT_DIR` points at instead of the caller's
+/// intended cwd/path -- `current_dir()`/`-C` are ignored once `GIT_DIR` is
+/// present. Every git invocation below clears these first so behavior is
+/// determined solely by the explicit cwd/path this module was given.
+const GIT_DISCOVERY_ENV_VARS: [&str; 3] = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"];
+
 /// Execute a git command and return the trimmed stdout
 fn git(args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
-        .args(args)
-        .output()
-        .context("failed to invoke git")?;
+    let mut cmd = Command::new("git");
+    for var in GIT_DISCOVERY_ENV_VARS {
+        cmd.env_remove(var);
+    }
+    let output = cmd.args(args).output().context("failed to invoke git")?;
 
     if !output.status.success() {
         anyhow::bail!(
@@ -81,7 +92,11 @@ fn git(args: &[&str]) -> Result<String> {
 
 /// Execute a git command in a specific directory and return the trimmed stdout
 fn git_at(repo_path: &Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
+    let mut cmd = Command::new("git");
+    for var in GIT_DISCOVERY_ENV_VARS {
+        cmd.env_remove(var);
+    }
+    let output = cmd
         .current_dir(repo_path)
         .args(args)
         .output()
@@ -1131,8 +1146,25 @@ pub fn extract_co_change_pairs(
 mod tests {
     use super::*;
 
+    /// Serializes tests that depend on (or mutate) the process' ambient working
+    /// directory. `git()` (as opposed to `git_at()`) always runs relative to
+    /// `std::env::current_dir()`, and `cargo test` runs tests in parallel
+    /// threads within one process — CWD is shared, global, mutable state.
+    /// `resolve_merge_base_auto_returns_none_in_no_git_repo` below temporarily
+    /// points CWD at a git-free tempdir; without this lock, any other test in
+    /// this module that shells out to `git()` expecting to be in the repo can
+    /// race against that window and fail nondeterministically.
+    static CWD_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_cwd() -> std::sync::MutexGuard<'static, ()> {
+        CWD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[test]
     fn test_extract_git_context() {
+        let _guard = lock_cwd();
         // This test requires a git repository
         // Skip if not in a git repo (e.g., in CI without git context)
         if git(&["rev-parse", "--git-dir"]).is_err() {
@@ -1165,6 +1197,7 @@ mod tests {
 
     #[test]
     fn test_extract_commit_churn() {
+        let _guard = lock_cwd();
         // Skip if not in a git repo
         if git(&["rev-parse", "--git-dir"]).is_err() {
             eprintln!("Skipping test: not in a git repository");
@@ -1201,6 +1234,7 @@ mod tests {
 
     #[test]
     fn test_resolve_ref_to_sha_head() {
+        let _guard = lock_cwd();
         let cwd = std::env::current_dir().expect("failed to get cwd");
         if git_at(&cwd, &["rev-parse", "--git-dir"]).is_err() {
             eprintln!("Skipping test: not in a git repository");
@@ -1219,6 +1253,7 @@ mod tests {
 
     #[test]
     fn test_resolve_ref_to_sha_abbreviated() {
+        let _guard = lock_cwd();
         let cwd = std::env::current_dir().expect("failed to get cwd");
         if git_at(&cwd, &["rev-parse", "--git-dir"]).is_err() {
             eprintln!("Skipping test: not in a git repository");
@@ -1238,6 +1273,7 @@ mod tests {
 
     #[test]
     fn test_resolve_ref_to_sha_invalid_ref() {
+        let _guard = lock_cwd();
         let cwd = std::env::current_dir().expect("failed to get cwd");
         if git_at(&cwd, &["rev-parse", "--git-dir"]).is_err() {
             eprintln!("Skipping test: not in a git repository");
@@ -1250,6 +1286,7 @@ mod tests {
 
     #[test]
     fn resolve_merge_base_auto_does_not_panic() {
+        let _guard = lock_cwd();
         // This function returns None when no common branch exists — that is
         // the expected outcome in environments where the repo has no main/master
         // branch (e.g., a detached shallow clone with only origin/* refs).
@@ -1260,6 +1297,7 @@ mod tests {
 
     #[test]
     fn resolve_merge_base_auto_returns_none_in_no_git_repo() {
+        let _guard = lock_cwd();
         // In a tempdir with no git repo every merge-base attempt fails → None.
         let tmp = tempfile::tempdir().unwrap();
         let old_dir = std::env::current_dir().unwrap();

--- a/hotspots-core/src/policy.rs
+++ b/hotspots-core/src/policy.rs
@@ -8,7 +8,7 @@
 //! - Policy evaluation order is deterministic
 //! - Baseline deltas skip all policy evaluation
 
-use crate::config::ResolvedConfig;
+use crate::config::{PolicyMode, ResolvedConfig};
 use crate::delta::{Delta, FunctionDeltaEntry, FunctionStatus};
 use crate::risk::RiskBand;
 use crate::snapshot::Snapshot;
@@ -179,8 +179,8 @@ pub fn evaluate_policies(
 
     // Evaluation order: Blocking policies first, then warning policies, then repo-level
     // 1. Blocking function-level policies
-    evaluate_critical_introduction(&delta.deltas, &mut results);
-    evaluate_excessive_risk_regression(&delta.deltas, &mut results);
+    evaluate_critical_introduction(&delta.deltas, config, &mut results);
+    evaluate_excessive_risk_regression(&delta.deltas, config, &mut results);
 
     // 2. Warning function-level policies
     evaluate_watch_threshold(&delta.deltas, config, &mut results);
@@ -201,7 +201,27 @@ pub fn evaluate_policies(
 ///
 /// Triggers when `after.band == Critical AND (before.band != Critical OR before is None)`
 /// `before is None` means no matching `function_id` in the parent snapshot (delta status `new`)
-fn evaluate_critical_introduction(deltas: &[FunctionDeltaEntry], results: &mut PolicyResults) {
+///
+/// A brand-new function that scores Critical on its first commit and an existing function
+/// that regresses into Critical are treated identically here — a Critical function needs
+/// review either way, regardless of whether the code is new or old. `config.critical_introduction_mode`
+/// controls the severity of that review requirement repo-wide (block/warn/off); it does not
+/// distinguish new from regressed.
+fn evaluate_critical_introduction(
+    deltas: &[FunctionDeltaEntry],
+    config: &ResolvedConfig,
+    results: &mut PolicyResults,
+) {
+    if config.critical_introduction_mode == PolicyMode::Off {
+        return;
+    }
+
+    let severity = match config.critical_introduction_mode {
+        PolicyMode::Block => PolicySeverity::Blocking,
+        PolicyMode::Warn => PolicySeverity::Warning,
+        PolicyMode::Off => unreachable!("handled above"),
+    };
+
     for entry in active_deltas(deltas) {
         // Check if function becomes Critical
         let becomes_critical = if let Some(after) = &entry.after {
@@ -226,13 +246,18 @@ fn evaluate_critical_introduction(deltas: &[FunctionDeltaEntry], results: &mut P
         if !was_critical_before {
             let message = format!("Function {} introduced as Critical", entry.function_id);
 
-            results.failed.push(PolicyResult {
+            let result = PolicyResult {
                 id: PolicyId::CriticalIntroduction,
-                severity: PolicySeverity::Blocking,
+                severity,
                 function_id: Some(entry.function_id.clone()),
                 message,
                 metadata: None,
-            });
+            };
+
+            match severity {
+                PolicySeverity::Blocking => results.failed.push(result),
+                PolicySeverity::Warning => results.warnings.push(result),
+            }
         }
     }
 }
@@ -240,8 +265,23 @@ fn evaluate_critical_introduction(deltas: &[FunctionDeltaEntry], results: &mut P
 /// Evaluate Excessive Risk Regression policy
 ///
 /// Triggers when `status == Modified && delta.lrs >= 1.0`
-/// Threshold is fixed at 1.0 LRS (absolute, not relative)
-fn evaluate_excessive_risk_regression(deltas: &[FunctionDeltaEntry], results: &mut PolicyResults) {
+/// Threshold is fixed at 1.0 LRS (absolute, not relative).
+/// `config.excessive_risk_regression_mode` controls the severity (block/warn/off).
+fn evaluate_excessive_risk_regression(
+    deltas: &[FunctionDeltaEntry],
+    config: &ResolvedConfig,
+    results: &mut PolicyResults,
+) {
+    if config.excessive_risk_regression_mode == PolicyMode::Off {
+        return;
+    }
+
+    let severity = match config.excessive_risk_regression_mode {
+        PolicyMode::Block => PolicySeverity::Blocking,
+        PolicyMode::Warn => PolicySeverity::Warning,
+        PolicyMode::Off => unreachable!("handled above"),
+    };
+
     const REGRESSION_THRESHOLD: f64 = 1.0;
 
     for entry in active_deltas(deltas) {
@@ -258,9 +298,9 @@ fn evaluate_excessive_risk_regression(deltas: &[FunctionDeltaEntry], results: &m
                     entry.function_id, delta.lrs
                 );
 
-                results.failed.push(PolicyResult {
+                let result = PolicyResult {
                     id: PolicyId::ExcessiveRiskRegression,
-                    severity: PolicySeverity::Blocking,
+                    severity,
                     function_id: Some(entry.function_id.clone()),
                     message,
                     metadata: Some(PolicyMetadata {
@@ -268,7 +308,12 @@ fn evaluate_excessive_risk_regression(deltas: &[FunctionDeltaEntry], results: &m
                         total_delta: None,
                         growth_percent: None,
                     }),
-                });
+                };
+
+                match severity {
+                    PolicySeverity::Blocking => results.failed.push(result),
+                    PolicySeverity::Warning => results.warnings.push(result),
+                }
             }
         }
     }
@@ -576,6 +621,7 @@ mod tests {
     #[test]
     fn test_critical_introduction_new_function() {
         let mut results = PolicyResults::new();
+        let config = ResolvedConfig::defaults().unwrap();
         let deltas = vec![create_test_delta_entry(
             "src/foo.ts::handler",
             FunctionStatus::New,
@@ -584,7 +630,7 @@ mod tests {
             None,
         )];
 
-        evaluate_critical_introduction(&deltas, &mut results);
+        evaluate_critical_introduction(&deltas, &config, &mut results);
 
         assert_eq!(results.failed.len(), 1);
         assert_eq!(results.failed[0].id, PolicyId::CriticalIntroduction);
@@ -598,6 +644,7 @@ mod tests {
     #[test]
     fn test_critical_introduction_modified_function() {
         let mut results = PolicyResults::new();
+        let config = ResolvedConfig::defaults().unwrap();
         let deltas = vec![create_test_delta_entry(
             "src/foo.ts::handler",
             FunctionStatus::Modified,
@@ -606,7 +653,7 @@ mod tests {
             Some(2.3),
         )];
 
-        evaluate_critical_introduction(&deltas, &mut results);
+        evaluate_critical_introduction(&deltas, &config, &mut results);
 
         assert_eq!(results.failed.len(), 1);
         assert_eq!(results.failed[0].id, PolicyId::CriticalIntroduction);
@@ -615,6 +662,7 @@ mod tests {
     #[test]
     fn test_critical_introduction_no_violation() {
         let mut results = PolicyResults::new();
+        let config = ResolvedConfig::defaults().unwrap();
         let deltas = vec![
             // Already Critical, stays Critical
             create_test_delta_entry(
@@ -634,7 +682,7 @@ mod tests {
             ),
         ];
 
-        evaluate_critical_introduction(&deltas, &mut results);
+        evaluate_critical_introduction(&deltas, &config, &mut results);
 
         assert_eq!(results.failed.len(), 0);
     }
@@ -642,6 +690,7 @@ mod tests {
     #[test]
     fn test_excessive_risk_regression_triggered() {
         let mut results = PolicyResults::new();
+        let config = ResolvedConfig::defaults().unwrap();
         let deltas = vec![create_test_delta_entry(
             "src/foo.ts::handler",
             FunctionStatus::Modified,
@@ -650,7 +699,7 @@ mod tests {
             Some(1.5), // >= 1.0 threshold
         )];
 
-        evaluate_excessive_risk_regression(&deltas, &mut results);
+        evaluate_excessive_risk_regression(&deltas, &config, &mut results);
 
         assert_eq!(results.failed.len(), 1);
         assert_eq!(results.failed[0].id, PolicyId::ExcessiveRiskRegression);
@@ -666,6 +715,7 @@ mod tests {
     #[test]
     fn test_excessive_risk_regression_below_threshold() {
         let mut results = PolicyResults::new();
+        let config = ResolvedConfig::defaults().unwrap();
         let deltas = vec![create_test_delta_entry(
             "src/foo.ts::handler",
             FunctionStatus::Modified,
@@ -674,7 +724,7 @@ mod tests {
             Some(0.9), // < 1.0 threshold
         )];
 
-        evaluate_excessive_risk_regression(&deltas, &mut results);
+        evaluate_excessive_risk_regression(&deltas, &config, &mut results);
 
         assert_eq!(results.failed.len(), 0);
     }
@@ -682,6 +732,7 @@ mod tests {
     #[test]
     fn test_excessive_risk_regression_new_function() {
         let mut results = PolicyResults::new();
+        let config = ResolvedConfig::defaults().unwrap();
         let deltas = vec![create_test_delta_entry(
             "src/foo.ts::handler",
             FunctionStatus::New,
@@ -690,10 +741,163 @@ mod tests {
             None,
         )];
 
-        evaluate_excessive_risk_regression(&deltas, &mut results);
+        evaluate_excessive_risk_regression(&deltas, &config, &mut results);
 
         // New functions don't trigger Excessive Risk Regression (only Modified)
         assert_eq!(results.failed.len(), 0);
+    }
+
+    #[test]
+    fn test_critical_introduction_warn_mode_downgrades_severity() {
+        let raw = crate::config::HotspotsConfig {
+            policy: Some(crate::config::PolicyConfig {
+                critical_introduction: Some("warn".to_string()),
+                critical_introduction_reason: Some(
+                    "research repo, dense one-shot scripts".to_string(),
+                ),
+                excessive_risk_regression: None,
+                excessive_risk_regression_reason: None,
+            }),
+            ..Default::default()
+        };
+        let config = raw.resolve().unwrap();
+
+        let mut results = PolicyResults::new();
+        let deltas = vec![create_test_delta_entry(
+            "src/foo.ts::handler",
+            FunctionStatus::New,
+            None,
+            Some("critical"),
+            None,
+        )];
+
+        evaluate_critical_introduction(&deltas, &config, &mut results);
+
+        // Same trigger condition, but downgraded to a warning, not a blocking failure.
+        assert_eq!(results.failed.len(), 0);
+        assert_eq!(results.warnings.len(), 1);
+        assert_eq!(results.warnings[0].id, PolicyId::CriticalIntroduction);
+        assert_eq!(results.warnings[0].severity, PolicySeverity::Warning);
+    }
+
+    #[test]
+    fn test_critical_introduction_off_mode_skips_entirely() {
+        let raw = crate::config::HotspotsConfig {
+            policy: Some(crate::config::PolicyConfig {
+                critical_introduction: Some("off".to_string()),
+                critical_introduction_reason: Some(
+                    "research repo, dense one-shot scripts".to_string(),
+                ),
+                excessive_risk_regression: None,
+                excessive_risk_regression_reason: None,
+            }),
+            ..Default::default()
+        };
+        let config = raw.resolve().unwrap();
+
+        let mut results = PolicyResults::new();
+        let deltas = vec![create_test_delta_entry(
+            "src/foo.ts::handler",
+            FunctionStatus::New,
+            None,
+            Some("critical"),
+            None,
+        )];
+
+        evaluate_critical_introduction(&deltas, &config, &mut results);
+
+        assert_eq!(results.failed.len(), 0);
+        assert_eq!(results.warnings.len(), 0);
+    }
+
+    #[test]
+    fn test_critical_introduction_new_vs_regressed_same_severity() {
+        // A brand-new function scored Critical and an existing function that regressed
+        // to Critical must produce identical severity under the same config — this
+        // policy does not distinguish "new" from "regressed", only overall strictness.
+        let config = ResolvedConfig::defaults().unwrap();
+
+        let mut new_results = PolicyResults::new();
+        let new_deltas = vec![create_test_delta_entry(
+            "src/foo.ts::handler",
+            FunctionStatus::New,
+            None,
+            Some("critical"),
+            None,
+        )];
+        evaluate_critical_introduction(&new_deltas, &config, &mut new_results);
+
+        let mut regressed_results = PolicyResults::new();
+        let regressed_deltas = vec![create_test_delta_entry(
+            "src/foo.ts::handler",
+            FunctionStatus::Modified,
+            Some("high"),
+            Some("critical"),
+            Some(2.3),
+        )];
+        evaluate_critical_introduction(&regressed_deltas, &config, &mut regressed_results);
+
+        assert_eq!(
+            new_results.failed[0].severity,
+            regressed_results.failed[0].severity
+        );
+    }
+
+    #[test]
+    fn test_policy_config_invalid_mode_rejected() {
+        let raw = crate::config::HotspotsConfig {
+            policy: Some(crate::config::PolicyConfig {
+                critical_introduction: Some("blocc".to_string()),
+                critical_introduction_reason: None,
+                excessive_risk_regression: None,
+                excessive_risk_regression_reason: None,
+            }),
+            ..Default::default()
+        };
+        assert!(raw.resolve().is_err());
+    }
+
+    #[test]
+    fn test_policy_config_warn_without_reason_rejected() {
+        let raw = crate::config::HotspotsConfig {
+            policy: Some(crate::config::PolicyConfig {
+                critical_introduction: Some("warn".to_string()),
+                critical_introduction_reason: None,
+                excessive_risk_regression: None,
+                excessive_risk_regression_reason: None,
+            }),
+            ..Default::default()
+        };
+        let err = raw.resolve().unwrap_err();
+        assert!(err.to_string().contains("critical_introduction_reason"));
+    }
+
+    #[test]
+    fn test_policy_config_warn_with_blank_reason_rejected() {
+        let raw = crate::config::HotspotsConfig {
+            policy: Some(crate::config::PolicyConfig {
+                critical_introduction: Some("off".to_string()),
+                critical_introduction_reason: Some("   ".to_string()),
+                excessive_risk_regression: None,
+                excessive_risk_regression_reason: None,
+            }),
+            ..Default::default()
+        };
+        assert!(raw.resolve().is_err());
+    }
+
+    #[test]
+    fn test_policy_config_block_mode_does_not_require_reason() {
+        let raw = crate::config::HotspotsConfig {
+            policy: Some(crate::config::PolicyConfig {
+                critical_introduction: Some("block".to_string()),
+                critical_introduction_reason: None,
+                excessive_risk_regression: None,
+                excessive_risk_regression_reason: None,
+            }),
+            ..Default::default()
+        };
+        assert!(raw.resolve().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `policy.critical_introduction` / `policy.excessive_risk_regression` to `.hotspotsrc.json` (`"block"` default / `"warn"` / `"off"`), so a repo whose baseline LRS runs legitimately high (e.g. a research repo with dense one-shot experiment scripts) can relax CI severity without annotating every function or excluding files forever. Deliberately does not distinguish "new function introduced as Critical" from "existing function regressed to Critical" — both are equally Critical.
- Downgrading below `"block"` requires a `<name>_reason` string (mirrors `// hotspots-ignore: <reason>`), so a CODEOWNERS reviewer sees *why* a gate was weakened in the same diff.
- Fixes a real bug found while chasing this: `git()`/`git_at()` silently ignore explicit cwd/path when `GIT_DIR` is present in the environment (e.g. when invoked from a git hook) — confirmed directly with `git -C /empty/dir rev-parse --git-dir` resolving to a different repo when `GIT_DIR` was set. Both helpers now clear `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` on every invocation.
- Also serializes 7 `git.rs` tests that depend on/mutate ambient CWD behind a `Mutex` (belt-and-suspenders alongside the env-var fix).

## Context
Triggered by a hotspots-research PR that got merged with an admin override because `critical-introduction` blocked on new eval-script functions scoring Critical on introduction — a real signal, but too strict a default for that repo without a way to configure it.

## Test plan
- [x] `cargo test --workspace` — all passing (425 lib tests + integration suites)
- [x] New tests: `warn` downgrades severity, `off` skips entirely, missing/blank `_reason` rejected, `block` doesn't require a reason, new-vs-regressed produce identical severity
- [x] End-to-end smoke test via CLI (`config validate`, `config show`, `analyze --mode delta --policy`) confirms `warn` mode reports without blocking, invalid config values are rejected with clear messages
- [x] `GIT_DIR` forced into env before test run (the exact hook condition) — 5/5 clean, previously failed ~1-in-3
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets` clean

## Follow-up (not in this PR)
`coupling.rs`, `gate.rs`, `prune.rs`, `snapshot.rs`, `trainer.rs` each construct their own `Command::new("git")` directly instead of going through `git()`/`git_at()`, and have the same latent `GIT_DIR` exposure. Worth centralizing in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)