### PR TITLE
feat: F62/F63 Gini-gated cold-start routing

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -42,6 +42,9 @@ pub(crate) struct AnalyzeArgs {
     pub hybrid_touches: Option<usize>,
     /// Skip the suppression gate check entirely.
     pub skip_gate: bool,
+    /// Rank via Gini-gated cold-start routing (F62/F63) instead of a trained ranker.
+    /// Explicit opt-in only; reads no fix-commit label data.
+    pub cold_start: bool,
 }
 
 /// Validate flag combinations that are mode/format-specific.
@@ -58,8 +61,12 @@ pub(crate) fn validate_analyze_flags(args: &AnalyzeArgs) -> anyhow::Result<()> {
         all_functions,
         include_models,
         explain_patterns,
+        cold_start,
         ..
     } = args;
+    if *cold_start && mode.is_some() {
+        anyhow::bail!("--cold-start is not compatible with --mode (it bypasses the trained-ranker/snapshot pipeline entirely)");
+    }
     if *policy && *mode != Some(OutputMode::Delta) {
         anyhow::bail!("--policy flag is only valid with --mode delta");
     }
@@ -145,6 +152,7 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         jobs,
         callgraph_skip_above,
         skip_gate,
+        cold_start,
     } = args;
 
     // Configure the global rayon thread pool before any parallel work begins.
@@ -189,6 +197,15 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         touch_args.hybrid.or(resolved_config.hybrid_touch_threshold),
         resolved_config.per_function_touches,
     );
