### PR TITLE
fix: catch swc lexer panics per-file instead of crashing

### DIFF
--- a/hotspots-core/src/analysis.rs
+++ b/hotspots-core/src/analysis.rs
@@ -6,6 +6,7 @@ use crate::metrics;
 use crate::report;
 use crate::risk;
 use anyhow::{Context, Result};
+use std::panic::{self, AssertUnwindSafe};
 use std::path::Path;
 use swc_common::{sync::Lrc, SourceMap};
 
@@ -60,7 +61,27 @@ pub fn analyze_file_with_config(
     let language = Language::from_path(path)
         .ok_or_else(|| anyhow::anyhow!("Unsupported file type: {}", path.display()))?;
     let parser = create_parser(language, source_map)?;
-    let module = parser.parse(&src, &path.to_string_lossy())?;
+
+    let parse_result = panic::catch_unwind(AssertUnwindSafe(|| {
+        parser.parse(&src, &path.to_string_lossy())
+    }));
+
+    let module = match parse_result {
+        Ok(result) => result?,
+        Err(panic_payload) => {
+            let msg = panic_payload
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| panic_payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_string());
+            eprintln!(
+                "warning: skipping {} — parser panicked: {}",
+                path.display(),
+                msg
+            );
+            return Ok(vec![]);
+        }
+    };
     let functions = module.discover_functions(file_index, &src);
 
     let func_cfg = FunctionAnalysisConfig {

--- a/hotspots-core/tests/integration_tests.rs
+++ b/hotspots-core/tests/integration_tests.rs
@@ -200,6 +200,21 @@ fn test_react_jsx_in_plain_js_file() {
     );
 }
 
+/// A file that trips a real panic (not a recoverable parse error) inside the
+/// swc lexer must be skipped with a warning, not crash the whole analysis run.
+/// See: https://github.com/stephenc222/hotspots/issues/135
+#[test]
+fn test_lexer_panic_is_skipped_not_fatal() {
+    let path = fixture_path("lexer-panic.tsx");
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+
+    let reports = analyze(&path, options).unwrap();
+    assert_eq!(reports.len(), 0);
+}
+
 /// Progress callback must be called with (0, total) after discovery, then
 /// (n, total) once per file analyzed, ending with (total, total).
 #[test]

--- a/tests/fixtures/lexer-panic.tsx
+++ b/tests/fixtures/lexer-panic.tsx
@@ -1,0 +1,3 @@
+function Component() {
+  return <div>&#xD800;</div>;
+}


### PR DESCRIPTION
## Summary
- `parser.parse()` in `analyze_file_with_config` is now wrapped in `std::panic::catch_unwind` so a real panic inside the swc lexer (not a recoverable parse error) degrades to a `warning: skipping ... — parser panicked: ...` and the scan continues, matching the existing skip-and-warn pattern for minified/vendored files and invalid CFGs.
- Adds a regression test (`test_lexer_panic_is_skipped_not_fatal`) using a minimal fixture (`tests/fixtures/lexer-panic.tsx`) that reliably reproduces the same swc panic (`failed to parse number as char` on an out-of-range JSX numeric entity like `&#xD800;`) locally, without needing the full swc-project/swc repo.

Fixes #135.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (full suite, including new regression test)
- [x] Built release binary and ran the exact repro from #135 against `swc-project/swc`'s `crates/swc_ecma_parser` (contains the actual panic-triggering fixture `tests/jsx/basic/entity/input.js`) — hit the real panic, logged the warning, and exited 0 with a valid JSON snapshot report instead of crashing.