### PR TITLE
Annotate ranked functions with history_depth confidence tier

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -516,6 +516,7 @@ fn handle_snapshot_mode(
     )
     .context("failed to build enriched snapshot")?;
 
+    snapshot.populate_history_depth();
     snapshot.populate_patterns(&resolved_config.pattern_thresholds);
     if explain_patterns {
         snapshot.populate_pattern_details(&resolved_config.pattern_thresholds);

--- a/hotspots-core/src/aggregates.rs
+++ b/hotspots-core/src/aggregates.rs
@@ -1121,6 +1121,7 @@ mod tests {
             age_days: None,
             last_touch_days: None,
             explanation: None,
+            history_depth: None,
         }
     }
 

--- a/hotspots-core/src/db/mod.rs
+++ b/hotspots-core/src/db/mod.rs
@@ -403,6 +403,12 @@ fn load_functions(conn: &Connection, sha: &str) -> Result<Vec<FunctionSnapshot>>
         let language = crate::language::Language::from_name(&language)
             .unwrap_or(crate::language::Language::TypeScript);
         let band = crate::risk::RiskBand::parse(&band).unwrap_or(crate::risk::RiskBand::Low);
+        let history_depth = crate::trainer::history_depth_tier(
+            churn
+                .as_ref()
+                .map(|c| (c.lines_added + c.lines_deleted) as u32)
+                .unwrap_or(0),
+        );
         functions.push(FunctionSnapshot {
             function_id,
             file,
@@ -443,6 +449,7 @@ fn load_functions(conn: &Connection, sha: &str) -> Result<Vec<FunctionSnapshot>>
             age_days: None,
             last_touch_days: None,
             explanation: None,
+            history_depth: Some(history_depth),
         });
     }
 

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -693,6 +693,7 @@ mod tests {
             age_days: None,
             last_touch_days: None,
             explanation: None,
+            history_depth: None,
         }
     }
 

--- a/hotspots-core/src/sarif.rs
+++ b/hotspots-core/src/sarif.rs
@@ -298,6 +298,7 @@ mod tests {
             age_days: None,
             last_touch_days: None,
             explanation: None,
+            history_depth: None,
         }
     }
 

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -258,6 +258,12 @@ pub struct FunctionSnapshot {
     /// None unless `--explain` was passed and a trained ranker is present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation: Option<String>,
+    /// Confidence tier for this function's ranked score, derived from `total_churn`
+    /// (F10). Higher tiers indicate more training signal was available for this
+    /// function's history depth. Display-only — not used as a training feature or
+    /// to filter output. Populated by `Snapshot::populate_history_depth()`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_depth: Option<crate::trainer::HistoryDepth>,
 }
 
 /// Risk distribution by band
@@ -505,6 +511,7 @@ impl Snapshot {
                     age_days: None,
                     last_touch_days: None,
                     explanation: None,
+                    history_depth: None, // Populated separately by populate_history_depth()
                 }
             })
             .collect();
@@ -655,6 +662,20 @@ impl Snapshot {
     /// Files with fewer than 2 commits receive `Some(1.0)` (no burst signal).
     ///
     /// Errors are soft: if the git call fails, all functions keep `burst_score = None`.
+    /// Populate `history_depth` on every function from its already-computed `churn`
+    /// (F10). Pure computation — no git subprocess, no repo_root needed. Functions
+    /// with no churn data (`churn: None`) are treated as `total_churn = 0` → `Sparse`.
+    pub fn populate_history_depth(&mut self) {
+        for func in &mut self.functions {
+            let total_churn = func
+                .churn
+                .as_ref()
+                .map(|c| (c.lines_added + c.lines_deleted) as u32)
+                .unwrap_or(0);
+            func.history_depth = Some(crate::trainer::history_depth_tier(total_churn));
+        }
+    }
+
     pub fn populate_burst_score(&mut self, repo_root: &Path) {
         use std::collections::HashMap;
 

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -119,6 +119,31 @@ pub fn extract_features(func: &FunctionSnapshot) -> [f64; 10] {
     ]
 }
 
+/// Confidence tier for a function's ranked score, derived from `total_churn`
+/// (lifetime lines added + deleted). F10 found the trained ranker is most reliable
+/// in the `Rich` bucket (FT ρ = +0.635) versus `Sparse` (FT ρ = +0.131) — same
+/// model, history-depth-dependent confidence. Display-only; not a training feature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryDepth {
+    Sparse,
+    Moderate,
+    Rich,
+    VeryRich,
+}
+
+/// Bucket boundaries come directly from F10's holdout analysis: Sparse 1–10,
+/// Moderate 11–50, Rich 51–200, VeryRich 201+ lifetime touches (approximated here
+/// by `total_churn`, the only per-function history-depth proxy in the snapshot).
+pub fn history_depth_tier(total_churn: u32) -> HistoryDepth {
+    match total_churn {
+        0..=10 => HistoryDepth::Sparse,
+        11..=50 => HistoryDepth::Moderate,
+        51..=200 => HistoryDepth::Rich,
+        _ => HistoryDepth::VeryRich,
+    }
+}
+
 /// Cold-start feature vector (F62/F63) — distinct from `extract_features()`'s 10
 /// structural/activity features. Order: commit_count, author_count, author_entropy,
 /// burst_score, isolation_rate, age_days, last_touch_days, authors_90d. All fields
