### PR TITLE
fix: suppression comments were no-op outside TS/JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 - Catch swc lexer panics per-file instead of crashing (#136)
+- Fix suppression comments being silently ignored for all languages except TypeScript/JavaScript
 
 ## [1.35.0] - 2026-08-24
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -366,9 +366,15 @@ Suppress CI policy failures while keeping the function visible in reports:
 function legacyBillingLogic() { ... }
 ```
 
+```python
+# hotspots-ignore: legacy payment processor, rewrite scheduled Q2 2026
+def legacy_billing_logic(): ...
+```
+
 Rules:
 - Comment must be on the line **immediately before** the function (no blank line between)
-- Format: `// hotspots-ignore: <reason>`
+- Format: `// hotspots-ignore: <reason>` — use `#` instead of `//` for Python; every other
+  supported language (Go, Java, C#, Rust, C/C++, TypeScript/JavaScript, Vue) uses `//`
 - Reason is required (missing reason triggers a warning, not a hard failure)
 - Suppressed functions still appear in all reports with a `suppression_reason` field
 - Suppressed functions still count toward net repo regression

--- a/hotspots-core/src/analysis.rs
+++ b/hotspots-core/src/analysis.rs
@@ -82,7 +82,16 @@ pub fn analyze_file_with_config(
             return Ok(vec![]);
         }
     };
-    let functions = module.discover_functions(file_index, &src);
+    let mut functions = module.discover_functions(file_index, &src);
+
+    // Extract suppression comments here, uniformly across all languages —
+    // language-specific parsers leave `suppression_reason: None` and rely on
+    // this pass rather than each duplicating the (language-agnostic) logic.
+    let comment_prefix = language.suppression_comment_prefix();
+    for function in &mut functions {
+        function.suppression_reason =
+            crate::suppression::extract_suppression(&src, function.span, comment_prefix);
+    }
 
     let func_cfg = FunctionAnalysisConfig {
         options,

--- a/hotspots-core/src/discover.rs
+++ b/hotspots-core/src/discover.rs
@@ -44,7 +44,9 @@ pub fn discover_functions(
     // Sort by span start for deterministic ordering
     collector.functions.sort_by_key(|f| f.span.start);
 
-    // Assign IDs and extract suppressions based on sorted order
+    // Assign IDs based on sorted order. Suppression comments are extracted
+    // uniformly for all languages by the caller (see `analysis.rs`), not here.
+    let _ = source;
     collector
         .functions
         .into_iter()
@@ -54,9 +56,6 @@ pub fn discover_functions(
                 file_index,
                 local_index: idx,
             };
-            // Extract suppression comment for this function
-            func.suppression_reason =
-                crate::suppression::extract_suppression(source, func.span, source_map);
             func
         })
         .collect()

--- a/hotspots-core/src/language/mod.rs
+++ b/hotspots-core/src/language/mod.rs
@@ -104,6 +104,18 @@ impl Language {
         }
     }
 
+    /// Line-comment prefix used to recognize `hotspots-ignore` suppression
+    /// comments in this language's source syntax.
+    ///
+    /// Every supported language uses `//` line comments except Python, which
+    /// uses `#`.
+    pub fn suppression_comment_prefix(&self) -> &'static str {
+        match self {
+            Language::Python => "#",
+            _ => "//",
+        }
+    }
+
     /// Detect language from file path
     ///
     /// Returns `None` if the file has no extension or the extension is not recognized.

--- a/hotspots-core/src/suppression.rs
+++ b/hotspots-core/src/suppression.rs
@@ -1,14 +1,14 @@
 //! Suppression comment extraction
 //!
-//! Parses `// hotspots-ignore: reason` comments from source code.
+//! Parses `<comment-prefix> hotspots-ignore: reason` comments from source code,
+//! e.g. `// hotspots-ignore: reason` or, for Python, `# hotspots-ignore: reason`.
 //!
 //! Global invariants enforced:
-//! - Deterministic extraction (pure function of source, span)
+//! - Deterministic extraction (pure function of source, span, comment prefix)
 //! - Comment must be on the line immediately before the function
 //! - Returns None (no suppression), Some("") (no reason), or Some("reason")
 
 use crate::language::SourceSpan;
-use swc_common::SourceMap;
 
 /// Extract suppression comment for a function
 ///
@@ -21,7 +21,8 @@ use swc_common::SourceMap;
 ///
 /// * `source` - The complete source code
 /// * `span` - The function's source span
-/// * `_source_map` - (Unused, kept for backwards compatibility)
+/// * `comment_prefix` - The line-comment prefix for this language (e.g. `"//"`
+///   or `"#"`), from [`crate::language::Language::suppression_comment_prefix`]
 ///
 /// # Comment Format
 ///
@@ -32,11 +33,7 @@ use swc_common::SourceMap;
 /// ```
 ///
 /// Blank lines between the comment and function will cause the comment to be ignored.
