### PR TITLE
feat: F98 low-label-density gate for cold-start routing

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -41,7 +41,7 @@ Adds `commit_count`, `author_count`, `author_entropy`, `burst_score`, `isolation
 existing per-file-subprocess pattern — see brief for why). Must ship before the next
 task below.
 
-**Status:** not started
+**Status:** done — PR #121 (branch `feat/history-signals-porting`), merged
 
 ---
 
@@ -56,9 +56,30 @@ streaming IsolationForest). IsolationForest design pre-validated against sklearn
 Python (`scripts/poc/validate_streaming_isolation_forest.py` in the research repo,
 mean ρ gap −0.014) — see the brief's Research Artifacts section before implementing.
 
-**Status:** not started (⚠️ note: F93 below already adds a per-file-subprocess
-`burst_score` to `FunctionSnapshot` — reconcile with this task's single-git-log-pass
-design before implementing, to avoid a duplicate/conflicting field)
+**Status:** done — PR #123 (branch `feat/f62-f63-cold-start-routing`), merged, released
+v1.33.0. `hotspots analyze --cold-start` ships with Gini-gated routing
+(`ColdStartRoute::Formula`/`Anomaly`/`UniformPrior`) in `trainer.rs`.
+
+---
+
+## Task: F98 low-label-density gate for cold-start routing
+
+**Brief:** `/Users/stephencollins/projects/stephencollins.tech-repos/hotspots-research/docs/promotion-briefs/f98-lowlabel-coldstart-gate.md`
+
+**Depends on:** F62/F63 Gini-gated cold-start routing above — shipped, so this was
+unblocked (hotspots#118 closed).
+
+Adds a second, independent gate to `cold_start_rank()`: repos with fix-commit history
+but a low positive rate (0.05–0.30, function-level) route to the same `IsolationForest`
+anomaly path as the Gini-low branch, evaluated before it. Always uses function-level
+(blame-based) labels via `collect_fix_functions`, ignoring `cfg.blame_labels`, to avoid
+the file-level pos_rate inflation the brief calls out for spark/envoy-shaped repos.
+
+**Status:** implemented — branch `feat/f98-lowlabel-coldstart-gate`, not yet pushed/PR'd.
+`cold_start_rank()` signature extended to `(snapshot, repo_root, cfg)`; `handle_cold_start`
+in `hotspots-cli/src/cmd/analyze.rs` updated accordingly. 4 new integration tests in
+`hotspots-core/tests/trainer_tests.rs` cover all acceptance criteria. Full workspace
+`cargo test` (457 tests), `cargo fmt --check`, `cargo clippy -D warnings` all clean.
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -31,6 +31,7 @@ hotspots analyze <PATH> [OPTIONS]
 | `--include-models` | off | Add model risk map to JSON/HTML (snapshot only) |
 | `--callgraph-skip-above N` | 50000 | Skip betweenness centrality if call graph > N edges |
 | `--skip-gate` | off | Disable suppression gate P@10 check |
+| `--cold-start` | off | Gini/label-density-gated ranking with no trained ranker required — see [Cold-Start Ranking](#cold-start-ranking) |
 | `-j N` / `--jobs N` | CPU count | Parallel worker threads |
 
 **Notes:**
@@ -39,6 +40,7 @@ hotspots analyze <PATH> [OPTIONS]
 - Snapshot mode text output requires `--explain` or `--level`
 - SARIF requires `--mode snapshot`; HTML requires `--mode snapshot` or `--mode delta`
 - `--policy` requires `--mode delta`
+- `--cold-start` is not compatible with `--mode` — it bypasses the trained-ranker/snapshot pipeline entirely
 
 ### `hotspots diff <base> <head>`
 
@@ -117,6 +119,43 @@ hotspots: using trained ranker (model class: Ridge)
 ```
 
 Once a model is trained, `hotspots analyze . --mode snapshot --explain` adds a `✦` phrase line below each CRITICAL/HIGH function — e.g. `✦ Churns heavily and is load-bearing.` — derived from which features rank in the top 20th percentile for that repo. No `✦` lines appear without a trained ranker.
