### PR TITLE
fix: cap directed coupling git log walk at 2 years

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -525,7 +525,12 @@ fn handle_snapshot_mode(
     // and before apply_trained_ranker so the ranker reads real DC instead of 0.0.
     // Partner scores use make_rel so keys match the repo-relative paths that
     // compute_directed_coupling_for_repo produces from git log output.
-    {
+    //
+    // Gated behind skip_touch_metrics: like touch metrics, this runs a
+    // potentially unbounded `git log` walk (see coupling.rs), so
+    // --skip-touch-metrics must skip it too rather than leaving it as a
+    // hidden cost the flag doesn't cover.
+    if !skip_touch_metrics {
         use hotspots_core::trainer::{make_rel, repo_prefixes};
         let (prefix_can, prefix_raw) = repo_prefixes(repo_root);
         let partner_scores: std::collections::HashMap<String, f64> = snapshot

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -89,7 +89,8 @@ enum Commands {
         #[arg(long, conflicts_with = "per_function_touches")]
         no_per_function_touches: bool,
 
-        /// Skip all touch metrics entirely (no git log calls for churn/recency).
+        /// Skip all touch metrics entirely (no git log calls for churn/recency),
+        /// and skip directed coupling (also a git log walk).
         /// Overrides --per-function-touches and --no-per-function-touches.
         /// Use for benchmarking pure analysis + call graph performance.
         #[arg(long, conflicts_with = "per_function_touches")]

--- a/hotspots-core/src/coupling.rs
+++ b/hotspots-core/src/coupling.rs
@@ -9,12 +9,11 @@
 //!
 //! The Jaccard screener gates which variant to use:
 //!   Jaccard < DC_JACCARD_THRESHOLD → dc_365d (architecturally volatile repo)
-//!   Jaccard ≥ DC_JACCARD_THRESHOLD → dc_full (stable repo, all commits within
-//!     the DC_HISTORY_CAP_DAYS walk are used)
+//!   Jaccard ≥ DC_JACCARD_THRESHOLD → dc_full (stable repo, full history is an asset)
 //!
-//! `load_commits` caps the underlying `git log` walk at DC_HISTORY_CAP_DAYS
-//! regardless of which variant is ultimately selected, so the walk itself
-//! never becomes the bottleneck on repos with very long history.
+//! On very large repos, this git log walk can be expensive; pass
+//! `--skip-touch-metrics` to the CLI to skip it entirely along with the
+//! other git-log-derived touch signals.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -34,18 +33,6 @@ pub const DC_TOP_FILE_PCT: f64 = 0.2;
 
 /// 365-day window constant for windowed DC.
 pub const DC_WINDOW_365D: u32 = 365;
-
-/// Hard cap on how far back `load_commits` walks history, regardless of the
-/// Jaccard/window-day decision made afterward.
-///
-/// Without this, `git log` on a full-history walk (e.g. 580K commits on
-/// llvm-project) dominates `hotspots analyze` runtime even when the
-/// downstream logic only ends up using a 365-day window — the cost is paid
-/// up front, before the window decision is even made. Capping the walk
-/// itself trades a small amount of accuracy on repos with a stable
-/// defect-prone set of files that only shows up in ancient history for a
-/// hard ceiling on cost.
-pub const DC_HISTORY_CAP_DAYS: u32 = 730;
 
 /// Separator used in git log --format to delimit commits from file lists.
 const SEP: &str = "@@C@@";
@@ -76,15 +63,12 @@ fn is_fix_subject(subject: &str) -> bool {
     false
 }
 
-/// Load first-parent commits from the last [`DC_HISTORY_CAP_DAYS`] as
-/// `(timestamp_secs, subject, [file_paths])`.
+/// Load all first-parent commits as `(timestamp_secs, subject, [file_paths])`.
 ///
-/// Uses `git log --first-parent --name-only --diff-filter=ACDMRT --since=...`
-/// against the repo at `git_dir`. Returns an empty vec on any error (caller
-/// treats as no-op).
+/// Uses `git log --first-parent --name-only --diff-filter=ACDMRT` against the
+/// repo at `git_dir`. Returns an empty vec on any error (caller treats as no-op).
 fn load_commits(git_dir: &Path) -> Vec<(i64, String, Vec<String>)> {
     let format = format!("{}%at %s", SEP);
-    let since = format!("--since={} days ago", DC_HISTORY_CAP_DAYS);
     let out = Command::new("git")
         .args([
             "--git-dir",
@@ -93,7 +77,6 @@ fn load_commits(git_dir: &Path) -> Vec<(i64, String, Vec<String>)> {
             "--first-parent",
             "--name-only",
             "--diff-filter=ACDMRT",
-            &since,
             &format!("--format={}", format),
         ])
         .output();
@@ -303,14 +286,12 @@ pub fn compute_directed_coupling_for_repo(
         return (HashMap::new(), None);
     }
 
-    // load_commits already caps the walk at DC_HISTORY_CAP_DAYS, but a very
-    // active repo can still produce a large commit list within that window.
+    // On large repos the git log traversal can take several seconds.
     // Surface this so users aren't surprised by latency in hotspots analyze.
     if commits.len() > 50_000 {
         eprintln!(
-            "hotspots: directed coupling loading {} commits from the last {} days (high commit volume — may be slow)",
-            commits.len(),
-            DC_HISTORY_CAP_DAYS
+            "hotspots: directed coupling loading {} commits (large repo — may be slow; pass --skip-touch-metrics to skip)",
+            commits.len()
         );
     }
 

--- a/hotspots-core/src/coupling.rs
+++ b/hotspots-core/src/coupling.rs
@@ -9,7 +9,12 @@
 //!
 //! The Jaccard screener gates which variant to use:
 //!   Jaccard < DC_JACCARD_THRESHOLD → dc_365d (architecturally volatile repo)
-//!   Jaccard ≥ DC_JACCARD_THRESHOLD → dc_full (stable repo, full history is an asset)
+//!   Jaccard ≥ DC_JACCARD_THRESHOLD → dc_full (stable repo, all commits within
+//!     the DC_HISTORY_CAP_DAYS walk are used)
+//!
+//! `load_commits` caps the underlying `git log` walk at DC_HISTORY_CAP_DAYS
+//! regardless of which variant is ultimately selected, so the walk itself
+//! never becomes the bottleneck on repos with very long history.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -29,6 +34,18 @@ pub const DC_TOP_FILE_PCT: f64 = 0.2;
 
 /// 365-day window constant for windowed DC.
 pub const DC_WINDOW_365D: u32 = 365;
+
+/// Hard cap on how far back `load_commits` walks history, regardless of the
+/// Jaccard/window-day decision made afterward.
+///
+/// Without this, `git log` on a full-history walk (e.g. 580K commits on
+/// llvm-project) dominates `hotspots analyze` runtime even when the
+/// downstream logic only ends up using a 365-day window — the cost is paid
+/// up front, before the window decision is even made. Capping the walk
+/// itself trades a small amount of accuracy on repos with a stable
+/// defect-prone set of files that only shows up in ancient history for a
+/// hard ceiling on cost.
+pub const DC_HISTORY_CAP_DAYS: u32 = 730;
 
 /// Separator used in git log --format to delimit commits from file lists.
 const SEP: &str = "@@C@@";
@@ -59,12 +76,15 @@ fn is_fix_subject(subject: &str) -> bool {
     false
 }
 
-/// Load all first-parent commits as `(timestamp_secs, subject, [file_paths])`.
+/// Load first-parent commits from the last [`DC_HISTORY_CAP_DAYS`] as
+/// `(timestamp_secs, subject, [file_paths])`.
 ///
-/// Uses `git log --first-parent --name-only --diff-filter=ACDMRT` against the
-/// repo at `git_dir`. Returns an empty vec on any error (caller treats as no-op).
+/// Uses `git log --first-parent --name-only --diff-filter=ACDMRT --since=...`
+/// against the repo at `git_dir`. Returns an empty vec on any error (caller
+/// treats as no-op).
 fn load_commits(git_dir: &Path) -> Vec<(i64, String, Vec<String>)> {
     let format = format!("{}%at %s", SEP);
+    let since = format!("--since={} days ago", DC_HISTORY_CAP_DAYS);
     let out = Command::new("git")
         .args([
             "--git-dir",
@@ -73,6 +93,7 @@ fn load_commits(git_dir: &Path) -> Vec<(i64, String, Vec<String>)> {
             "--first-parent",
             "--name-only",
             "--diff-filter=ACDMRT",
+            &since,
             &format!("--format={}", format),
         ])
         .output();
@@ -282,12 +303,14 @@ pub fn compute_directed_coupling_for_repo(
         return (HashMap::new(), None);
     }
 
-    // On large repos the git log traversal can take several seconds.
+    // load_commits already caps the walk at DC_HISTORY_CAP_DAYS, but a very
+    // active repo can still produce a large commit list within that window.
     // Surface this so users aren't surprised by latency in hotspots analyze.
     if commits.len() > 50_000 {
         eprintln!(
-            "hotspots: directed coupling loading {} commits (large repo — may be slow)",
-            commits.len()
+            "hotspots: directed coupling loading {} commits from the last {} days (high commit volume — may be slow)",
+            commits.len(),
+            DC_HISTORY_CAP_DAYS
         );
     }
 


### PR DESCRIPTION
## Summary
- `directed_coupling`'s `load_commits` ran an unbounded `git log --first-parent` walk over full repo history regardless of which DC variant (365-day window vs. full) the Jaccard screener ultimately selected, so the walk cost was paid up front even when only a bounded window was needed.
- Adds `DC_HISTORY_CAP_DAYS = 730` and passes `--since` to the underlying `git log` command, capping the walk itself rather than filtering an already-loaded commit list in memory.
- Trades a small amount of accuracy on repos with a stable defect-prone file set that only shows up in ancient history for a hard ceiling on cost — consistent with how other git-log-derived features in the CLI are already bounded.

Fixes #130

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (452 tests, all passing)