@@ -1314,6 +1339,23 @@ impl RankerModel {
 mod tests {
     use super::*;
 
+    // ── history_depth_tier (F10) ─────────────────────────────────────────────
+
+    #[test]
+    fn history_depth_tier_covers_all_buckets() {
+        assert_eq!(history_depth_tier(0), HistoryDepth::Sparse);
+        assert_eq!(history_depth_tier(5), HistoryDepth::Sparse);
+        assert_eq!(history_depth_tier(10), HistoryDepth::Sparse);
+        assert_eq!(history_depth_tier(11), HistoryDepth::Moderate);
+        assert_eq!(history_depth_tier(25), HistoryDepth::Moderate);
+        assert_eq!(history_depth_tier(50), HistoryDepth::Moderate);
+        assert_eq!(history_depth_tier(51), HistoryDepth::Rich);
+        assert_eq!(history_depth_tier(100), HistoryDepth::Rich);
+        assert_eq!(history_depth_tier(200), HistoryDepth::Rich);
+        assert_eq!(history_depth_tier(201), HistoryDepth::VeryRich);
+        assert_eq!(history_depth_tier(250), HistoryDepth::VeryRich);
+    }
+
     // ── precision_at_k ────────────────────────────────────────────────────────
 
     fn make_scored(ids: &[&str], scores: &[f64]) -> Vec<ScoredFunction> {
@@ -1555,6 +1597,7 @@ mod tests {
                 age_days: None,
                 last_touch_days: None,
                 explanation: None,
+                history_depth: None,
             })
             .collect();
 
@@ -1730,6 +1773,7 @@ mod tests {
                 age_days: Some(30.0),
                 last_touch_days: Some(1.0),
                 explanation: None,
+                history_depth: None,
             })
             .collect();
 
@@ -1859,6 +1903,7 @@ mod tests {
             age_days: None,
             last_touch_days: None,
             explanation: None,
+            history_depth: None,
         };
         assert_eq!(cold_start_features(&func), [0.0; 8]);
     }

--- a/hotspots-core/src/trends.rs
+++ b/hotspots-core/src/trends.rs
@@ -513,6 +513,7 @@ mod tests {
                     age_days: None,
                     last_touch_days: None,
                     explanation: None,
+                    history_depth: None,
                 }],
             ),
             create_test_snapshot(
@@ -558,6 +559,7 @@ mod tests {
                     age_days: None,
                     last_touch_days: None,
                     explanation: None,
+                    history_depth: None,
                 }],
             ),
         ];
@@ -615,6 +617,7 @@ mod tests {
                     age_days: None,
                     last_touch_days: None,
                     explanation: None,
+                    history_depth: None,
                 }],
             ),
             create_test_snapshot(
@@ -660,6 +663,7 @@ mod tests {
                     age_days: None,
                     last_touch_days: None,
                     explanation: None,
+                    history_depth: None,
                 }],
             ),
         ];
@@ -716,6 +720,7 @@ mod tests {
                         age_days: None,
                         last_touch_days: None,
                         explanation: None,
+                        history_depth: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -757,6 +762,7 @@ mod tests {
                         age_days: None,
                         last_touch_days: None,
                         explanation: None,
+                        history_depth: None,
                     },
                 ],
             ),
@@ -804,6 +810,7 @@ mod tests {
                         age_days: None,
                         last_touch_days: None,
                         explanation: None,
+                        history_depth: None,
                     },
                     FunctionSnapshot {
                         function_id: "src/bar.ts::func2".to_string(),
@@ -845,6 +852,7 @@ mod tests {
                         age_days: None,
                         last_touch_days: None,
                         explanation: None,
+                        history_depth: None,
                     },
                 ],
             ),

--- a/hotspots-core/tests/trainer_tests.rs
+++ b/hotspots-core/tests/trainer_tests.rs
@@ -93,6 +93,7 @@ fn make_func(file: &str, name: &str, line: u32) -> FunctionSnapshot {
         age_days: None,
         last_touch_days: None,
         explanation: None,
+        history_depth: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- F10 found the trained ranker is far more reliable on functions with 51–200 lifetime touches (FT ρ=+0.635) than sparse-history ones (FT ρ=+0.131) — same model, different confidence depending on how much history exists for a function.
- Adds `HistoryDepth` (`Sparse`/`Moderate`/`Rich`/`VeryRich`) to `FunctionSnapshot`, derived from `total_churn` at display time via `history_depth_tier()`. No training feature, no model change, no filtering — pure output annotation, per the brief.
- Populated in the `analyze` output path (`Snapshot::populate_history_depth()`) and reconstructed from stored churn when a persisted snapshot is reloaded from the DB, so it survives round-trips.

## Note
The brief's bucket boundaries (1–10 / 11–50 / 51–200 / 201+) come from F10's original *file-level lifetime touch count*. The only per-function history-depth proxy available in `FunctionSnapshot` is `total_churn` (lines added+deleted for that function), which is what the brief specifies as the source — smaller in magnitude than file-level touch counts. On a smoke test against this repo itself, most functions landed in `Sparse` under these thresholds. Bucket boundaries were left unchanged per the brief ("do not change bucket boundaries; they come directly from F10's holdout analysis"); recalibrating them against the function-level distribution would be a separate follow-up if the tiers turn out to carry too little discriminating power in practice.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — 454 core tests + all other suites, 0 failed
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] New unit test `history_depth_tier_covers_all_buckets` covers all four bucket boundaries
- [x] Manual smoke test: `hotspots analyze --mode snapshot --format json --all-functions` confirms `history_depth` serializes as lowercase snake_case strings (`"sparse"`, `"very_rich"`, etc.)

Brief: `docs/promotion-briefs/f10-history-depth-context.md` in `hotspots-research`
Finding: `docs/findings/10-history-depth-and-signal-quality.md` in `hotspots-research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)