+
+### Cold-Start Ranking
+
+`hotspots analyze <PATH> --cold-start` produces a ranking without a trained ranker and
+without the label thresholds `hotspots train` requires (≥ 50 functions, ≥ 5 positive / ≥
+10 negative labels). It skips the trained-ranker lookup and snapshot pipeline entirely —
+`--mode` cannot be combined with it.
+
+```
+hotspots analyze . --cold-start
+hotspots analyze . --cold-start --top 20
+```
+
+Routing is decided per-repo by two independent gates, checked in this order, and printed
+before the ranked list (`cold-start route: formula|anomaly|uniform-prior`):
+
+1. **Uniform-prior guard.** If no file stands out even by raw commit count (top decile of
+   files by `commit_count` accounts for less than 20% of total commits), there's no basis
+   for a ranking — prints `(uniform prior — no ranking to show; all files equally likely)`
+   and returns an empty list rather than a manufactured one.
+2. **Low-label-density gate.** If the repo has *some* fix-commit history but the function-level
+   positive rate is low (5–30% of functions, with a Shannon-entropy floor to filter out
+   near-degenerate splits) — plenty of history, not enough confirmed fixes to trust a
+   supervised model — routes to the same label-free anomaly score as gate 3 below.
+3. **Gini-coefficient gate** (fallback). Computes the Gini coefficient of `commit_count`
+   across all functions:
+   - **High concentration** (a few files dominate commit activity, Gini ≥ 0.55) → the
+     existing formula score (`activity_risk`/`lrs`) is already a sufficient day-one
+     ranking; no model needed.
+   - **Low concentration** (Gini < 0.55) → fits a label-free `IsolationForest` on an
+     8-feature history vector (`commit_count`, `author_count`, `author_entropy`,
+     `burst_score`, `isolation_rate`, `age_days`, `last_touch_days`, `authors_90d`) and
+     ranks by anomaly score.
+
+Both anomaly routes (gate 2 and the low-Gini branch of gate 3) use the same
+`IsolationForest` implementation — memory-bounded, streaming, no full-matrix
+intermediate structure. Neither requires a `.hotspots/ranker.json` model file.
 
 ### `hotspots prune`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -58,6 +58,34 @@ hotspots analyze . --mode delta --format json   # machine-readable output
 
 In PR context (GitHub Actions, GitLab CI, CircleCI, Travis), delta mode automatically compares against the merge-base rather than the direct parent. Detection is via environment variables (`GITHUB_EVENT_NAME=pull_request`, `CI_MERGE_REQUEST_IID`, etc.).
 
