### PR TITLE
fix: include tags and remotes as reachable refs in prune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 - Warn loudly when policy evaluation is silently skipped (#147)
+- `prune --unreachable` now also treats `refs/tags/*` and `refs/remotes/*` as reachable, not just `refs/heads/*`, preventing irreversible deletion of snapshots for detached-HEAD checkouts and tagged-only releases (#142)
 
 ## [1.35.1] - 2026-08-26
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -165,7 +165,7 @@ Remove unreachable snapshots (after force-push or branch deletion).
 hotspots prune --unreachable [--older-than DAYS] [--dry-run]
 ```
 
-`--unreachable` is required. Only prunes snapshots unreachable from `refs/heads/*`.
+`--unreachable` is required. Only prunes snapshots unreachable from `refs/heads/*`, `refs/tags/*`, or `refs/remotes/*`.
 
 ### `hotspots compact`
 

--- a/hotspots-cli/src/cmd/prune.rs
+++ b/hotspots-cli/src/cmd/prune.rs
@@ -12,10 +12,18 @@ pub(crate) fn handle_prune(
 
     let repo_root = find_repo_root(&std::env::current_dir()?)?;
     let options = prune::PruneOptions {
-        ref_patterns: vec!["refs/heads/*".to_string()],
+        ref_patterns: vec![
+            "refs/heads/*".to_string(),
+            "refs/tags/*".to_string(),
+            "refs/remotes/*".to_string(),
+        ],
         older_than_days: older_than,
         dry_run,
     };
+    println!(
+        "Considering commits reachable from: {}",
+        options.ref_patterns.join(", ")
+    );
     let result = prune::prune_unreachable(&repo_root, options)?;
 
     if dry_run {

--- a/hotspots-core/src/prune.rs
+++ b/hotspots-core/src/prune.rs
@@ -18,7 +18,7 @@ use crate::snapshot::{self, Index};
 /// Pruning options
 #[derive(Debug, Clone)]
 pub struct PruneOptions {
-    /// Tracked ref patterns (default: ["refs/heads/*"])
+    /// Tracked ref patterns (default: ["refs/heads/*", "refs/tags/*", "refs/remotes/*"])
     pub ref_patterns: Vec<String>,
     /// Only prune commits older than this many days (None = no age filter)
     pub older_than_days: Option<u64>,
@@ -29,7 +29,11 @@ pub struct PruneOptions {
 impl Default for PruneOptions {
     fn default() -> Self {
         PruneOptions {
-            ref_patterns: vec!["refs/heads/*".to_string()],
+            ref_patterns: vec![
+                "refs/heads/*".to_string(),
+                "refs/tags/*".to_string(),
+                "refs/remotes/*".to_string(),
+            ],
             older_than_days: None,
             dry_run: false,
         }
@@ -68,7 +72,7 @@ fn git_at(repo_path: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-/// Enumerate tracked refs (default: local branches refs/heads/*)
+/// Enumerate tracked refs (default: refs/heads/*, refs/tags/*, refs/remotes/*)
 ///
 /// Returns a list of commit SHAs pointed to by the tracked refs.
 fn enumerate_tracked_refs(repo_path: &Path, patterns: &[String]) -> Result<Vec<String>> {
@@ -247,4 +251,99 @@ pub fn prune_unreachable(repo_path: &Path, options: PruneOptions) -> Result<Prun
         reachable_count,
         unreachable_kept_count,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Initializes a temp git repo with one commit, tags it `v1.0`, then
+    /// deletes the local branch pointing at it so the commit is only
+    /// reachable via the tag (simulating a detached-HEAD checkout or a
+    /// deleted release branch). Returns (tempdir, commit sha).
+    fn repo_with_tag_only_commit() -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo_path = dir.path();
+
+        git_at(repo_path, &["init", "-q"]).expect("git init failed");
+        git_at(repo_path, &["config", "user.email", "test@example.com"]).unwrap();
+        git_at(repo_path, &["config", "user.name", "Test"]).unwrap();
+
+        std::fs::write(repo_path.join("file.txt"), "hello").unwrap();
+        git_at(repo_path, &["add", "file.txt"]).unwrap();
+        git_at(repo_path, &["commit", "-q", "-m", "initial"]).unwrap();
+
+        let sha = git_at(repo_path, &["rev-parse", "HEAD"]).unwrap();
+        git_at(repo_path, &["tag", "v1.0"]).unwrap();
+
+        // Detach HEAD, then delete every local branch so the commit is only
+        // reachable via the tag.
+        git_at(repo_path, &["checkout", "-q", "--detach"]).unwrap();
+        let branches = git_at(
+            repo_path,
+            &["for-each-ref", "--format=%(refname:short)", "refs/heads/*"],
+        )
+        .unwrap();
+        for branch in branches.lines().filter(|l| !l.is_empty()) {
+            git_at(repo_path, &["branch", "-D", branch]).unwrap();
+        }
+
+        (dir, sha)
+    }
+
+    #[test]
+    fn test_default_ref_patterns_include_tags_and_remotes() {
+        let patterns = PruneOptions::default().ref_patterns;
+        assert!(patterns.contains(&"refs/heads/*".to_string()));
+        assert!(patterns.contains(&"refs/tags/*".to_string()));
+        assert!(patterns.contains(&"refs/remotes/*".to_string()));
+    }
+
+    #[test]
+    fn test_heads_only_pattern_misses_tag_only_commit() {
+        // Regression guard for hotspots#142: with the OLD default
+        // (refs/heads/* only), a commit reachable only via a tag or a
+        // deleted-locally-but-still-tagged branch is invisible to
+        // reachability tracking — this is the exact silent-data-loss bug.
+        let (dir, sha) = repo_with_tag_only_commit();
+        let shas = enumerate_tracked_refs(dir.path(), &["refs/heads/*".to_string()]).unwrap();
+        assert!(!shas.contains(&sha));
+    }
+
+    #[test]
+    fn test_default_ref_patterns_find_tag_only_commit() {
+        let (dir, sha) = repo_with_tag_only_commit();
+        let shas =
+            enumerate_tracked_refs(dir.path(), &PruneOptions::default().ref_patterns).unwrap();
+        assert!(shas.contains(&sha));
+    }
+
+    #[test]
+    fn test_prune_unreachable_keeps_tag_only_snapshot_by_default() {
+        let (dir, sha) = repo_with_tag_only_commit();
+        let repo_path = dir.path();
+
+        // Write a snapshot for the tag-only commit directly to disk.
+        let snapshot_path = snapshot::snapshot_path(repo_path, &sha);
+        std::fs::create_dir_all(snapshot_path.parent().unwrap()).unwrap();
+        std::fs::write(&snapshot_path, "{}").unwrap();
+
+        let mut index = Index::new();
+        index.add_commit(snapshot::IndexEntry {
+            sha: sha.clone(),
+            parents: Vec::new(),
+            timestamp: 0,
+        });
+        let index_json = index.to_json().unwrap();
+        snapshot::atomic_write(&snapshot::index_path(repo_path), &index_json).unwrap();
+
+        let result = prune_unreachable(repo_path, PruneOptions::default()).unwrap();
+
+        assert_eq!(
+            result.pruned_count, 0,
+            "tag-only snapshot must not be pruned"
+        );
+        assert_eq!(result.reachable_count, 1);
+        assert!(snapshot_path.exists());
+    }
 }


### PR DESCRIPTION
## Summary

`PruneOptions::default()` and the CLI's `handle_prune` hardcoded `ref_patterns: vec!["refs/heads/*"]` — only local branches counted as "reachable" for `hotspots prune --unreachable`. `refs/tags/*` and `refs/remotes/*` were never considered, so:

- A detached-HEAD checkout (common in CI) has no local branches at all — every snapshot looks unreachable.
- A repo where an old release branch was deleted locally but still exists as a tag loses snapshot history for that tagged release.
- A stale/deleted local branch whose remote-tracking ref still points at it has its snapshots pruned even though the history is still in use.

This fix:
- Adds `refs/tags/*` and `refs/remotes/*` to the default `ref_patterns` in both `PruneOptions::default()` (`hotspots-core/src/prune.rs`) and the CLI's hardcoded options (`hotspots-cli/src/cmd/prune.rs`).
- Prints the ref patterns being considered "reachable" before deleting anything, so a CI log makes the reachability scope visible.
- Updates `docs/REFERENCE.md` to describe the new default.

## Not done (out of scope for this fix)

The issue also suggested defaulting `dry_run` to `true` for `--unreachable`, requiring an explicit `--force` to actually delete. That's a bigger CLI UX/behavior change (new flag, changed default for an existing flag) — left as a follow-up if wanted, since the tags/remotes fix alone closes the actual data-loss gap described in the issue.

## Linked Issues

Closes #142.

## Test Plan

- [x] `cargo test --workspace` — 461 unit tests + all integration suites, 0 failures
- [x] New regression tests added in `hotspots-core/src/prune.rs`:
  - `test_default_ref_patterns_include_tags_and_remotes`
  - `test_heads_only_pattern_misses_tag_only_commit` (reproduces the exact bug against the old default)
  - `test_default_ref_patterns_find_tag_only_commit`
  - `test_prune_unreachable_keeps_tag_only_snapshot_by_default` (end-to-end: real git repo, tag-only commit, snapshot survives prune)

## Pre-merge Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Changelog entry added under `[Unreleased]`
- [x] `docs/REFERENCE.md` updated