### PR TITLE
perf: fold burst_score into history_signals shared git-log walk

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -259,10 +259,22 @@ Activity Risk = LRS
 
 `burst_score` is a sliding 30-day-window max/mean commit ratio per file (always ≥ 1.0;
 higher means commits cluster into frantic bursts rather than steady, spread-out
-changes). Computed from a single full-history `git log` pass per `hotspots analyze`
-run (mirrors the batching used for touch metrics — one subprocess, not one per file).
-On repos with more than 50,000 commits, this prints a one-line stderr warning since
-the full-history scan can take a few seconds.
+changes). For each commit touching a file, it counts how many of that file's commits
+fall within the following 30 days, then divides the largest such count by the mean —
+a file with 5 commits crammed into one week scores higher than one with 5 commits
+spread evenly across a year, even though both have `commit_count = 5`.
+
+Computed as part of the same single full-history `git log --name-only` pass used for
+the other cold-start signals (`commit_count`, `author_count`, `author_entropy`,
+`isolation_rate`, `age_days`, `last_touch_days`) — one subprocess per `hotspots
+analyze` run, not one per file and not a separate walk from those other six signals.
+Files with fewer than 2 commits get the baseline `1.0` (no burst signal); files with
+no matching commit history keep `burst_score = None`.
+
+Validated against real-world defect data: it's one of the strongest signals in a
+CVE/OSV-linked-file logistic regression (largest standardized coefficient of 5
+candidate signals, positive across all leave-one-repo-out folds tested) — see
+`hotspots-research` findings F67 and F93 for the full cross-repo evaluation.
 
 Activity Risk is always ≥ LRS. When no git data is available, Activity Risk = LRS.
 

--- a/hotspots-core/src/history_signals.rs
+++ b/hotspots-core/src/history_signals.rs
@@ -1,11 +1,12 @@
 //! Cold-start history signals — F63 signal-porting prerequisite.
 //!
-//! Six file-level signals ported from `cheap_signals.py` in `hotspots-research`,
-//! computed from a single `git log` pass over the whole repo (not one subprocess
-//! per file, unlike `populate_authors_90d`/`populate_convention_bug_fix_count`).
-//! `burst_score` is not duplicated here — it already exists on `FunctionSnapshot`
-//! via `Snapshot::populate_burst_score` (F93) and is reused as-is by
-//! `trainer::cold_start_features`.
+//! Seven file-level signals (six F62/F63 cold-start signals plus `burst_score`,
+//! F93), computed from a single `git log` pass over the whole repo (not one
+//! subprocess per file, unlike `populate_authors_90d`/`populate_convention_bug_fix_count`).
+//! `burst_score`'s formula lives here too (moved from `snapshot.rs`) so
+//! `Snapshot::populate_burst_score` can reuse this module's loader instead of
+//! spawning its own redundant full-history `git log` walk — see
+//! `hotspots-research/docs/promotion-briefs/burst-score-history-signals-shared-walk.md`.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -21,7 +22,7 @@ pub struct CommitRecord {
     pub files: Vec<String>,
 }
 
-/// Per-file cold-start signals (F62/F63 feature set, minus `burst_score`).
+/// Per-file cold-start signals (F62/F63 feature set) plus `burst_score` (F93).
 pub struct HistorySignals {
     pub commit_count: u32,
     pub author_count: u32,
@@ -29,6 +30,7 @@ pub struct HistorySignals {
     pub isolation_rate: f64,
     pub age_days: f64,
     pub last_touch_days: f64,
+    pub burst_score: f64,
 }
 
 /// Load full commit history as `(timestamp, author_email, files)` via a single
@@ -110,8 +112,44 @@ fn author_entropy(authors: &[&str]) -> f64 {
         .sum::<f64>()
 }
 
-/// Single pass over `commits`, aggregating per-file cold-start signals.
-/// Mirrors `cheap_signals.py::compute_file_signals` (minus `burst_score`,
+/// Sliding 30-day-window max/mean commit ratio (F93). Moved from `snapshot.rs`
+/// so it shares this module's single-pass commit load with the other six
+/// cold-start signals instead of triggering its own `git log` walk.
+///
+/// For each commit, counts how many commits (including itself) fall within the
+/// following 30-day window, then divides the maximum such count by the mean.
+/// Mirrors `cheap_signals.py::_burst_score` in `hotspots-research`. Returns
+/// `1.0` (no burst signal) when fewer than 2 timestamps are given.
+fn burst_score(timestamps: &[i64]) -> f64 {
+    const BURST_WINDOW_DAYS: i64 = 30;
+    const BURST_WINDOW_SECS: i64 = BURST_WINDOW_DAYS * 86400;
+
+    if timestamps.len() < 2 {
+        return 1.0;
+    }
+
+    let mut sorted = timestamps.to_vec();
+    sorted.sort_unstable();
+
+    let mut counts = Vec::with_capacity(sorted.len());
+    let mut j = 0usize;
+    for (i, &t) in sorted.iter().enumerate() {
+        while j < sorted.len() && sorted[j] < t + BURST_WINDOW_SECS {
+            j += 1;
+        }
+        counts.push((j - i) as f64);
+    }
+
+    let mean_c = counts.iter().sum::<f64>() / counts.len() as f64;
+    if mean_c == 0.0 {
+        return 1.0;
+    }
+
+    counts.iter().cloned().fold(f64::MIN, f64::max) / mean_c
+}
+
+/// Single pass over `commits`, aggregating per-file cold-start signals plus
+/// `burst_score`. Mirrors `cheap_signals.py::compute_file_signals` (minus
 /// `co_change_partners`, `mean_co_change_size` — out of scope, see brief).
 pub fn compute_history_signals(commits: &[CommitRecord]) -> HashMap<String, HistorySignals> {
     let now_ts = std::time::SystemTime::now()
@@ -152,6 +190,7 @@ pub fn compute_history_signals(commits: &[CommitRecord]) -> HashMap<String, Hist
                 isolation_rate,
                 age_days: (last_ts - first_ts) as f64 / 86400.0,
                 last_touch_days: (now_ts - last_ts) as f64 / 86400.0,
+                burst_score: burst_score(&timestamps),
             },
         );
     }
