### PR TITLE
fix: remove burst_score from live activity-risk score

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -79,3 +79,22 @@ passing. Also rebuilt missing `benchmarks/run.sh` + `benchmarks/corpus.json` (re
 by README but absent from the repo) and re-ran the 7-repo benchmark: mean ρ +0.350 →
 +0.386, all 7 repos improved (`benchmarks/versions/v1.30.0.json`,
 `benchmarks/RESULTS.md`). Tracker row updated to `promoted`.
+
+---
+
+## Task: Remove `burst_score` from live activity-risk score
+
+**Brief:** `/Users/stephencollins/projects/stephencollins.tech-repos/hotspots-research/docs/promotion-briefs/burst-score-remove-from-live-score.md`
+
+`burst_score` is computed over a file's entire commit history and is effectively
+monotonic non-decreasing, so including it in `compute_activity_risk` made
+`activity_risk` a one-way ratchet — a single historical burst could permanently
+keep a file at CRITICAL regardless of current state. Removes the burst term from
+`compute_activity_risk`'s sum; `RiskFactors.burst` is now always `0.0`.
+`ScoringWeights.burst`, `ActivityRiskInput.burst_score`, and the `burst_score`
+computation in `history_signals.rs`/`snapshot.rs` are untouched — kept in place for
+a future trailing-window replacement, per the brief's "Do not" section.
+
+**Status:** done — branch `fix/burst-score-remove-from-live-score`, PR #126,
+`cargo test` passing (452 tests). Tracker row `burst-score-remove-from-live` still
+needs to flip from `pending` to `promoted` once merged.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -254,8 +254,21 @@ Activity Risk = LRS
   + (scc_size if in cycle else 0) × 0.3           # cyclic dependency
   + min(dependency_depth / 3, 5.0) × 0.1         # depth from entrypoints
   + neighbor_churn / 500 × 0.2                    # churn in callees
-  + max(0, burst_score − 1.0) × 0.3               # commit-timing burstiness
 ```
+
+`burst_score` no longer contributes to the live Activity Risk / composite score. It is
+computed and stored on the snapshot (and still used by `trainer::cold_start_features`
+for offline model training), but `compute_activity_risk` in `scoring.rs` does not read
+it: `burst_score` is a full-history value that is effectively monotonic non-decreasing,
+so folding it into the live score made Activity Risk a one-way ratchet — a file with
+any historical burst, however old, could never leave the CRITICAL tier on this term
+alone even after the code had long since stabilized. See
+`hotspots-research/docs/burst-score-non-decaying-issue.md` for the full diagnosis and
+`hotspots-research/docs/promotion-briefs/burst-score-remove-from-live-score.md` for this
+change; a trailing-window or decayed replacement for the live score is tracked as
+follow-on research. The `burst` weight (`ScoringWeights.burst`, default `0.3`) and the
+`RiskFactors.burst` field are both kept in place, unused (`RiskFactors.burst` is always
+`0.0`), so a future replacement can reuse them without a renaming exercise.
 
 `burst_score` is a sliding 30-day-window max/mean commit ratio per file (always ≥ 1.0;
 higher means commits cluster into frantic bursts rather than steady, spread-out
@@ -278,9 +291,11 @@ candidate signals, positive across all leave-one-repo-out folds tested) — see
 
 Activity Risk is always ≥ LRS. When no git data is available, Activity Risk = LRS.
 
-All eight activity-risk weights above (`churn`, `touch`, `recency`, `fan_in`, `scc`,
-`depth`, `neighbor_churn`, `burst`) are overridable via the `scoring` key in
-`.hotspotsrc.json`:
+All seven activity-risk weights in the formula above (`churn`, `touch`, `recency`,
+`fan_in`, `scc`, `depth`, `neighbor_churn`) are overridable via the `scoring` key in
+`.hotspotsrc.json`. `burst` is also accepted for forward compatibility with a future
+replacement, but currently has no effect since `burst_score` is not read by the live
+formula:
 
 ```json
 {

--- a/hotspots-core/src/scoring.rs
+++ b/hotspots-core/src/scoring.rs
@@ -130,14 +130,16 @@ pub fn compute_activity_risk(
         0.0
     };
 
-    // Burst factor: burst_score is already a max/mean ratio (>= 1.0); use the
-    // amount above the steady-state baseline of 1.0 so a non-bursty file
-    // contributes nothing.
-    let burst_score = if let Some(burst) = input.burst_score {
-        (burst - 1.0).max(0.0) * weights.burst
-    } else {
-        0.0
-    };
+    // Burst factor: removed from the live composite score. burst_score is
+    // computed over a file's entire commit history and is monotonic
+    // non-decreasing, so including it here made activity_risk a one-way
+    // ratchet — a single historical burst could permanently keep a file at
+    // CRITICAL regardless of current state. See
+    // hotspots-research/docs/burst-score-non-decaying-issue.md and
+    // docs/promotion-briefs/burst-score-remove-from-live-score.md. The
+    // `burst_score` value itself is still computed and stored (see
+    // `history_signals.rs`/`snapshot.rs`) for other consumers such as
+    // `trainer::cold_start_features`.
 
     // Total activity risk
     let activity_risk = complexity_score
@@ -147,8 +149,7 @@ pub fn compute_activity_risk(
         + fan_in_score
         + scc_score
         + depth_score
-        + neighbor_churn_score
-        + burst_score;
+        + neighbor_churn_score;
 
     let risk_factors = RiskFactors {
         complexity: complexity_score,
@@ -159,7 +160,7 @@ pub fn compute_activity_risk(
         cyclic_dependency: scc_score,
         depth: depth_score,
         neighbor_churn: neighbor_churn_score,
-        burst: burst_score,
+        burst: 0.0,
     };
 
     (activity_risk, risk_factors)
@@ -273,9 +274,11 @@ mod tests {
             &ScoringWeights::default(),
         );
 
-        assert!(risk_with_burst > risk_without_burst);
+        // burst_score no longer contributes to activity_risk: a file with a
+        // historical burst (burst_score: Some(4.0)) scores identically to
+        // one without, and RiskFactors.burst is always 0.0.
+        assert_eq!(risk_with_burst, risk_without_burst);
         assert_eq!(factors_without_burst.burst, 0.0);
-        // (4.0 - 1.0) * 0.3 = 0.9
-        assert!((factors_with_burst.burst - 0.9).abs() < 0.001);
+        assert_eq!(factors_with_burst.burst, 0.0);
     }
 }


### PR DESCRIPTION
## Summary
- `burst_score` is computed over a file's entire commit history and is effectively monotonic non-decreasing, so including it in `compute_activity_risk` made `activity_risk` a one-way ratchet — a single historical burst could permanently keep a file at CRITICAL regardless of current state.
- Removes the burst term from `compute_activity_risk`'s sum; `RiskFactors.burst` is now always `0.0`.
- `ScoringWeights.burst`, `ActivityRiskInput.burst_score`, and the `burst_score` computation in `history_signals.rs`/`snapshot.rs` are untouched — `burst_score` still feeds `trainer::cold_start_features` and future formula refits, just no longer the live score.
- Implements `docs/promotion-briefs/burst-score-remove-from-live-score.md`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (452 tests passing, including inverted `test_compute_activity_risk_with_burst_score`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)