+## Cold-Start Ranking
+
+`hotspots train` needs at least 50 functions and enough confirmed fix-commit labels
+(≥ 5 positive / ≥ 10 negative) to fit a ranker — a repo that's brand new to hotspots, or
+one with too little confirmed-fix history, doesn't clear that bar. `--cold-start` gives
+those repos a ranking anyway, with no trained model required:
+
+```bash
+hotspots analyze . --cold-start
+hotspots analyze . --cold-start --top 20
+```
+
+It skips the trained-ranker/snapshot pipeline entirely (`--mode` can't be combined with
+it) and picks one of three strategies per-repo, printed as the route before the ranked
+list:
+
+- **`formula`** — commit activity is concentrated in a few files; the existing
+  `activity_risk`/`lrs` score is already a good day-one ranking.
+- **`anomaly`** — commit activity is spread out, or the repo has fix history but too few
+  confirmed fixes to trust a supervised model; ranks by a label-free anomaly score over
+  history signals (commit count, author entropy, burst score, isolation rate, age, etc.)
+  instead.
+- **`uniform-prior`** — no file stands out by commit count at all; prints a note instead
+  of a manufactured ranking.
+
+See [`docs/REFERENCE.md`](REFERENCE.md#cold-start-ranking) for the exact routing
+thresholds.
+
 ## `hotspots diff`
 
 Compare snapshots between any two git refs (not just parent → HEAD):

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -324,7 +324,8 @@ fn handle_cold_start(
     snapshot.populate_history_signals(&repo_root);
     snapshot.populate_authors_90d(&repo_root);
 
-    let result = hotspots_core::trainer::cold_start_rank(&snapshot);
+    let train_cfg = hotspots_core::trainer::TrainConfig::default();
+    let result = hotspots_core::trainer::cold_start_rank(&snapshot, &repo_root, &train_cfg);
 
     let route_label = match result.route {
         hotspots_core::trainer::ColdStartRoute::Formula => "formula",

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -745,6 +745,27 @@ const COLD_START_N_TREES: usize = 100;
 const COLD_START_SUBSAMPLE_SIZE: usize = 256;
 const COLD_START_SEED: u64 = 42;
 
+/// Low-label-density gate (F98): function-level positive rate lower bound.
+/// Repos with `pos_rate` in `[LOWLABEL_POS_RATE_MIN, LOWLABEL_POS_RATE_MAX)` have fix
+/// history but too few confirmed fixes relative to total files for a supervised model
+/// to be trustworthy — route to the same label-free anomaly score as the Gini-low branch.
+pub const LOWLABEL_POS_RATE_MIN: f64 = 0.05;
+/// Low-label-density gate (F98): function-level positive rate upper bound (exclusive).
+pub const LOWLABEL_POS_RATE_MAX: f64 = 0.30;
+/// Low-label-density gate (F98): binary label-entropy floor. Separates F98's 4
+/// confirmed-good repos (entropy 0.391-0.932) from the rejected `dotnet__aspnetcore`
+/// case (entropy 0.198).
+pub const LOWLABEL_ENTROPY_MIN: f64 = 0.3;
+
+/// Standard binary Shannon entropy of a positive rate `p`. Returns `0.0` at the
+/// degenerate extremes (`p == 0.0` or `p == 1.0`) rather than `NaN`.
+fn binary_entropy(p: f64) -> f64 {
+    if p <= 0.0 || p >= 1.0 {
+        return 0.0;
+    }
+    -p * p.log2() - (1.0 - p) * (1.0 - p).log2()
+}
+
 /// Which cold-start ranking strategy was used.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColdStartRoute {
@@ -800,7 +821,11 @@ pub fn gini_coefficient(values: &[f64]) -> f64 {
 ///
 /// Two streaming passes over `snapshot.functions` on the `Anomaly` route (fit, then
 /// score) — no intermediate full-matrix structure is built at any point.
-pub fn cold_start_rank(snapshot: &Snapshot) -> ColdStartResult {
+pub fn cold_start_rank(
+    snapshot: &Snapshot,
+    repo_root: &Path,
+    cfg: &TrainConfig,
+) -> ColdStartResult {
     let commit_counts: Vec<f64> = snapshot
         .functions
         .iter()
@@ -828,9 +853,7 @@ pub fn cold_start_rank(snapshot: &Snapshot) -> ColdStartResult {
         }
     }
 
-    let gini = gini_coefficient(&commit_counts);
-
-    if gini < LOW_GINI {
+    let anomaly_route = || -> ColdStartResult {
         let forest = IsolationForest::fit(
             snapshot.functions.iter().map(cold_start_features),
             COLD_START_N_TREES,
@@ -846,10 +869,40 @@ pub fn cold_start_rank(snapshot: &Snapshot) -> ColdStartResult {
             })
             .collect();
         ranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
-        return ColdStartResult {
+        ColdStartResult {
             route: ColdStartRoute::Anomaly,
             ranked,
-        };
+        }
+    };
+
+    // F98: low-label-density gate, evaluated before the Gini branch. Always uses
+    // function-level (blame-based) labels regardless of `cfg.blame_labels` — the
+    // file-level path inflates pos_rate on repos where one fix commit touches a
+    // file with many functions (e.g. measured 0.751 vs true 0.133 on
+    // apache__spark in the research corpus), which would prevent this gate from
+    // ever firing on the exact repos it was built for.
+    if let Ok(fix_funcs) = collect_fix_functions(
+        snapshot,
+        repo_root,
+        cfg.label_window_days,
+        cfg.label_before.as_deref(),
+    ) {
+        let n_pos = fix_funcs.len();
+        if n_pos > 0 {
+            let pos_rate = n_pos as f64 / snapshot.functions.len() as f64;
+            let label_entropy = binary_entropy(pos_rate);
+            if (LOWLABEL_POS_RATE_MIN..LOWLABEL_POS_RATE_MAX).contains(&pos_rate)
+                && label_entropy > LOWLABEL_ENTROPY_MIN
+            {
+                return anomaly_route();
+            }
+        }
+    }
+
+    let gini = gini_coefficient(&commit_counts);
+
+    if gini < LOW_GINI {
+        return anomaly_route();
     }
 
     let mut ranked: Vec<ScoredFunction> = snapshot
@@ -1708,7 +1761,8 @@ mod tests {
         // Flat distribution: top-decile share = 0.10 < 0.20 guard.
         let counts = vec![1u32; 20];
         let snap = make_snapshot_with_commit_counts(&counts);
-        let result = cold_start_rank(&snap);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = cold_start_rank(&snap, dir.path(), &TrainConfig::default());
         assert_eq!(result.route, ColdStartRoute::UniformPrior);
         assert!(result.ranked.is_empty());
     }
@@ -1720,7 +1774,8 @@ mod tests {
         let mut counts = vec![1u32; 20];
         counts[0] = 30;
         let snap = make_snapshot_with_commit_counts(&counts);
-        let result = cold_start_rank(&snap);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = cold_start_rank(&snap, dir.path(), &TrainConfig::default());
         assert_eq!(result.route, ColdStartRoute::Formula);
         assert_eq!(result.ranked.len(), 20);
         // Ranked descending by activity_risk (lrs proxy: i/20, so f19 has the highest).
@@ -1739,7 +1794,8 @@ mod tests {
         counts[1] = 12;
         counts[2] = 10;
         let snap = make_snapshot_with_commit_counts(&counts);
-        let result = cold_start_rank(&snap);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = cold_start_rank(&snap, dir.path(), &TrainConfig::default());
         assert_eq!(result.route, ColdStartRoute::Anomaly);
         assert_eq!(result.ranked.len(), 30);
         for w in result.ranked.windows(2) {
@@ -1750,7 +1806,8 @@ mod tests {
     #[test]
     fn cold_start_empty_snapshot_is_uniform_prior_and_does_not_panic() {
         let snap = make_snapshot_with_commit_counts(&[]);
-        let result = cold_start_rank(&snap);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = cold_start_rank(&snap, dir.path(), &TrainConfig::default());
         assert_eq!(result.route, ColdStartRoute::UniformPrior);
         assert!(result.ranked.is_empty());
     }

--- a/hotspots-core/tests/trainer_tests.rs
+++ b/hotspots-core/tests/trainer_tests.rs
@@ -12,7 +12,8 @@ use hotspots_core::snapshot::{
     AnalysisInfo, CallGraphMetrics, ChurnMetrics, CommitInfo, FunctionSnapshot, Snapshot,
 };
 use hotspots_core::trainer::{
-    collect_fix_files, collect_fix_functions, extract_features, train, TrainConfig, FEATURE_NAMES,
+    cold_start_rank, collect_fix_files, collect_fix_functions, extract_features, train,
+    ColdStartRoute, TrainConfig, FEATURE_NAMES,
 };
 use std::path::Path;
 use std::process::Command;
@@ -428,4 +429,152 @@ fn train_returns_none_below_threshold() {
 
     let result = train(&snapshot, p, &TrainConfig::default(), None).expect("train");
     assert!(result.is_none(), "too few functions → None");
+}
+
+// ── F98: low-label-density cold-start gate ─────────────────────────────────────
+
+/// One function block per index: `def func_{i}():\n    x = {i}\n    return x\n`,
+/// blocks joined with a blank-line separator. Function `i`'s start line is
+/// `1 + i * 4` (3 body lines + 1 blank separator line per preceding block).
+fn make_blocks(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| format!("def func_{i}():\n    x = {i}\n    return x\n"))
+        .collect()
+}
+
+fn render_blocks(blocks: &[String]) -> String {
+    blocks.join("\n")
+}
+
+/// A snapshot of `n` functions in `file`, each with `commit_count` set from
+/// `counts` (must be length `n`) — used to control the Gini branch independently
+/// of git-derived fix-commit labels.
+fn make_snapshot_with_file_and_counts(file: &str, n: usize, counts: &[u32]) -> Snapshot {
+    assert_eq!(counts.len(), n);
+    let functions = (0..n)
+        .map(|i| {
+            let mut f = make_func(file, &format!("func_{i}"), (1 + i * 4) as u32);
+            f.commit_count = Some(counts[i]);
+            f
+        })
+        .collect();
+    make_snapshot(functions)
+}
+
+#[test]
+fn cold_start_lowlabel_gate_overrides_gini_formula_route() {
+    let dir = init_repo();
+    let p = dir.path();
+
+    let mut blocks = make_blocks(20);
+    commit_file(p, "big.py", &render_blocks(&blocks), "feat: add big module");
+
+    // Three separate fix commits, each touching exactly one distinct function —
+    // function-level pos_rate = 3/20 = 0.15, in [0.05, 0.30).
+    for target in [2usize, 7, 13] {
+        blocks[target] = format!("def func_{target}():\n    x = {target}  # fixed\n    return x\n");
+        commit_file(
+            p,
+            "big.py",
+            &render_blocks(&blocks),
+            &format!("fix: correct func_{target}"),
+        );
+    }
+
+    // Skewed commit_count (one dominant function) — would route Formula via the
+    // Gini branch (gini ≈ 0.56, same shape as cold_start_formula_route_ranks_by_activity_risk)
+    // if the low-label-density gate did not fire first.
+    let mut counts = vec![1u32; 20];
+    counts[0] = 30;
+    let snap = make_snapshot_with_file_and_counts("big.py", 20, &counts);
+
+    let result = cold_start_rank(&snap, p, &TrainConfig::default());
+    assert_eq!(
+        result.route,
+        ColdStartRoute::Anomaly,
+        "pos_rate=0.15 in-band should override the Gini branch"
+    );
+}
+
+#[test]
+fn cold_start_lowlabel_gate_does_not_fire_below_pos_rate_floor() {
+    let dir = init_repo();
+    let p = dir.path();
+
+    let mut blocks = make_blocks(30);
+    commit_file(p, "big.py", &render_blocks(&blocks), "feat: add big module");
+
+    // Single fix commit touching one function — pos_rate = 1/30 ≈ 0.033, below
+    // LOWLABEL_POS_RATE_MIN (0.05).
+    blocks[0] = "def func_0():\n    x = 0  # fixed\n    return x\n".to_string();
+    commit_file(p, "big.py", &render_blocks(&blocks), "fix: correct func_0");
+
+    let mut counts = vec![1u32; 30];
+    counts[0] = 45;
+    let snap = make_snapshot_with_file_and_counts("big.py", 30, &counts);
+
+    let result = cold_start_rank(&snap, p, &TrainConfig::default());
+    assert_eq!(
+        result.route,
+        ColdStartRoute::Formula,
+        "pos_rate below the floor must not trigger the low-label-density gate"
+    );
+}
+
+#[test]
+fn cold_start_lowlabel_gate_falls_through_with_no_fix_history() {
+    let dir = init_repo();
+    let p = dir.path();
+
+    let blocks = make_blocks(20);
+    commit_file(p, "big.py", &render_blocks(&blocks), "feat: add big module");
+    commit_file(
+        p,
+        "big.py",
+        &format!("{}\n# reformatted\n", render_blocks(&blocks)),
+        "chore: reformat big module",
+    );
+
+    let mut counts = vec![1u32; 20];
+    counts[0] = 30;
+    let snap = make_snapshot_with_file_and_counts("big.py", 20, &counts);
+
+    // No panic, and falls through cleanly to the existing Gini-based Formula route.
+    let result = cold_start_rank(&snap, p, &TrainConfig::default());
+    assert_eq!(result.route, ColdStartRoute::Formula);
+}
+
+#[test]
+fn cold_start_lowlabel_gate_uses_function_level_not_file_level_labels() {
+    let dir = init_repo();
+    let p = dir.path();
+
+    let mut blocks = make_blocks(20);
+    commit_file(p, "big.py", &render_blocks(&blocks), "feat: add big module");
+
+    // Three fix commits, all touching the same single file "big.py" but each
+    // modifying only one distinct function. Function-level pos_rate = 3/20 = 0.15
+    // (in-band). If this gate mistakenly used file-level labelling (any fix commit
+    // touching the file marks every function in it positive), pos_rate would read
+    // as 20/20 = 1.0 (out of band) and the gate would never fire.
+    for target in [1usize, 9, 18] {
+        blocks[target] = format!("def func_{target}():\n    x = {target}  # fixed\n    return x\n");
+        commit_file(
+            p,
+            "big.py",
+            &render_blocks(&blocks),
+            &format!("fix: correct func_{target}"),
+        );
+    }
+
+    let mut counts = vec![1u32; 20];
+    counts[0] = 30;
+    let snap = make_snapshot_with_file_and_counts("big.py", 20, &counts);
+
+    let result = cold_start_rank(&snap, p, &TrainConfig::default());
+    assert_eq!(
+        result.route,
+        ColdStartRoute::Anomaly,
+        "function-level pos_rate (0.15) should drive the gate, not file-level (1.0)"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds a second, independent gate to `cold_start_rank()`: repos with fix-commit history but a low positive rate (0.05–0.30, function-level) route to the same label-free `IsolationForest` anomaly path as the existing Gini-low branch, evaluated before it
- Always uses function-level (blame-based) labels via `collect_fix_functions`, ignoring `cfg.blame_labels`, to avoid the file-level pos_rate inflation identified for spark/envoy-shaped repos in the research finding
- `cold_start_rank()` signature extended to `(snapshot, repo_root, cfg)`; `hotspots-cli`'s `--cold-start` handler updated accordingly

Closes #122

## Test plan
- [x] `cargo test` — full workspace (457 tests) passing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] 4 new git-fixture integration tests in `hotspots-core/tests/trainer_tests.rs`: gate overrides Gini when in-band, doesn't fire below the pos_rate floor, falls through gracefully with zero fix history, and uses function-level (not file-level) labels
- [x] Manual smoke test: `cargo run -- analyze --cold-start .` against this repo itself — prints route and non-empty ranked list, no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)