@@ -253,5 +292,42 @@ mod tests {
         let bad = Path::new("/nonexistent/path/that/does/not/exist/.git");
         let commits = load_commits_with_author(bad);
         assert!(commits.is_empty());
+    }
+
+    #[test]
+    fn burst_score_single_commit_is_baseline() {
+        assert_eq!(burst_score(&[0]), 1.0);
+    }
+
+    #[test]
+    fn burst_score_evenly_spaced_commits_is_baseline() {
+        // Commits 60 days apart never share a 30-day window with another commit,
+        // so max == mean == 1.0 for every commit.
+        const DAY: i64 = 86400;
+        let timestamps = vec![0, 60 * DAY, 120 * DAY, 180 * DAY];
+        assert_eq!(burst_score(&timestamps), 1.0);
+    }
+
+    #[test]
+    fn burst_score_detects_a_burst() {
+        // 5 commits clustered on day 0, then 1 commit alone on day 60: the
+        // clustered commits' windows each see all 5, giving max=5, mean=(5*5+1)/6.
+        const DAY: i64 = 86400;
+        let timestamps = vec![0, 0, 0, 0, 0, 60 * DAY];
+        let score = burst_score(&timestamps);
+        assert!(score > 1.0, "expected a burst signal, got {score}");
+    }
+
+    #[test]
+    fn compute_history_signals_matches_burst_score_fixture() {
+        let commits = fixture_commits();
+        let signals = compute_history_signals(&commits);
+        // a.rs: commits at d0, d1, d5 — all within 30 days of each other, so
+        // the forward-window counts are [3, 2, 1] (max=3, mean=2, ratio=1.5).
+        let a = signals.get("a.rs").expect("a.rs present");
+        assert!((a.burst_score - 1.5).abs() < 1e-9, "got {}", a.burst_score);
+        // c.rs: single commit -> baseline 1.0.
+        let c = signals.get("c.rs").expect("c.rs present");
+        assert_eq!(c.burst_score, 1.0);
     }
 }

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -439,40 +439,6 @@ fn subsystem_for_file(
     best.map(|s| s.to_string())
 }
 