-pub fn extract_suppression(
-    source: &str,
-    span: SourceSpan,
-    _source_map: &SourceMap,
-) -> Option<String> {
+pub fn extract_suppression(source: &str, span: SourceSpan, comment_prefix: &str) -> Option<String> {
     // Get the line number of the function start (1-indexed)
     let func_line = span.start_line;
 
@@ -59,7 +56,8 @@ pub fn extract_suppression(
     let prev_line = lines[prev_line_num - 1].trim();
 
     // Check if the line contains the suppression comment
-    if !prev_line.starts_with("// hotspots-ignore") {
+    let marker = format!("{comment_prefix} hotspots-ignore");
+    if !prev_line.starts_with(&marker) {
         return None;
     }
 
@@ -118,7 +116,7 @@ mod tests {
             .expect("no function found");
 
         let source_span = crate::language::span::span_with_location(function_span, &source_map);
-        extract_suppression(source, source_span, &source_map)
+        extract_suppression(source, source_span, "//")
     }
 
     #[test]
@@ -208,5 +206,46 @@ function foo() {
 }
 "#;
         assert_eq!(parse_and_extract(source), None);
+    }
+
+    // Python uses `#` line comments, not `//`. These tests exercise
+    // `extract_suppression` directly against a synthetic Python-shaped span
+    // rather than going through the swc/TS test harness above.
+    fn python_span(func_line: u32) -> SourceSpan {
+        SourceSpan {
+            start: 0,
+            end: 0,
+            start_line: func_line,
+            end_line: func_line,
+            start_col: 0,
+        }
+    }
+
+    #[test]
+    fn test_hash_prefix_suppression_with_reason() {
+        let source =
+            "# hotspots-ignore: legacy code, will refactor later\ndef foo():\n    return 42\n";
+        assert_eq!(
+            extract_suppression(source, python_span(2), "#"),
+            Some("legacy code, will refactor later".to_string())
+        );
+    }
+
+    #[test]
+    fn test_hash_prefix_no_match_against_slash_comment() {
+        let source = "// hotspots-ignore: this is a JS-style comment\ndef foo():\n    return 42\n";
+        assert_eq!(extract_suppression(source, python_span(2), "#"), None);
+    }
+
+    #[test]
+    fn test_slash_prefix_no_match_against_hash_comment() {
+        let source = "# hotspots-ignore: this is a Python-style comment\nfunction foo() {}\n";
+        assert_eq!(extract_suppression(source, python_span(2), "//"), None);
+    }
+
+    #[test]
+    fn test_hash_prefix_blank_line_between() {
+        let source = "# hotspots-ignore: should not be recognized\n\ndef foo():\n    return 42\n";
+        assert_eq!(extract_suppression(source, python_span(3), "#"), None);
     }
 }

--- a/hotspots-core/tests/suppression_tests.rs
+++ b/hotspots-core/tests/suppression_tests.rs
@@ -1,14 +1,36 @@
 //! Integration tests for suppression comments
+//!
+//! These tests go through the full `analyze_file_with_config` pipeline (not
+//! `discover::discover_functions` directly) because suppression extraction is
+//! wired in once, uniformly, at the language-agnostic call site in
+//! `analysis.rs` — every parser's `discover_functions` leaves
+//! `suppression_reason: None` and relies on that later pass.
 
+use hotspots_core::analysis::analyze_file_with_config;
 use hotspots_core::delta::{Delta, FunctionDeltaEntry, FunctionStatus};
-use hotspots_core::discover;
-use hotspots_core::parser;
 use hotspots_core::policy::{evaluate_policies, PolicyId, PolicySeverity};
 use hotspots_core::risk::RiskBand;
 use hotspots_core::snapshot::Snapshot;
-use hotspots_core::{git::GitContext, ResolvedConfig};
+use hotspots_core::{git::GitContext, AnalysisOptions, ResolvedConfig};
 use std::path::Path;
 use swc_common::{sync::Lrc, SourceMap};
+use tempfile::Builder;
+
+fn analyze_source(source: &str, suffix: &str) -> Vec<hotspots_core::report::FunctionRiskReport> {
+    let file = Builder::new()
+        .suffix(suffix)
+        .tempfile()
+        .expect("create temp file");
+    std::fs::write(file.path(), source).expect("write temp source");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let options = AnalysisOptions {
+        min_lrs: None,
+        top_n: None,
+    };
+    analyze_file_with_config(file.path(), &cm, 0, &options, None, None, None)
+        .expect("analysis should succeed")
+}
 
 #[test]
 fn test_suppression_comment_extraction() {
@@ -29,9 +51,7 @@ function notSuppressed() {
 }
 "#;
 
-    let cm: Lrc<SourceMap> = Default::default();
-    let module = parser::parse_source(source, &cm, "test.ts").unwrap();
-    let functions = discover::discover_functions(&module, 0, source, &cm);
+    let functions = analyze_source(source, ".ts");
 
     assert_eq!(functions.len(), 2);
     assert_eq!(
@@ -50,9 +70,7 @@ function suppressed() {
 }
 "#;
 
-    let cm: Lrc<SourceMap> = Default::default();
-    let module = parser::parse_source(source, &cm, "test.ts").unwrap();
-    let functions = discover::discover_functions(&module, 0, source, &cm);
+    let functions = analyze_source(source, ".ts");
 
     assert_eq!(functions.len(), 1);
     assert_eq!(functions[0].suppression_reason, Some(String::new()));
@@ -68,12 +86,47 @@ function notSuppressed() {
 }
 "#;
 
-    let cm: Lrc<SourceMap> = Default::default();
-    let module = parser::parse_source(source, &cm, "test.ts").unwrap();
-    let functions = discover::discover_functions(&module, 0, source, &cm);
+    let functions = analyze_source(source, ".ts");
 
     assert_eq!(functions.len(), 1);
     assert_eq!(functions[0].suppression_reason, None);
+}
+
+/// Regression test: suppression previously only worked for TypeScript/
+/// JavaScript, because `extract_suppression` was called solely from the
+/// swc-specific `discover.rs` path. Every other language's parser set
+/// `suppression_reason: None` unconditionally and nothing ever filled it in
+/// — `// hotspots-ignore` was a silent no-op on Python, Go, Java, C#, Rust,
+/// and C. This test exercises a non-JS language end-to-end.
+#[test]
+fn test_suppression_works_for_python() {
+    let source = "# hotspots-ignore: legacy code\ndef suppressed():\n    if True:\n        return 1\n    return 0\n\n\ndef not_suppressed():\n    if True:\n        return 1\n    return 0\n";
+
+    let functions = analyze_source(source, ".py");
+
+    assert_eq!(functions.len(), 2);
+    assert_eq!(
+        functions[0].suppression_reason,
+        Some("legacy code".to_string())
+    );
+    assert_eq!(functions[1].suppression_reason, None);
+}
+
+/// Regression test: a Go file previously never got suppression either,
+/// since `Language::Go`'s parser also left `suppression_reason: None` with
+/// no follow-up extraction step.
+#[test]
+fn test_suppression_works_for_go() {
+    let source = "// hotspots-ignore: legacy code\nfunc Suppressed() int {\n\tif true {\n\t\treturn 1\n\t}\n\treturn 0\n}\n\nfunc NotSuppressed() int {\n\tif true {\n\t\treturn 1\n\t}\n\treturn 0\n}\n";
+
+    let functions = analyze_source(source, ".go");
+
+    assert_eq!(functions.len(), 2);
+    assert_eq!(
+        functions[0].suppression_reason,
+        Some("legacy code".to_string())
+    );
+    assert_eq!(functions[1].suppression_reason, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`// hotspots-ignore` suppression comments silently did nothing for every language except TypeScript/JavaScript.

`extract_suppression` was only ever invoked from `discover.rs`, the swc-specific (TS/JS) discovery path. Every other language's parser — Go, Python, Java, C#, Rust, C/CHeader — set `suppression_reason: None` unconditionally, each with an identical `// Will be extracted separately` comment (`go/parser.rs:133`, `python/parser.rs:134`, `java/parser.rs:138`, etc.). That follow-up step was never written. A suppression comment on a Python or Go function would parse without error and simply have no effect — the function stayed subject to CI policy gating with no indication anything was wrong.

This fix:
- Moves suppression extraction out of the TS-only `discover.rs` and into `analysis.rs`, the one call site every language's parser already funnels through (`module.discover_functions(...)`).
- Adds `Language::suppression_comment_prefix()` (`#` for Python, `//` for the other 11 languages), since `extract_suppression`'s marker check was hardcoded to `//` and Python doesn't use that syntax.
- Adds end-to-end regression tests (`test_suppression_works_for_python`, `test_suppression_works_for_go`) that exercise the real `analyze_file_with_config` pipeline — these would have caught the original gap, since the old tests called `discover::discover_functions` directly and only ever tested the TS path.

Surfaced during an internal weakness audit of the CLI. Tracked in `hotspots-research`'s promotion tracker cross-repo tasks table (no formula/ranking change, so no promotion brief needed per this repo's research-sync convention).

## Linked Issues

None filed yet — found during audit, not from a user report.

## Test Plan

- [x] Unit tests pass (`cargo test --workspace` — 458 hotspots-core unit tests + all integration suites, 0 failures)
- [x] New regression tests added: `test_suppression_works_for_python`, `test_suppression_works_for_go` (both green; both would fail on `main`)
- [ ] Manual verification (not applicable — covered by the new integration tests)

## Pre-merge Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated `docs/USAGE.md` suppression section with a Python example and per-language comment-prefix note
- [x] Changelog entry added under `[Unreleased]`

Marked as draft pending review — this is a real behavior change (suppression now actually works on 6 languages where it silently didn't before), worth a second look before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E1LPC89UhzZb1nhZBYeBsQ)_