### PR TITLE
fix: track whether config set exclude for config show label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include tags and remotes as reachable refs in prune (#148)
 - Consult rename_hint in critical-introduction policy (#149)
 - Reject jointly-zero weights in config validation (#150)
+- `config show` no longer mislabels excludes as "custom" when the loaded config file didn't actually set an `exclude` key (#146)
 
 ## [1.35.1] - 2026-08-26
 

--- a/hotspots-cli/src/cmd/config.rs
+++ b/hotspots-cli/src/cmd/config.rs
@@ -100,7 +100,7 @@ pub(crate) fn handle_config(action: ConfigAction) -> anyhow::Result<()> {
             );
             println!(
                 "  exclude: active ({} patterns)",
-                if resolved.config_path.is_some() {
+                if resolved.exclude_is_custom {
                     "custom"
                 } else {
                     "default"

--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -366,6 +366,9 @@ pub struct ResolvedConfig {
     pub excessive_risk_regression_reason: Option<String>,
     /// Path the config was loaded from (None if defaults)
     pub config_path: Option<PathBuf>,
+    /// Whether the loaded config file set an `exclude` key specifically
+    /// (as opposed to `exclude` being active only via built-in defaults)
+    pub exclude_is_custom: bool,
 }
 
 impl HotspotsConfig {
@@ -812,6 +815,7 @@ impl HotspotsConfig {
             betweenness_approx_k: self.betweenness_approx_k.unwrap_or(256),
             callgraph_skip_above: self.callgraph_skip_above.unwrap_or(usize::MAX),
             config_path: None,
+            exclude_is_custom: !self.exclude.is_empty(),
         })
     }
 }
@@ -1197,6 +1201,27 @@ mod tests {
         let resolved = load_and_resolve(dir.path(), Some(&config_path)).unwrap();
         assert_eq!(resolved.weight_cc, 2.0);
         assert_eq!(resolved.config_path, Some(config_path));
+        // Regression test for hotspots#146: a config file that sets only
+        // `weights` and never touches `exclude` must not report exclude as
+        // custom just because *a* config file was found.
+        assert!(!resolved.exclude_is_custom);
+    }
+
+    #[test]
+    fn test_exclude_is_custom_when_config_sets_exclude() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("custom.json");
+        fs::write(&config_path, r#"{"exclude": ["**/legacy/**"]}"#).unwrap();
+
+        let resolved = load_and_resolve(dir.path(), Some(&config_path)).unwrap();
+        assert!(resolved.exclude_is_custom);
+    }
+
+    #[test]
+    fn test_exclude_is_not_custom_with_no_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = load_and_resolve(dir.path(), None).unwrap();
+        assert!(!resolved.exclude_is_custom);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`hotspots config show` decided whether to label the resolved `exclude` patterns "custom" or "default" based only on whether *any* config file was found (`resolved.config_path.is_some()`), not whether that config file actually set an `exclude` key. A config that only sets, say, `weights` and never touches `exclude` still reported `exclude: active (custom patterns)` — misleading when debugging why a file is or isn't scanned. Diagnostic-output only, no effect on actual scanning behavior.

This fix adds `ResolvedConfig::exclude_is_custom: bool`, computed in `resolve()` the same way `include`'s existing `Option`-based check works (`!self.exclude.is_empty()`), and switches `config show`'s label to use it instead of `config_path.is_some()`.

## Linked Issues

Closes #146.

## Test Plan

- [x] `cargo test --workspace` — 465 unit tests + all integration suites, 0 failures
- [x] New/updated regression tests in `hotspots-core/src/config.rs`:
  - `test_load_and_resolve_explicit_path` — asserts `exclude_is_custom` is false for a config that only sets `weights` (the exact false-positive scenario from the issue)
  - `test_exclude_is_custom_when_config_sets_exclude`
  - `test_exclude_is_not_custom_with_no_config_file`

## Pre-merge Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Changelog entry added under `[Unreleased]`
- [ ] Docs — no update needed; this is a diagnostic-output correctness fix, not a documented behavior change