-/// Sliding 30-day-window max/mean commit ratio (F93).
-///
-/// For each commit, counts how many commits (including itself) fall within the
-/// following 30-day window, then divides the maximum such count by the mean.
-/// Mirrors `cheap_signals.py::_burst_score` in `hotspots-research`. Returns
-/// `1.0` (no burst signal) when fewer than 2 timestamps are given.
-fn burst_score(timestamps: &[i64]) -> f64 {
-    const BURST_WINDOW_DAYS: i64 = 30;
-    const BURST_WINDOW_SECS: i64 = BURST_WINDOW_DAYS * 86400;
-
-    if timestamps.len() < 2 {
-        return 1.0;
-    }
-
-    let mut sorted = timestamps.to_vec();
-    sorted.sort_unstable();
-
-    let mut counts = Vec::with_capacity(sorted.len());
-    let mut j = 0usize;
-    for (i, &t) in sorted.iter().enumerate() {
-        while j < sorted.len() && sorted[j] < t + BURST_WINDOW_SECS {
-            j += 1;
-        }
-        counts.push((j - i) as f64);
-    }
-
-    let mean_c = counts.iter().sum::<f64>() / counts.len() as f64;
-    if mean_c == 0.0 {
-        return 1.0;
-    }
-
-    counts.iter().cloned().fold(f64::MIN, f64::max) / mean_c
-}
-
 impl Snapshot {
     /// Create a new snapshot from git context and function reports
     ///
@@ -681,51 +647,23 @@ impl Snapshot {
 
     /// Populate `burst_score` for every function (F93).
     ///
-    /// Runs a single `git log --name-only` pass over the whole repository to
-    /// collect per-file commit timestamps, then computes a sliding 30-day-window
-    /// max/mean commit ratio per file. File-level: all functions in the same
-    /// file receive the same value. Mirrors the batching approach used by
-    /// `git::batch_touch_metrics_at` — one subprocess instead of one per file.
+    /// Runs a single `git log --name-only` pass over the whole repository via
+    /// `history_signals::load_commits_with_author` (the same loader
+    /// `populate_history_signals` uses) and reads `burst_score` off the
+    /// resulting per-file `HistorySignals` — no separate `git log` subprocess.
+    /// File-level: all functions in the same file receive the same value.
     /// Files with fewer than 2 commits receive `Some(1.0)` (no burst signal).
     ///
     /// Errors are soft: if the git call fails, all functions keep `burst_score = None`.
     pub fn populate_burst_score(&mut self, repo_root: &Path) {
         use std::collections::HashMap;
-        use std::process::Command;
 
-        let out = Command::new("git")
-            .args(["log", "--format=COMMIT %at", "--name-only"])
-            .current_dir(repo_root)
-            .output();
-
-        let Ok(out) = out else { return };
-        if !out.status.success() {
+        let git_dir = crate::coupling::git_dir(repo_root);
+        let commits = crate::history_signals::load_commits_with_author(&git_dir);
+        if commits.is_empty() {
             return;
         }
-        let text = String::from_utf8_lossy(&out.stdout);
-
-        let mut timestamps_by_file: HashMap<String, Vec<i64>> = HashMap::new();
-        let mut current_ts: i64 = 0;
-        let mut commit_count: usize = 0;
-        for line in text.lines() {
-            if let Some(ts_str) = line.strip_prefix("COMMIT ") {
-                current_ts = ts_str.trim().parse().unwrap_or(0);
-                commit_count += 1;
-                // On large repos the full-history git log traversal can take several
-                // seconds and hold a non-trivial amount of memory. Surface this so
-                // users aren't surprised (mirrors coupling::compute_directed_coupling_for_repo).
-                if commit_count == 50_001 {
-                    eprintln!(
-                        "hotspots: burst_score loading full commit history (large repo — may be slow)"
-                    );
-                }
-            } else if !line.trim().is_empty() {
-                timestamps_by_file
-                    .entry(line.trim().to_string())
-                    .or_default()
-                    .push(current_ts);
-            }
-        }
+        let signals = crate::history_signals::compute_history_signals(&commits);
 
         let mut file_indices: HashMap<String, Vec<usize>> = HashMap::new();
         for (i, func) in self.functions.iter().enumerate() {
@@ -738,12 +676,11 @@ impl Snapshot {
         }
 
         for (rel, indices) in &file_indices {
-            let score = match timestamps_by_file.get(rel) {
-                Some(timestamps) => burst_score(timestamps),
-                None => continue,
+            let Some(s) = signals.get(rel) else {
+                continue;
             };
             for &i in indices {
-                self.functions[i].burst_score = Some(score);
+                self.functions[i].burst_score = Some(s.burst_score);
             }
         }
     }


### PR DESCRIPTION
## Summary
- `Snapshot::populate_burst_score` ran its own standalone full-history `git log --name-only` subprocess even though `populate_history_signals` already walks the same commit history via `history_signals::load_commits_with_author`. Moved `burst_score`'s formula into `history_signals.rs` and added it as a field on `HistorySignals`, computed in the same single-pass aggregation as the other six cold-start signals. `populate_burst_score` now reads the value off the shared loader instead of spawning a second `git log` walk.
- Supersedes #124 (`burst_score_skip_above` threshold), which was closed — `burst_score` has validated, replicated lift (hotspots-research F67, F93: largest coefficient of 5 signals in the OSV formula, positive in 21/21 LORO folds), so a threshold that silently drops it on large repos was the wrong fix for the underlying redundant-walk cost. This PR removes the redundant walk instead.
- No formula, weight, or window changes — `burst_score` values are unchanged (verified below).

Full spec: `hotspots-research/docs/promotion-briefs/burst-score-history-signals-shared-walk.md`

## Test plan
- [x] `cargo test --workspace` — all passing (452 lib tests + integration suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Added `history_signals` unit tests for `burst_score` (baseline, evenly-spaced, and burst-detection cases) plus a fixture-based `compute_history_signals` check
- [x] Ran `hotspots analyze --mode snapshot --all-functions` on this repo before/after: 900/901 functions' `burst_score` values are bit-for-bit identical; the one difference is the `burst_score` free function's own git-blame history, which moved from `snapshot.rs` to `history_signals.rs` as part of this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)