### PR TITLE
Hedge unvalidated ownership/coupling phrasing in --explain

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -643,3 +643,5 @@ All languages have full parity across all metrics and features.
 ## Scoring Changelog
 
 All changes to formulas, weights, thresholds, or ranking rules are tracked in git commit history. The LRS formula and default weights have been stable since v1.0. The trained ranker feature was introduced in a later release; the current model is `model_version 5` (10 features). Check `CHANGELOG.md` for version-specific details.
+
+- The `authors_90d` and `directed_coupling` `--explain` phrases were reworded from directive to descriptive language (e.g. "no clear owner" → "no single frequent owner in recent history") after four independent tests found no outcome benefit from acting on the ownership/coupling diagnosis. See `META-12-observational-prescription-tests-fail.md` and `F103-review-hotspots-interventional.md` in `hotspots-research`.

--- a/hotspots-core/src/phrases.rs
+++ b/hotspots-core/src/phrases.rs
@@ -69,8 +69,8 @@ fn single_phrase(name: &str) -> &'static str {
         "total_churn" => "high lifetime churn",
         "lrs" => "structurally complex",
         "fan_in" => "depended on by many callers",
-        "authors_90d" => "no clear owner",
-        "directed_coupling" => "tightly coupled to other hotspots",
+        "authors_90d" => "no single frequent owner in recent history",
+        "directed_coupling" => "frequently changes alongside other hotspots",
         "cc" => "high cyclomatic complexity",
         "nd" => "deeply nested",
         _ => "elevated risk signal",
@@ -83,15 +83,15 @@ fn pair_phrase(a: &str, b: &str) -> Option<&'static str> {
             "churns heavily and is load-bearing"
         }
         ("total_churn", "authors_90d") | ("authors_90d", "total_churn") => {
-            "high churn with no clear owner"
+            "high churn with no single frequent owner in recent history"
         }
         ("lrs", "fan_in") | ("fan_in", "lrs") => "structurally complex and widely depended on",
         ("lrs", "total_churn") | ("total_churn", "lrs") => "complex and frequently changed",
         ("authors_90d", "fan_in") | ("fan_in", "authors_90d") => {
-            "no clear owner and called from many places"
+            "no single frequent owner in recent history, called from many places"
         }
         ("directed_coupling", "total_churn") | ("total_churn", "directed_coupling") => {
-            "coupled to hotspots and changing frequently"
+            "changes alongside other hotspots and is changing frequently"
         }
         _ => return None,
     };
@@ -154,7 +154,7 @@ mod tests {
             ..all_low()
         };
         let result = top_phrases(&fp, 3);
-        assert_eq!(result, "No clear owner.");
+        assert_eq!(result, "No single frequent owner in recent history.");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `authors_90d` and `directed_coupling` phrases in the `--explain` output previously read as implicit prescriptions ("no clear owner", "tightly coupled to other hotspots") with no wording distinction from `total_churn`/`lrs`-driven phrases.
- Four independent tests in `hotspots-research` (F85, F86, F87, F97 observational; F103 interventional) found no outcome benefit from acting on the ownership/coupling diagnosis, unlike the `complexity_reduction` prescription (F84-validated) tied to `total_churn`/`lrs`/`fan_in`/`cc`/`nd`.
- Rewords the two phrases (plus their pairwise co-occurrence combinations) to descriptive language so the CLI doesn't imply a validated recommendation it can't back. String-literal-only change in `phrases.rs` — no schema, flag, or threshold changes.

## Test plan
- [x] `cargo test -p hotspots-core phrases::` — 6/6 pass
- [x] `cargo test --workspace` — 453+ tests, 0 failed
- [x] `cargo build --workspace` — clean
- [x] Manual smoke test: trained ranker on this repo, ran `hotspots analyze --explain --top 0`, confirmed new phrasing ("frequently changes alongside other hotspots") renders in live CLI output

Brief: `docs/promotion-briefs/f55-meta12-phrase-hedging.md` in `hotspots-research`
Meta: `docs/meta/META-12-observational-prescription-tests-fail.md` in `hotspots-research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)