+
+    if cold_start {
+        return handle_cold_start(
+            &normalized_path,
+            &resolved_config,
+            effective_touch_mode,
+            effective_top,
+        );
+    }
 
     if let Some(output_mode) = mode {
         let result = handle_mode_output(
@@ -268,6 +285,69 @@ struct TouchArgs {
     per_function: bool,
     hybrid: Option<usize>,
     skip: bool,
+}
+
+/// `hotspots analyze --cold-start`: Gini-gated cold-start routing (F62/F63).
+///
+/// Skips the trained-ranker lookup entirely. Builds a snapshot with the cold-start
+/// history signals populated (but no touch/churn/call-graph work — not needed for the
+/// 8-feature cold-start vector), runs `cold_start_rank()`, and prints the routing
+/// decision (Formula / Anomaly / UniformPrior) before the ranked list. Reads no
+/// fix-commit label data.
+fn handle_cold_start(
+    path: &Path,
+    resolved_config: &hotspots_core::ResolvedConfig,
+    touch_mode: TouchMode,
+    top: Option<usize>,
+) -> anyhow::Result<()> {
+    let repo_root = find_repo_root(path)?;
+    let analysis_progress = make_analysis_progress();
+    let reports = analyze_with_progress(
+        path,
+        AnalysisOptions {
+            min_lrs: None,
+            top_n: None,
+        },
+        Some(resolved_config),
+        Some(analysis_progress.as_ref()),
+    )?;
+
+    let mut snapshot = build_enriched_snapshot(
+        &repo_root,
+        resolved_config,
+        reports,
+        touch_mode,
+        None,
+        true, // skip touch metrics — not part of the cold-start feature set
+    )
+    .context("failed to build snapshot for cold-start ranking")?;
+    snapshot.populate_history_signals(&repo_root);
+    snapshot.populate_authors_90d(&repo_root);
+
+    let result = hotspots_core::trainer::cold_start_rank(&snapshot);
+
+    let route_label = match result.route {
+        hotspots_core::trainer::ColdStartRoute::Formula => "formula",
+        hotspots_core::trainer::ColdStartRoute::Anomaly => "anomaly",
+        hotspots_core::trainer::ColdStartRoute::UniformPrior => "uniform-prior",
+    };
+    println!("cold-start route: {route_label}");
+
+    if result.ranked.is_empty() {
+        println!("(uniform prior — no ranking to show; all files equally likely)");
+        return Ok(());
+    }
+
+    let limit = match top {
+        Some(0) => result.ranked.len(),
+        Some(n) => n,
+        None => 20,
+    };
+    for scored in result.ranked.iter().take(limit) {
+        println!("{:.4}  {}", scored.score, scored.function_id);
+    }
+
+    Ok(())
 }
 
 fn handle_default_output(

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -131,6 +131,13 @@ enum Commands {
         /// large repos. Conflicts with --per-function-touches and --no-per-function-touches.
         #[arg(long, value_name = "N", conflicts_with_all = ["per_function_touches", "no_per_function_touches"])]
         hybrid_touches: Option<usize>,
+
+        /// Rank using a Gini-gated cold-start strategy (formula / IsolationForest
+        /// anomaly / uniform prior) instead of a trained ranker. For repos with no
+        /// fix-commit label history yet. Reads no label data. Explicit opt-in only —
+        /// not an automatic fallback when `hotspots train` fails its label threshold.
+        #[arg(long)]
+        cold_start: bool,
     },
     /// Prune unreachable snapshots
     Prune {
@@ -326,6 +333,7 @@ fn main() -> anyhow::Result<()> {
             callgraph_skip_above,
             hybrid_touches,
             skip_gate,
+            cold_start,
         } => cmd::analyze::handle_analyze(AnalyzeArgs {
             path,
             format,
@@ -350,6 +358,7 @@ fn main() -> anyhow::Result<()> {
             callgraph_skip_above,
             hybrid_touches,
             skip_gate,
+            cold_start,
         })?,
         Commands::Prune {
             unreachable,

--- a/hotspots-core/src/isolation_forest.rs
+++ b/hotspots-core/src/isolation_forest.rs
@@ -1,0 +1,276 @@
+//! From-scratch IsolationForest for the F62/F63 cold-start anomaly route.
+//!
+//! Memory-bounded independent of repo size: `fit()` takes an iterator and fills
+//! `n_trees` independent reservoir samples (reservoir sampling, one pass), so peak
+//! memory is `O(n_trees * subsample_size)` regardless of how many rows are streamed
+//! through it. Scoped exactly to the 8-feature cold-start vector — not a general-purpose
+//! anomaly detection library. Mirrors
+//! `hotspots-research/scripts/poc/validate_streaming_isolation_forest.py`.
+
+use rand::rngs::SmallRng;
+use rand::Rng;
+use rand::SeedableRng;
+
+/// Split metadata for one isolation-tree node. No training rows are retained.
+pub struct IsolationNode {
+    pub feature_idx: usize,
+    pub split_value: f64,
+    pub left: Option<usize>,
+    pub right: Option<usize>,
+    pub size: usize,
+}
+
+/// Arena of nodes for a single isolation tree (index 0 is the root).
+pub struct IsolationTree {
+    nodes: Vec<IsolationNode>,
+}
+
+/// Ensemble of isolation trees. Total memory is `O(n_trees * subsample_size)` nodes.
+pub struct IsolationForest {
+    trees: Vec<IsolationTree>,
+    subsample_size: usize,
+}
+
+/// Average path length of an unsuccessful BST search over `n` items
+/// (Liu et al. 2008 normalization constant).
+fn c(n: usize) -> f64 {
+    if n <= 1 {
+        return 0.0;
+    }
+    let n = n as f64;
+    2.0 * ((n - 1.0).ln() + 0.577_215_664_9) - 2.0 * (n - 1.0) / n
+}
+
+impl IsolationTree {
+    /// Recursively splits `rows` (indices into the reservoir) on a random feature at a
+    /// random threshold, building a flat node arena. Returns the index of the root node.
+    fn build(
+        nodes: &mut Vec<IsolationNode>,
+        rows: &[[f64; 8]],
+        depth: usize,
+        height_limit: usize,
+        rng: &mut SmallRng,
+    ) -> usize {
+        let size = rows.len();
+        if depth >= height_limit || size <= 1 {
+            nodes.push(IsolationNode {
+                feature_idx: 0,
+                split_value: 0.0,
+                left: None,
+                right: None,
+                size,
+            });
+            return nodes.len() - 1;
+        }
+
+        let feature_idx = rng.gen_range(0..8);
+        let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+        for row in rows {
+            let v = row[feature_idx];
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+        if lo == hi {
+            nodes.push(IsolationNode {
+                feature_idx: 0,
+                split_value: 0.0,
+                left: None,
+                right: None,
+                size,
+            });
+            return nodes.len() - 1;
+        }
+
+        let split_value = rng.gen_range(lo..hi);
+        let left_rows: Vec<[f64; 8]> = rows
+            .iter()
+            .copied()
+            .filter(|r| r[feature_idx] < split_value)
+            .collect();
+        let right_rows: Vec<[f64; 8]> = rows
+            .iter()
+            .copied()
+            .filter(|r| r[feature_idx] >= split_value)
+            .collect();
+
+        if left_rows.is_empty() || right_rows.is_empty() {
+            nodes.push(IsolationNode {
+                feature_idx: 0,
+                split_value: 0.0,
+                left: None,
+                right: None,
+                size,
+            });
+            return nodes.len() - 1;
+        }
+
+        let left_idx = Self::build(nodes, &left_rows, depth + 1, height_limit, rng);
+        let right_idx = Self::build(nodes, &right_rows, depth + 1, height_limit, rng);
+
+        nodes.push(IsolationNode {
+            feature_idx,
+            split_value,
+            left: Some(left_idx),
+            right: Some(right_idx),
+            size,
+        });
+        nodes.len() - 1
+    }
+
+    fn path_length(&self, row: &[f64], node_idx: usize, depth: usize) -> f64 {
+        let node = &self.nodes[node_idx];
+        match (node.left, node.right) {
+            (Some(left), Some(right)) => {
+                if row[node.feature_idx] < node.split_value {
+                    self.path_length(row, left, depth + 1)
+                } else {
+                    self.path_length(row, right, depth + 1)
+                }
+            }
+            _ => depth as f64 + c(node.size),
+        }
+    }
+}
+
+impl IsolationForest {
+    /// Fit an isolation forest from a streaming iterator of 8-feature rows.
+    ///
+    /// Single pass over `rows`, filling `n_trees` independent reservoirs (reservoir
+    /// sampling) capped at `subsample_size` each — the full feature set is never
+    /// materialized at once. Builds one `IsolationTree` per reservoir after the pass.
+    pub fn fit(
+        rows: impl Iterator<Item = [f64; 8]>,
+        n_trees: usize,
+        subsample_size: usize,
+        seed: u64,
+    ) -> IsolationForest {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mut reservoirs: Vec<Vec<[f64; 8]>> = (0..n_trees)
+            .map(|_| Vec::with_capacity(subsample_size))
+            .collect();
+
+        for (i, row) in rows.enumerate() {
+            for reservoir in reservoirs.iter_mut() {
+                if reservoir.len() < subsample_size {
+                    reservoir.push(row);
+                } else {
+                    let j = rng.gen_range(0..=i);
+                    if j < subsample_size {
+                        reservoir[j] = row;
+                    }
+                }
+            }
+        }
+
+        let height_limit = (subsample_size.max(2) as f64).log2().ceil() as usize;
+        let trees: Vec<IsolationTree> = reservoirs
+            .into_iter()
+            .map(|reservoir| {
+                let mut nodes = Vec::new();
+                if !reservoir.is_empty() {
+                    IsolationTree::build(&mut nodes, &reservoir, 0, height_limit, &mut rng);
+                }
+                IsolationTree { nodes }
+            })
+            .collect();
+
+        IsolationForest {
+            trees,
+            subsample_size,
+        }
+    }
+
+    /// Normalized anomaly score for a single row: `2^(-E[h(x)] / c(subsample_size))`.
+    /// Higher scores indicate more anomalous (more isolable) rows. Scores one row at a
+    /// time — the caller streams rows through this, no internal batching.
+    pub fn anomaly_score(&self, row: &[f64]) -> f64 {
+        let valid_trees: Vec<&IsolationTree> =
+            self.trees.iter().filter(|t| !t.nodes.is_empty()).collect();
+        if valid_trees.is_empty() {
+            return 0.0;
+        }
+        let avg_path: f64 = valid_trees
+            .iter()
+            .map(|t| t.path_length(row, t.nodes.len() - 1, 0))
+            .sum::<f64>()
+            / valid_trees.len() as f64;
+        let c_n = c(self.subsample_size);
+        if c_n <= 0.0 {
+            return 0.0;
+        }
+        2.0_f64.powf(-avg_path / c_n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outliers_rank_in_top_10_of_95_plus_5() {
+        // 95 points clustered near origin, 5 points far away — synthetic outlier check
+        // mirrors the brief's acceptance criterion 3.
+        let mut rng = SmallRng::seed_from_u64(7);
+        let mut rows: Vec<[f64; 8]> = Vec::new();
+        for _ in 0..95 {
+            let mut row = [0.0; 8];
+            for v in row.iter_mut() {
+                *v = rng.gen_range(-1.0..1.0);
+            }
+            rows.push(row);
+        }
+        let mut outlier_rows: Vec<[f64; 8]> = Vec::new();
+        for _ in 0..5 {
+            let mut row = [0.0; 8];
+            for v in row.iter_mut() {
+                *v = 5.0 + rng.gen_range(-1.0..1.0);
+            }
+            outlier_rows.push(row);
+            rows.push(row);
+        }
+
+        let forest = IsolationForest::fit(rows.iter().copied(), 100, 256, 42);
+
+        let mut scored: Vec<(usize, f64)> = rows
+            .iter()
+            .enumerate()
+            .map(|(i, r)| (i, forest.anomaly_score(r)))
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+        let top10: std::collections::HashSet<usize> =
+            scored.iter().take(10).map(|(i, _)| *i).collect();
+        let outlier_indices: std::collections::HashSet<usize> = (95..100).collect();
+
+        let hits = outlier_indices.intersection(&top10).count();
+        assert!(
+            hits >= 4,
+            "expected at least 4/5 outliers in top 10, got {hits}: {scored:?}"
+        );
+    }
+
+    #[test]
+    fn fit_never_collects_full_dataset() {
+        // Reservoir size is bounded regardless of how many rows stream through —
+        // confirmed indirectly by fitting on a large stream and checking it completes
+        // in reasonable time/without unbounded growth (memory bound is structural,
+        // enforced by construction: reservoirs are Vec::with_capacity(subsample_size)
+        // and never grow past that).
+        let rows = (0..50_000).map(|i| {
+            let f = (i % 7) as f64;
+            [f; 8]
+        });
+        let forest = IsolationForest::fit(rows, 10, 32, 1);
+        assert_eq!(forest.trees.len(), 10);
+        for tree in &forest.trees {
+            // Each tree has at most 2*subsample_size - 1 nodes (full binary tree bound).
+            assert!(tree.nodes.len() <= 2 * 32);
+        }
+    }
+
+    #[test]
+    fn empty_input_scores_zero() {
+        let forest = IsolationForest::fit(std::iter::empty(), 10, 32, 1);
+        assert_eq!(forest.anomaly_score(&[0.0; 8]), 0.0);
+    }
+}

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod git;
 pub mod history_signals;
 pub mod html;
 pub mod imports;
+pub mod isolation_forest;
 pub mod language;
 pub mod metrics;
 pub mod models;

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -24,6 +24,7 @@
 //!   causes the trained ranker to reproduce the heuristic score rather than learning
 //!   from structural features, making `hotspots train` a no-op in practice.
 
+use crate::isolation_forest::IsolationForest;
 use crate::snapshot::{FunctionSnapshot, Snapshot};
 use anyhow::{bail, Context, Result};
 use linfa::prelude::Fit;
@@ -721,6 +722,149 @@ pub fn screen_repo(snapshot: &Snapshot) -> (ScreenerVerdict, f64) {
     };
 
     (verdict, mean_hs)
+}
+
+// ── Cold-start routing (F62/F63) ─────────────────────────────────────────────
+
+/// Gini ≥ this on `commit_count` → the existing formula score is a sufficient
+/// day-one ranking. Matches F62's validated threshold exactly.
+pub const HIGH_GINI: f64 = 0.60;
+
+/// Gini < this on `commit_count` → route to the label-free IsolationForest anomaly
+/// score (F63). Between `LOW_GINI` and `HIGH_GINI` is an ungated middle zone that
+/// defaults to the formula path — F62 does not define a third bucket.
+pub const LOW_GINI: f64 = 0.55;
+
+/// Uniform-prior guard: if the top 10% of files by `commit_count` account for less
+/// than this share of total commits, no file stands out even by raw count — return
+/// a uniform prior instead of a manufactured ranking. Adapted from F63's `pos_rate`
+/// guard, which does not apply at true cold-start (no labels exist yet).
+const UNIFORM_PRIOR_TOP_DECILE_SHARE: f64 = 0.20;
+
+const COLD_START_N_TREES: usize = 100;
+const COLD_START_SUBSAMPLE_SIZE: usize = 256;
+const COLD_START_SEED: u64 = 42;
+
+/// Which cold-start ranking strategy was used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColdStartRoute {
+    /// Gini ≥ `HIGH_GINI` (or the ungated middle zone) — existing formula score.
+    Formula,
+    /// Gini < `LOW_GINI` — label-free IsolationForest anomaly score.
+    Anomaly,
+    /// No file stands out by commit-count concentration — uniform prior.
+    UniformPrior,
+}
+
+/// Result of `cold_start_rank()`: the routing decision plus the ranked functions.
+pub struct ColdStartResult {
+    pub route: ColdStartRoute,
+    pub ranked: Vec<ScoredFunction>,
+}
+
+/// Standard Gini coefficient: `sum((2*i - n - 1) * v_i) / (n * sum(v))` over
+/// ascending-sorted `values`, `i` 1-indexed. Matches F62's formula exactly. Returns
+/// `0.0` for empty input or when all values are zero (no concentration to measure).
+pub fn gini_coefficient(values: &[f64]) -> f64 {
+    let n = values.len();
+    if n == 0 {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let total: f64 = sorted.iter().sum();
+    if total == 0.0 {
+        return 0.0;
+    }
+    let numerator: f64 = sorted
+        .iter()
+        .enumerate()
+        .map(|(idx, &v)| {
+            let i = (idx + 1) as f64;
+            (2.0 * i - n as f64 - 1.0) * v
+        })
+        .sum();
+    numerator / (n as f64 * total)
+}
+
+/// Rank a snapshot for a repo with zero (or unreliable) label history.
+///
+/// Routes via the Gini coefficient of `commit_count` across all functions (F62):
+/// - `Gini >= HIGH_GINI` (or the 0.55-0.60 middle zone) → `Formula`: rank by the
+///   existing `activity_risk`/`lrs` score, no new model needed.
+/// - `Gini < LOW_GINI` → `Anomaly`: fit a label-free `IsolationForest` on the 8-feature
+///   cold-start vector (`cold_start_features`) and rank by anomaly score.
+/// - Uniform-prior guard (checked first): if the top 10% of files by `commit_count`
+///   account for less than 20% of total commits, no file stands out even by raw count
+///   — return a uniform prior rather than a manufactured ranking.
+///
+/// Two streaming passes over `snapshot.functions` on the `Anomaly` route (fit, then
+/// score) — no intermediate full-matrix structure is built at any point.
+pub fn cold_start_rank(snapshot: &Snapshot) -> ColdStartResult {
+    let commit_counts: Vec<f64> = snapshot
+        .functions
+        .iter()
+        .map(|f| f.commit_count.unwrap_or(0) as f64)
+        .collect();
+
+    if commit_counts.is_empty() {
+        return ColdStartResult {
+            route: ColdStartRoute::UniformPrior,
+            ranked: vec![],
+        };
+    }
+
+    let total_commits: f64 = commit_counts.iter().sum();
+    if total_commits > 0.0 {
+        let mut sorted_desc = commit_counts.clone();
+        sorted_desc.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        let top_decile_n = ((sorted_desc.len() as f64 * 0.10).ceil() as usize).max(1);
+        let top_decile_share: f64 = sorted_desc[..top_decile_n].iter().sum::<f64>() / total_commits;
+        if top_decile_share < UNIFORM_PRIOR_TOP_DECILE_SHARE {
+            return ColdStartResult {
+                route: ColdStartRoute::UniformPrior,
+                ranked: vec![],
+            };
+        }
+    }
+
+    let gini = gini_coefficient(&commit_counts);
+
+    if gini < LOW_GINI {
+        let forest = IsolationForest::fit(
+            snapshot.functions.iter().map(cold_start_features),
+            COLD_START_N_TREES,
+            COLD_START_SUBSAMPLE_SIZE,
+            COLD_START_SEED,
+        );
+        let mut ranked: Vec<ScoredFunction> = snapshot
+            .functions
+            .iter()
+            .map(|f| ScoredFunction {
+                function_id: f.function_id.clone(),
+                score: forest.anomaly_score(&cold_start_features(f)),
+            })
+            .collect();
+        ranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        return ColdStartResult {
+            route: ColdStartRoute::Anomaly,
+            ranked,
+        };
+    }
+
+    let mut ranked: Vec<ScoredFunction> = snapshot
+        .functions
+        .iter()
+        .map(|f| ScoredFunction {
+            function_id: f.function_id.clone(),
+            score: f.activity_risk.unwrap_or(f.lrs),
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    ColdStartResult {
+        route: ColdStartRoute::Formula,
+        ranked,
+    }
 }
 
 // ── Regime screener ────────────────────────────────────────────────────────
@@ -1458,5 +1602,207 @@ mod tests {
         .unwrap();
         let model = RankerModel::load(&path).expect("should load");
         assert_eq!(model.model_version, 5);
+    }
+
+    // ── cold-start routing (F62/F63) ────────────────────────────────────────────
+
+    #[test]
+    fn gini_uniform_distribution_is_zero() {
+        assert_eq!(gini_coefficient(&[1.0, 1.0, 1.0, 1.0]), 0.0);
+    }
+
+    #[test]
+    fn gini_single_dominant_value_matches_hand_computation() {
+        let g = gini_coefficient(&[0.0, 0.0, 0.0, 10.0]);
+        assert!((g - 0.75).abs() < 1e-9, "got {g}");
+    }
+
+    #[test]
+    fn gini_ascending_series_matches_hand_computation() {
+        let g = gini_coefficient(&[1.0, 2.0, 3.0, 4.0]);
+        assert!((g - 0.25).abs() < 1e-9, "got {g}");
+    }
+
+    #[test]
+    fn gini_empty_is_zero() {
+        assert_eq!(gini_coefficient(&[]), 0.0);
+    }
+
+    fn make_snapshot_with_commit_counts(counts: &[u32]) -> Snapshot {
+        use crate::language::Language;
+        use crate::report::MetricsReport;
+        use crate::risk::RiskBand;
+        use crate::snapshot::{AnalysisInfo, CommitInfo, FunctionSnapshot};
+
+        let functions = counts
+            .iter()
+            .enumerate()
+            .map(|(i, &cc)| FunctionSnapshot {
+                function_id: format!("f{i}"),
+                file: format!("src/f{i}.rs"),
+                line: 1,
+                language: Language::Rust,
+                metrics: MetricsReport {
+                    cc: 1,
+                    nd: 0,
+                    fo: 0,
+                    ns: 0,
+                    loc: 10,
+                },
+                lrs: (i as f64) / (counts.len() as f64),
+                band: RiskBand::Low,
+                suppression_reason: None,
+                churn: None,
+                touch_count_30d: None,
+                days_since_last_change: None,
+                callgraph: None,
+                activity_risk: Some((i as f64) / (counts.len() as f64)),
+                risk_factors: None,
+                percentile: None,
+                driver: None,
+                driver_detail: None,
+                quadrant: None,
+                patterns: vec![],
+                pattern_details: None,
+                subsystem: None,
+                authors_90d: Some(1),
+                directed_coupling: None,
+                jaccard_label_stability: None,
+                convention_bug_fix_count: None,
+                burst_score: Some(1.0),
+                commit_count: Some(cc),
+                author_count: Some(1),
+                author_entropy: Some(0.0),
+                isolation_rate: Some(0.5),
+                age_days: Some(30.0),
+                last_touch_days: Some(1.0),
+                explanation: None,
+            })
+            .collect();
+
+        Snapshot {
+            schema_version: 1,
+            commit: CommitInfo {
+                sha: "test".into(),
+                parents: vec![],
+                timestamp: 0,
+                branch: None,
+                message: None,
+                author: None,
+                is_fix_commit: None,
+                is_revert_commit: None,
+                ticket_ids: vec![],
+            },
+            analysis: AnalysisInfo {
+                scope: "test".into(),
+                tool_version: "0.0.0".into(),
+            },
+            functions,
+            summary: None,
+            aggregates: None,
+        }
+    }
+
+    #[test]
+    fn cold_start_uniform_prior_when_no_file_stands_out() {
+        // Flat distribution: top-decile share = 0.10 < 0.20 guard.
+        let counts = vec![1u32; 20];
+        let snap = make_snapshot_with_commit_counts(&counts);
+        let result = cold_start_rank(&snap);
+        assert_eq!(result.route, ColdStartRoute::UniformPrior);
+        assert!(result.ranked.is_empty());
+    }
+
+    #[test]
+    fn cold_start_formula_route_ranks_by_activity_risk() {
+        // One dominant file: gini ≈ 0.56 (>= HIGH_GINI's neighborhood), top-decile
+        // share ≈ 0.63 (passes the guard).
+        let mut counts = vec![1u32; 20];
+        counts[0] = 30;
+        let snap = make_snapshot_with_commit_counts(&counts);
+        let result = cold_start_rank(&snap);
+        assert_eq!(result.route, ColdStartRoute::Formula);
+        assert_eq!(result.ranked.len(), 20);
+        // Ranked descending by activity_risk (lrs proxy: i/20, so f19 has the highest).
+        assert_eq!(result.ranked[0].function_id, "f19");
+        for w in result.ranked.windows(2) {
+            assert!(w[0].score >= w[1].score);
+        }
+    }
+
+    #[test]
+    fn cold_start_anomaly_route_when_gini_below_low_threshold() {
+        // Low-concentration distribution (gini ≈ 0.31 < LOW_GINI) with top-decile
+        // share ≈ 0.41 (passes the guard) — routes to Anomaly.
+        let mut counts = vec![2u32; 30];
+        counts[0] = 15;
+        counts[1] = 12;
+        counts[2] = 10;
+        let snap = make_snapshot_with_commit_counts(&counts);
+        let result = cold_start_rank(&snap);
+        assert_eq!(result.route, ColdStartRoute::Anomaly);
+        assert_eq!(result.ranked.len(), 30);
+        for w in result.ranked.windows(2) {
+            assert!(w[0].score >= w[1].score);
+        }
+    }
+
+    #[test]
+    fn cold_start_empty_snapshot_is_uniform_prior_and_does_not_panic() {
+        let snap = make_snapshot_with_commit_counts(&[]);
+        let result = cold_start_rank(&snap);
+        assert_eq!(result.route, ColdStartRoute::UniformPrior);
+        assert!(result.ranked.is_empty());
+    }
+
+    #[test]
+    fn cold_start_features_never_panics_on_none_fields() {
+        use crate::language::Language;
+        use crate::report::MetricsReport;
+        use crate::risk::RiskBand;
+        use crate::snapshot::FunctionSnapshot;
+
+        let func = FunctionSnapshot {
+            function_id: "f0".into(),
+            file: "src/f0.rs".into(),
+            line: 1,
+            language: Language::Rust,
+            metrics: MetricsReport {
+                cc: 1,
+                nd: 0,
+                fo: 0,
+                ns: 0,
+                loc: 10,
+            },
+            lrs: 0.0,
+            band: RiskBand::Low,
+            suppression_reason: None,
+            churn: None,
+            touch_count_30d: None,
+            days_since_last_change: None,
+            callgraph: None,
+            activity_risk: None,
+            risk_factors: None,
+            percentile: None,
+            driver: None,
+            driver_detail: None,
+            quadrant: None,
+            patterns: vec![],
+            pattern_details: None,
+            subsystem: None,
+            authors_90d: None,
+            directed_coupling: None,
+            jaccard_label_stability: None,
+            convention_bug_fix_count: None,
+            burst_score: None,
+            commit_count: None,
+            author_count: None,
+            author_entropy: None,
+            isolation_rate: None,
+            age_days: None,
+            last_touch_days: None,
+            explanation: None,
+        };
+        assert_eq!(cold_start_features(&func), [0.0; 8]);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `hotspots analyze --cold-start`: ranks a repo with zero (or unreliable) fix-commit label history, no trained ranker required
- `gini_coefficient()` on `commit_count` gates the route (F62): Gini >= 0.60 (or the 0.55-0.60 middle zone) -> formula (`activity_risk`/`lrs`); Gini < 0.55 -> label-free `IsolationForest` anomaly score (F63)
- Uniform-prior guard: if the top 10% of files by `commit_count` account for < 20% of total commits, returns a uniform prior instead of a manufactured ranking
- New `hotspots-core/src/isolation_forest.rs`: from-scratch, memory-bounded IsolationForest — `fit()` takes an iterator and streams `n_trees` independent reservoir samples (default 100 x 256) in one pass, so peak memory never scales with repo size
- `cold_start_rank()` prints the routing decision (Formula/Anomaly/UniformPrior) before the ranked list; explicit opt-in flag, reads no label data

Closes #118. Second dependent issue, #122 (F98 low-label-density gate), can now start.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (448/448 core unit tests + all integration suites)
- [x] New tests: `gini_coefficient` hand-computed reference values, uniform-prior/formula/anomaly routing fixtures, `cold_start_features` None-safety, IsolationForest synthetic-outlier detection (95 inliers + 5 outliers, >=4/5 land in top 10), empty-input edge case, reservoir-bound structural check
- [x] Manual end-to-end: `hotspots analyze . --cold-start --top 15` on this repo — printed `cold-start route: anomaly` and a sensible ranked list (new/low-history files ranked highest)
- [x] Self-analysis diff vs `main`: no new hotspots introduced; only expected minor complexity increase in `validate_analyze_flags` (one new flag-compatibility check) and `train` (two added lines)
- [x] Verified `--cold-start` rejects `--mode` combination with a clear error
- [x] Verified by construction: `handle_cold_start` never calls `collect_fix_files`/`collect_fix_functions` — no label data read
- [x] **Acceptance criterion 3b (ranking parity)**: validated against `hotspots-research`'s local `cheap_signals.csv`/`train.jsonl` for all three reference repos, using the same 8-feature vector, seed=42, n_trees=100, subsample=256, no scaling:

  | Repo | rho (ours) | rho (sklearn baseline) | gap | P@10 gap |
  |---|---|---|---|---|
  | facebook/react | +0.407 | +0.404 | +0.003 | +0.000 |
  | django/django | +0.538 | +0.578 | -0.040 | +0.000 |
  | elastic/elasticsearch | +0.252 | +0.253 | -0.001 | -0.100 |

  All three within the brief's +/-0.10 rho tolerance. Validation script was a throwaway `hotspots-core/examples/` binary, deleted after use — not part of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)