### PR TITLE
fix: sandbox git_at from inherited GIT_DIR in prune tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+- `prune` test helper's `git_at` no longer inherits `GIT_DIR`/`GIT_WORK_TREE`/etc. from the invoking process — under `git commit`'s pre-commit hook, these were previously inherited by `cargo test`'s own subprocess `git` calls, silently redirecting supposedly-isolated tempdir git operations onto the real repository (observed corrupting this repo's own `.git/config`)
+
 ## [1.35.2] - 2026-08-28
 
 ### Bug Fixes

--- a/hotspots-core/src/prune.rs
+++ b/hotspots-core/src/prune.rs
@@ -53,13 +53,32 @@ pub struct PruneResult {
     pub unreachable_kept_count: usize,
 }
 
+/// Environment variables git uses to locate a repository, bypassing normal
+/// cwd-based discovery. If the calling process inherited one of these (e.g.
+/// `GIT_DIR`, set by git itself for hook subprocesses), passing only
+/// `current_dir` below is not enough to sandbox `git` to `repo_path` — a
+/// var like `GIT_DIR` takes priority and silently redirects the command at
+/// the *caller's* repository instead. Every call site here operates on a
+/// repo identified explicitly by `repo_path`, so none of these should ever
+/// be inherited.
+const GIT_ENV_VARS_TO_CLEAR: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+];
+
 /// Execute a git command in a specific directory
 fn git_at(repo_path: &Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
-        .current_dir(repo_path)
-        .args(args)
-        .output()
-        .context("failed to invoke git")?;
+    let mut command = Command::new("git");
+    command.current_dir(repo_path).args(args);
+    for var in GIT_ENV_VARS_TO_CLEAR {
+        command.env_remove(var);
+    }
+    let output = command.output().context("failed to invoke git")?;
 
     if !output.status.success() {
         anyhow::bail!(
@@ -289,6 +308,60 @@ mod tests {
         }
 
         (dir, sha)
+    }
+
+    #[test]
+    fn test_git_at_ignores_inherited_git_dir() {
+        // Regression test: git_at is called from within `cargo test`, which
+        // may itself be a child of `git commit`'s pre-commit hook — a
+        // context where git sets GIT_DIR/GIT_WORK_TREE in the environment
+        // for hook subprocesses. Before this fix, `git_at` only passed
+        // `current_dir`, so an inherited GIT_DIR silently overrode it and
+        // every "isolated" tempdir git command (git init, git config, git
+        // commit) actually operated on whatever GIT_DIR pointed at instead
+        // — this is exactly how a prune test once corrupted this repo's own
+        // real .git/config with `user.email=test@example.com`.
+        let real_repo = tempfile::tempdir().unwrap();
+        git_at(real_repo.path(), &["init", "-q"]).unwrap();
+        let real_git_dir = real_repo.path().join(".git");
+        assert!(real_git_dir.exists());
+
+        // SAFETY: single-threaded test process section; no other test reads
+        // these vars. Simulate a hook-inherited GIT_DIR/GIT_WORK_TREE
+        // pointing at `real_repo`, then run git_at against a *different*,
+        // unrelated tempdir the way `repo_with_tag_only_commit` does.
+        unsafe {
+            std::env::set_var("GIT_DIR", real_git_dir.to_str().unwrap());
+            std::env::set_var("GIT_WORK_TREE", real_repo.path().to_str().unwrap());
+        }
+        let result = std::panic::catch_unwind(|| {
+            let victim = tempfile::tempdir().unwrap();
+            git_at(victim.path(), &["init", "-q"]).unwrap();
+            git_at(
+                victim.path(),
+                &["config", "user.email", "victim@example.com"],
+            )
+            .unwrap();
+            victim
+        });
+        unsafe {
+            std::env::remove_var("GIT_DIR");
+            std::env::remove_var("GIT_WORK_TREE");
+        }
+        let victim = result.expect("git_at must not panic under an inherited GIT_DIR");
+
+        // The victim tempdir must have its own independent .git with the
+        // config write actually applied there...
+        let victim_email = git_at(victim.path(), &["config", "user.email"]).unwrap();
+        assert_eq!(victim_email, "victim@example.com");
+
+        // ...and the "real" repo (simulating this actual project's .git)
+        // must be completely untouched by the victim's git init/config.
+        let real_config = std::fs::read_to_string(real_git_dir.join("config")).unwrap();
+        assert!(
+            !real_config.contains("victim@example.com"),
+            "git_at leaked a nested test's git config into the inherited GIT_DIR's repo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**This is a hotfix for a real, already-shipped bug (in v1.35.2 via #148/#142), discovered by accident while a separate agent worked on #138.**

`hotspots-core/src/prune.rs`'s test helper `git_at` sandboxes a git command to a tempdir using only `.current_dir(repo_path)`. That's not sufficient: if the calling process has `GIT_DIR` (or `GIT_WORK_TREE`, etc.) set in its environment — which git itself sets for pre-commit hook subprocesses — those env vars take priority over `current_dir` and silently redirect the "isolated" git command at the *real* repository instead of the tempdir.

Concretely: this repo's own `.githooks/pre-commit` runs `cargo test` as a hook subprocess. When `cargo test` runs the `prune::tests::repo_with_tag_only_commit` helper (added in #148), its `git config user.email test@example.com` / `git config user.name Test` calls — intended to configure a *disposable tempdir* repo — instead wrote directly into **this actual project's real `.git/config`**, because `GIT_DIR` was inherited from the hook's own `git commit` invocation. I hit this for real today: this repo's shared `.git/config` had `user.name=Test` / `user.email=test@example.com` after a routine commit, discovered only because it produced a misattributed commit author on an unrelated PR.

## Fix

`git_at` now explicitly `env_remove`s every git-repository-location env var (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_CEILING_DIRECTORIES`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`) before spawning the subprocess, so `current_dir` is always authoritative regardless of what the calling process inherited. This affects every call site in the file (all go through the single shared `git_at` helper) — no behavior change for the production `prune_unreachable` path, since it's never invoked with those vars set in practice.

## Verification

Added `test_git_at_ignores_inherited_git_dir`, which simulates the exact hook-inherited-`GIT_DIR` scenario: sets `GIT_DIR`/`GIT_WORK_TREE` to point at one tempdir repo, then calls `git_at` against a second, unrelated tempdir, and asserts (a) the second tempdir's own config write actually landed there, and (b) the first tempdir's config was not touched. I confirmed this test fails without the fix (reproducing the exact corruption) and passes with it — full before/after verification, not just a green run.

Also did an end-to-end check: committed this fix through the *actual* pre-commit hook (not `--no-verify`) and confirmed `cargo test` running as the hook's own child no longer touches this repo's real `.git/config`.

## Linked Issues

None — not filed as a GitHub issue first since it was caught and fixed in the same session it was discovered. Happy to file one retroactively if preferred.

## Test Plan

- [x] `cargo test --workspace` — 472 unit tests + all integration suites, 0 failures
- [x] New regression test `test_git_at_ignores_inherited_git_dir`, verified to fail without the fix and pass with it
- [x] Committed through the real pre-commit hook (no `--no-verify`), confirmed no config corruption

## Pre-merge Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Changelog entry added under `[Unreleased]`
- [ ] Docs — no update needed; this is a test-hermeticity fix with no CLI-visible behavior change