### PR TITLE
fix: walk Go statement_list bodies and route break/continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 - Sandbox git_at from inherited GIT_DIR in prune tests (#153)
 - Build Java CFG edges for ternaries, &&/||, lambdas (#152)
+- Walk Go statement_list bodies instead of collapsing them (#140)
+- Fix Go type-switch cases and switch default fallthrough edge (#140)
+- Route Go labeled/unlabeled break and continue to correct targets (#140)
 
 ## [1.35.2] - 2026-08-28
 

--- a/hotspots-core/src/language/go/cfg_builder.rs
+++ b/hotspots-core/src/language/go/cfg_builder.rs
@@ -48,7 +48,13 @@ struct GoCfgBuilderState {
 }
 
 struct LoopContext {
-    break_target: NodeId,
+    /// Lazily created: `None` until something actually needs to jump here
+    /// (a `break`, a case falling through, or a no-default fallback edge).
+    /// A `for` loop's own header->join "exit" edge always creates it eagerly
+    /// since that path is unconditional, so it's only ever lazy for
+    /// switch/select, where every case may terminate control flow itself
+    /// (e.g. `return` in every case), leaving the join node unneeded.
+    break_target: Option<NodeId>,
     /// `None` for switch/select contexts, which do not accept `continue`
     continue_target: Option<NodeId>,
     /// Label naming this construct, for labeled break/continue
@@ -66,6 +72,21 @@ impl GoCfgBuilderState {
             loop_stack: Vec::new(),
             pending_label: None,
         }
+    }
+
+    /// Get or lazily create the break target for the loop/switch/select
+    /// context at `idx` in `loop_stack`.
+    fn get_or_create_break_target(&mut self, idx: usize) -> NodeId {
+        if let Some(ctx) = self.loop_stack.get(idx) {
+            if let Some(id) = ctx.break_target {
+                return id;
+            }
+        }
+        let id = self.cfg.add_node(NodeKind::Join);
+        if let Some(ctx) = self.loop_stack.get_mut(idx) {
+            ctx.break_target = Some(id);
+        }
+        id
     }
 
     /// Build CFG from a block node
@@ -205,13 +226,14 @@ impl GoCfgBuilderState {
         let body_start = self.cfg.add_node(NodeKind::Statement);
         self.cfg.add_edge(loop_header, body_start);
 
-        // Join node (after loop)
-        let join_node = self.cfg.add_node(NodeKind::Join);
-
-        // Push loop context for break/continue
+        // Push loop context for break/continue. The join node is created
+        // lazily below via get_or_create_break_target, but a `for` loop's
+        // header always has an unconditional "exit" edge to it (the loop
+        // condition can always be false, or there is none), so it will
+        // always end up created.
         let label = self.pending_label.take();
         self.loop_stack.push(LoopContext {
-            break_target: join_node,
+            break_target: None,
             continue_target: Some(loop_header),
             label,
         });
@@ -229,11 +251,13 @@ impl GoCfgBuilderState {
             }
         }
 
+        // Exit condition from loop header
+        let idx = self.loop_stack.len() - 1;
+        let join_node = self.get_or_create_break_target(idx);
+        self.cfg.add_edge(loop_header, join_node);
+
         // Pop loop context
         self.loop_stack.pop();
-
-        // Exit condition from loop header
-        self.cfg.add_edge(loop_header, join_node);
 
         self.current_node = Some(join_node);
     }
@@ -245,15 +269,17 @@ impl GoCfgBuilderState {
         let condition_node = self.cfg.add_node(NodeKind::Condition);
         self.cfg.add_edge(from_node, condition_node);
 
-        // Join node after switch
-        let join_node = self.cfg.add_node(NodeKind::Join);
-
         // Push break context (switch/select break independently of any
         // enclosing loop; `continue` is not valid here, so continue_target
-        // is None and unlabeled continue skips over this context)
+        // is None and unlabeled continue skips over this context). The join
+        // node itself is created lazily: if every case terminates control
+        // flow (e.g. `return` in every case) and there's a default (so no
+        // fallback-to-join edge is added either), nothing ever needs a join
+        // node, and creating one eagerly would leave it unreachable.
+        let idx = self.loop_stack.len();
         let label = self.pending_label.take();
         self.loop_stack.push(LoopContext {
-            break_target: join_node,
+            break_target: None,
             continue_target: None,
             label,
         });
@@ -287,22 +313,23 @@ impl GoCfgBuilderState {
                 // Case ends connect to join (unless they explicitly break/return)
                 if let Some(case_end) = self.current_node {
                     if case_end != self.cfg.exit {
+                        let join_node = self.get_or_create_break_target(idx);
                         self.cfg.add_edge(case_end, join_node);
                     }
                 }
             }
         }
 
-        self.loop_stack.pop();
-
         // If there's no default case, no case is guaranteed to match, so the
         // switch can fall through directly to join. When a default exists,
         // one case always executes, so this edge would be spurious.
         if !has_default {
+            let join_node = self.get_or_create_break_target(idx);
             self.cfg.add_edge(condition_node, join_node);
         }
 
-        self.current_node = Some(join_node);
+        let ctx = self.loop_stack.pop().expect("pushed switch context above");
+        self.current_node = ctx.break_target;
     }
 
     fn visit_type_switch(&mut self, node: &Node, source: &str) {
@@ -317,14 +344,15 @@ impl GoCfgBuilderState {
         let condition_node = self.cfg.add_node(NodeKind::Condition);
         self.cfg.add_edge(from_node, condition_node);
 
-        // Join node after select
-        let join_node = self.cfg.add_node(NodeKind::Join);
-
         // Push break context (select break independently of any enclosing
-        // loop; `continue` is not valid here)
+        // loop; `continue` is not valid here). The join node is created
+        // lazily: if every case terminates control flow (e.g. `return` in
+        // every case), nothing ever needs a join node, and creating one
+        // eagerly would leave it unreachable.
+        let idx = self.loop_stack.len();
         let label = self.pending_label.take();
         self.loop_stack.push(LoopContext {
-            break_target: join_node,
+            break_target: None,
             continue_target: None,
             label,
         });
@@ -348,15 +376,15 @@ impl GoCfgBuilderState {
 
                 if let Some(case_end) = self.current_node {
                     if case_end != self.cfg.exit {
+                        let join_node = self.get_or_create_break_target(idx);
                         self.cfg.add_edge(case_end, join_node);
                     }
                 }
             }
         }
 
-        self.loop_stack.pop();
-
-        self.current_node = Some(join_node);
+        let ctx = self.loop_stack.pop().expect("pushed select context above");
+        self.current_node = ctx.break_target;
     }
 
     fn visit_return(&mut self, _node: &Node) {
@@ -371,17 +399,22 @@ impl GoCfgBuilderState {
     fn visit_break(&mut self, node: &Node, source: &str) {
         if let Some(from_node) = self.current_node {
             let label = find_label_text(node, source);
-            let target = match &label {
+            let idx = match &label {
                 Some(label) => self
                     .loop_stack
                     .iter()
-                    .rev()
-                    .find(|ctx| ctx.label.as_deref() == Some(label.as_str()))
-                    .map(|ctx| ctx.break_target),
-                None => self.loop_stack.last().map(|ctx| ctx.break_target),
+                    .rposition(|ctx| ctx.label.as_deref() == Some(label.as_str())),
+                None => {
+                    if self.loop_stack.is_empty() {
+                        None
+                    } else {
+                        Some(self.loop_stack.len() - 1)
+                    }
+                }
             };
 
-            if let Some(target) = target {
+            if let Some(idx) = idx {
+                let target = self.get_or_create_break_target(idx);
                 let break_node = self.cfg.add_node(NodeKind::Statement);
                 self.cfg.add_edge(from_node, break_node);
                 self.cfg.add_edge(break_node, target);

--- a/hotspots-core/src/language/go/cfg_builder.rs
+++ b/hotspots-core/src/language/go/cfg_builder.rs
@@ -41,13 +41,18 @@ impl CfgBuilder for GoCfgBuilder {
 struct GoCfgBuilderState {
     cfg: Cfg,
     current_node: Option<NodeId>,
-    /// Stack of loop contexts for break/continue
+    /// Stack of loop/switch/select contexts for break/continue
     loop_stack: Vec<LoopContext>,
+    /// Label attached to the next loop/switch/select statement visited, if any
+    pending_label: Option<String>,
 }
 
 struct LoopContext {
     break_target: NodeId,
-    continue_target: NodeId,
+    /// `None` for switch/select contexts, which do not accept `continue`
+    continue_target: Option<NodeId>,
+    /// Label naming this construct, for labeled break/continue
+    label: Option<String>,
 }
 
 impl GoCfgBuilderState {
@@ -59,6 +64,7 @@ impl GoCfgBuilderState {
             cfg,
             current_node: Some(entry),
             loop_stack: Vec::new(),
+            pending_label: None,
         }
     }
 
@@ -98,8 +104,10 @@ impl GoCfgBuilderState {
             "type_switch_statement" => self.visit_type_switch(node, source),
             "select_statement" => self.visit_select(node, source),
             "return_statement" => self.visit_return(node),
-            "break_statement" => self.visit_break(),
-            "continue_statement" => self.visit_continue(),
+            "break_statement" => self.visit_break(node, source),
+            "continue_statement" => self.visit_continue(node, source),
+            "goto_statement" => self.visit_goto(),
+            "labeled_statement" => self.visit_labeled(node, source),
             "defer_statement" => self.visit_defer(node),
             "go_statement" => self.visit_go_statement(node),
             "expression_statement" => {
@@ -111,6 +119,21 @@ impl GoCfgBuilderState {
                 }
             }
             "block" => self.build_from_block(node, source),
+            "statement_list" => {
+                // tree-sitter-go wraps every sequence of statements (a
+                // function/if/for block body, a switch/select case body,
+                // etc.) in a statement_list node. Without flattening it
+                // here, every statement inside would be treated as one
+                // opaque, un-dispatched node - collapsing entire multi-
+                // statement blocks into a single generic statement and
+                // silently skipping any if/for/switch/etc. nested inside.
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if child.is_named() {
+                        self.visit_node(&child, source);
+                    }
+                }
+            }
             _ => {
                 // Regular statement - add node and continue
                 self.visit_simple_statement();
@@ -186,9 +209,11 @@ impl GoCfgBuilderState {
         let join_node = self.cfg.add_node(NodeKind::Join);
 
         // Push loop context for break/continue
+        let label = self.pending_label.take();
         self.loop_stack.push(LoopContext {
             break_target: join_node,
-            continue_target: loop_header,
+            continue_target: Some(loop_header),
+            label,
         });
 
         // Visit loop body
@@ -223,10 +248,29 @@ impl GoCfgBuilderState {
         // Join node after switch
         let join_node = self.cfg.add_node(NodeKind::Join);
 
-        // Visit each case
+        // Push break context (switch/select break independently of any
+        // enclosing loop; `continue` is not valid here, so continue_target
+        // is None and unlabeled continue skips over this context)
+        let label = self.pending_label.take();
+        self.loop_stack.push(LoopContext {
+            break_target: join_node,
+            continue_target: None,
+            label,
+        });
+
+        // Visit each case. Regular switches use "expression_case"; type
+        // switches (switch x.(type) { case T: ... }) use "type_case".
+        let mut has_default = false;
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            if child.kind() == "expression_case" || child.kind() == "default_case" {
+            if child.kind() == "expression_case"
+                || child.kind() == "type_case"
+                || child.kind() == "default_case"
+            {
+                if child.kind() == "default_case" {
+                    has_default = true;
+                }
+
                 let case_start = self.cfg.add_node(NodeKind::Statement);
                 self.cfg.add_edge(condition_node, case_start);
 
@@ -249,8 +293,14 @@ impl GoCfgBuilderState {
             }
         }
 
-        // If no default, condition can go directly to join
-        self.cfg.add_edge(condition_node, join_node);
+        self.loop_stack.pop();
+
+        // If there's no default case, no case is guaranteed to match, so the
+        // switch can fall through directly to join. When a default exists,
+        // one case always executes, so this edge would be spurious.
+        if !has_default {
+            self.cfg.add_edge(condition_node, join_node);
+        }
 
         self.current_node = Some(join_node);
     }
@@ -269,6 +319,15 @@ impl GoCfgBuilderState {
 
         // Join node after select
         let join_node = self.cfg.add_node(NodeKind::Join);
+
+        // Push break context (select break independently of any enclosing
+        // loop; `continue` is not valid here)
+        let label = self.pending_label.take();
+        self.loop_stack.push(LoopContext {
+            break_target: join_node,
+            continue_target: None,
+            label,
+        });
 
         // Visit each communication case
         let mut cursor = node.walk();
@@ -295,6 +354,8 @@ impl GoCfgBuilderState {
             }
         }
 
+        self.loop_stack.pop();
+
         self.current_node = Some(join_node);
     }
 
@@ -307,26 +368,93 @@ impl GoCfgBuilderState {
         }
     }
 
-    fn visit_break(&mut self) {
+    fn visit_break(&mut self, node: &Node, source: &str) {
         if let Some(from_node) = self.current_node {
-            if let Some(loop_ctx) = self.loop_stack.last() {
+            let label = find_label_text(node, source);
+            let target = match &label {
+                Some(label) => self
+                    .loop_stack
+                    .iter()
+                    .rev()
+                    .find(|ctx| ctx.label.as_deref() == Some(label.as_str()))
+                    .map(|ctx| ctx.break_target),
+                None => self.loop_stack.last().map(|ctx| ctx.break_target),
+            };
+
+            if let Some(target) = target {
                 let break_node = self.cfg.add_node(NodeKind::Statement);
                 self.cfg.add_edge(from_node, break_node);
-                self.cfg.add_edge(break_node, loop_ctx.break_target);
+                self.cfg.add_edge(break_node, target);
                 self.current_node = None; // Dead code after break
             }
         }
     }
 
-    fn visit_continue(&mut self) {
+    fn visit_continue(&mut self, node: &Node, source: &str) {
         if let Some(from_node) = self.current_node {
-            if let Some(loop_ctx) = self.loop_stack.last() {
+            let label = find_label_text(node, source);
+            // `continue` only targets an enclosing `for` loop; switch/select
+            // contexts (continue_target: None) are transparent to it.
+            let target = match &label {
+                Some(label) => self
+                    .loop_stack
+                    .iter()
+                    .rev()
+                    .find(|ctx| ctx.label.as_deref() == Some(label.as_str()))
+                    .and_then(|ctx| ctx.continue_target),
+                None => self
+                    .loop_stack
+                    .iter()
+                    .rev()
+                    .find_map(|ctx| ctx.continue_target),
+            };
+
+            if let Some(target) = target {
                 let continue_node = self.cfg.add_node(NodeKind::Statement);
                 self.cfg.add_edge(from_node, continue_node);
-                self.cfg.add_edge(continue_node, loop_ctx.continue_target);
+                self.cfg.add_edge(continue_node, target);
                 self.current_node = None; // Dead code after continue
             }
         }
+    }
+
+    fn visit_goto(&mut self) {
+        if let Some(from_node) = self.current_node {
+            // goto is a branch: +1 CC, then control leaves this path.
+            // We don't track named jump targets (matches the C builder's
+            // approximation), so it is modeled as an edge straight to exit.
+            let goto_node = self.cfg.add_node(NodeKind::Condition);
+            self.cfg.add_edge(from_node, goto_node);
+            self.cfg.add_edge(goto_node, self.cfg.exit);
+            self.current_node = None;
+        }
+    }
+
+    fn visit_labeled(&mut self, node: &Node, source: &str) {
+        // A label is a jump target reachable via goto. Always create a node
+        // for it so dead code after a goto/return/break doesn't panic.
+        let label_node = self.cfg.add_node(NodeKind::Statement);
+        if let Some(from) = self.current_node {
+            self.cfg.add_edge(from, label_node);
+        } else {
+            self.cfg.add_edge(self.cfg.entry, label_node);
+        }
+        self.current_node = Some(label_node);
+
+        // Record the label so the following loop/switch/select statement
+        // can be targeted by a labeled break/continue.
+        self.pending_label = find_label_text(node, source);
+
+        // Visit the labeled statement itself (skip the label_name child)
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.is_named() && child.kind() != "label_name" {
+                self.visit_node(&child, source);
+                break;
+            }
+        }
+
+        self.pending_label = None;
     }
 
     fn visit_defer(&mut self, _node: &Node) {
@@ -354,6 +482,13 @@ impl GoCfgBuilderState {
 /// Find a child node by field name
 fn find_child_by_field<'a>(node: Node<'a>, field: &str) -> Option<Node<'a>> {
     node.child_by_field_name(field)
+}
+
+/// Extract the label name text from a labeled/break/continue statement node,
+/// if it has a `label_name` child.
+fn find_label_text(node: &Node, source: &str) -> Option<String> {
+    find_child_by_kind(*node, "label_name")
+        .map(|n| source[n.start_byte()..n.end_byte()].to_string())
 }
 
 /// Check if a node is a panic() call
@@ -479,5 +614,484 @@ func test() {
             "Expected at least 2 edges, got {}",
             cfg.edge_count()
         );
+    }
+
+    /// Parse `source`, find the first declared function, and build its CFG.
+    fn build_cfg(source: &str) -> Cfg {
+        use crate::language::GoParser;
+        let parser = GoParser::new().unwrap();
+        let module = parser.parse(source, "test.go").unwrap();
+        let functions = module.discover_functions(0, source);
+        assert_eq!(functions.len(), 1, "expected exactly one function");
+        let builder = GoCfgBuilder;
+        builder.build(&functions[0])
+    }
+
+    // ---- go statements (goroutines) ----
+
+    #[test]
+    fn test_go_statement_simple() {
+        let source = r#"
+package main
+func test() {
+    go doWork()
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        // go statement is a fork, not a branch: entry -> stmt -> exit, no CC increase
+        assert!(cfg.node_count() >= 2);
+    }
+
+    #[test]
+    fn test_go_statement_with_closure_body_not_walked() {
+        // The goroutine body (containing an if) must not be walked into as
+        // part of the enclosing function's control flow - it executes
+        // concurrently, not inline.
+        let source = r#"
+package main
+func test(x int) {
+    go func() {
+        if x > 0 {
+            doWork()
+        }
+    }()
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        // No Condition node should be produced from the closure's inner `if`,
+        // since the goroutine body is not part of this function's CFG.
+        let condition_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Condition))
+            .count();
+        assert_eq!(
+            condition_count, 0,
+            "goroutine body should not be walked into"
+        );
+    }
+
+    #[test]
+    fn test_multiple_go_statements_sequential() {
+        let source = r#"
+package main
+func test() {
+    go doWork()
+    go doOtherWork()
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 3);
+    }
+
+    // ---- defer statements ----
+
+    #[test]
+    fn test_defer_statement_simple() {
+        let source = r#"
+package main
+func test() {
+    defer cleanup()
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        // defer does not fork or branch: no Condition node produced
+        let condition_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Condition))
+            .count();
+        assert_eq!(condition_count, 0);
+    }
+
+    #[test]
+    fn test_defer_does_not_execute_inline() {
+        // A defer followed by more statements should behave as ordinary
+        // sequential flow: defer doesn't jump or terminate the block.
+        let source = r#"
+package main
+func test() {
+    defer cleanup()
+    doWork()
+    doMore()
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        // entry -> defer_stmt -> doWork -> doMore -> exit: linear chain
+        assert_eq!(cfg.node_count(), 5);
+        assert_eq!(cfg.edge_count(), 4);
+    }
+
+    #[test]
+    fn test_multiple_defers() {
+        let source = r#"
+package main
+func test() {
+    defer cleanup()
+    defer cleanup()
+    defer cleanup()
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 4);
+    }
+
+    // ---- select statements ----
+
+    #[test]
+    fn test_select_statement_branches_like_switch() {
+        let source = r#"
+package main
+func test(ch1 chan int, ch2 chan int) {
+    select {
+    case <-ch1:
+        doA()
+    case <-ch2:
+        doB()
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        // Each communication_case should be reachable from a shared
+        // Condition node (the select), and both should reach a join.
+        let condition_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Condition))
+            .count();
+        assert_eq!(condition_count, 1, "select should add one Condition node");
+    }
+
+    #[test]
+    fn test_select_with_default() {
+        let source = r#"
+package main
+func test(ch chan int) {
+    select {
+    case v := <-ch:
+        _ = v
+    default:
+        doB()
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 4);
+    }
+
+    #[test]
+    fn test_select_in_loop_break_targets_select_not_loop() {
+        // An unlabeled `break` inside a select's case must exit the select,
+        // not the enclosing `for` loop.
+        let source = r#"
+package main
+func test(ch chan int) {
+    for {
+        select {
+        case <-ch:
+            break
+        default:
+            doB()
+        }
+        doAfterSelect()
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        // doAfterSelect() must still be reachable (break only exits the
+        // select, so the loop body continues past it).
+        let stmt_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Statement))
+            .count();
+        // entry-adjacent statements: select cases (2) + break + doB + doAfterSelect >= 4
+        assert!(stmt_count >= 4, "got {} statement nodes", stmt_count);
+    }
+
+    // ---- type switches ----
+
+    #[test]
+    fn test_type_switch_visits_every_case() {
+        // Regression: type_case nodes (used by `switch x.(type)`) were
+        // previously not recognized by the switch visitor (only
+        // expression_case/default_case were), so non-default cases were
+        // silently skipped rather than contributing to the CFG.
+        let source = r#"
+package main
+func test(x interface{}) {
+    switch x.(type) {
+    case int:
+        doInt()
+    case string:
+        doString()
+    default:
+        doOther()
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        let stmt_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Statement))
+            .count();
+        // At least 3 case-start nodes + 3 case-body statement nodes = 6.
+        // (Before the fix, only the default_case was recognized, so the
+        // int/string type_case branches were silently dropped.)
+        assert!(
+            stmt_count >= 6,
+            "all three type_case/default_case branches should be visited, got {} statement nodes",
+            stmt_count
+        );
+    }
+
+    #[test]
+    fn test_type_switch_without_default_has_fallthrough_edge() {
+        let source = r#"
+package main
+func test(x interface{}) {
+    switch x.(type) {
+    case int:
+        doInt()
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        // No default: the switch condition must have a direct edge to join
+        // representing "no case matched".
+        assert!(cfg.node_count() >= 4);
+    }
+
+    // ---- switch default-case fallthrough edge ----
+
+    #[test]
+    fn test_switch_with_default_has_no_spurious_fallthrough_edge() {
+        // Regression: the switch visitor used to unconditionally add a
+        // condition -> join edge even when a default case exists, even
+        // though a default case guarantees some case always executes.
+        let with_default = r#"
+package main
+func test(x int) {
+    switch x {
+    case 1:
+        doA()
+    default:
+        doB()
+    }
+}
+"#;
+        let without_default = r#"
+package main
+func test(x int) {
+    switch x {
+    case 1:
+        doA()
+    }
+}
+"#;
+        let cfg_with = build_cfg(with_default);
+        let cfg_without = build_cfg(without_default);
+        cfg_with.validate().unwrap();
+        cfg_without.validate().unwrap();
+
+        assert!(
+            !has_condition_to_join_edge(&cfg_with),
+            "switch with a default case must not have a direct \
+             condition -> join fallthrough edge, since a case always matches"
+        );
+        assert!(
+            has_condition_to_join_edge(&cfg_without),
+            "switch without a default case must have a direct \
+             condition -> join fallthrough edge for the no-match path"
+        );
+    }
+
+    /// True if the CFG has an edge directly from a Condition node to a Join node.
+    fn has_condition_to_join_edge(cfg: &Cfg) -> bool {
+        let kind_of = |id: NodeId| cfg.nodes.iter().find(|n| n.id == id).map(|n| n.kind);
+        cfg.edges.iter().any(|e| {
+            matches!(kind_of(e.from), Some(NodeKind::Condition))
+                && matches!(kind_of(e.to), Some(NodeKind::Join))
+        })
+    }
+
+    // ---- labeled break/continue ----
+
+    #[test]
+    fn test_labeled_continue_targets_outer_loop() {
+        let source = r#"
+package main
+func test() {
+Outer:
+    for i := 0; i < 10; i++ {
+        for j := 0; j < 10; j++ {
+            if j == 5 {
+                continue Outer
+            }
+        }
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 5);
+    }
+
+    #[test]
+    fn test_labeled_break_targets_outer_loop() {
+        let source = r#"
+package main
+func test() {
+Outer:
+    for i := 0; i < 10; i++ {
+        for j := 0; j < 10; j++ {
+            if j == 5 {
+                break Outer
+            }
+        }
+        doAfterOuterLoop()
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 6);
+    }
+
+    #[test]
+    fn test_labeled_break_from_switch_in_loop() {
+        let source = r#"
+package main
+func test(x int) {
+Loop:
+    for i := 0; i < 10; i++ {
+        switch x {
+        case 1:
+            break Loop
+        default:
+            doB()
+        }
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        assert!(cfg.node_count() >= 5);
+    }
+
+    #[test]
+    fn test_unlabeled_break_in_switch_does_not_break_outer_loop() {
+        // Regression: switch/select never pushed their own break context,
+        // so an unlabeled `break` inside a switch nested in a loop was
+        // silently dropped instead of exiting only the switch.
+        let source = r#"
+package main
+func test(x int) {
+    for i := 0; i < 10; i++ {
+        switch x {
+        case 1:
+            break
+        default:
+            doB()
+        }
+        doAfterSwitch()
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        let stmt_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Statement))
+            .count();
+        // doAfterSwitch() must be present and reachable in the CFG.
+        assert!(stmt_count >= 5, "got {} statement nodes", stmt_count);
+    }
+
+    // ---- goto / labeled statements ----
+
+    #[test]
+    fn test_goto_statement_terminates_current_path() {
+        let source = r#"
+package main
+func test(x int) {
+    if x < 0 {
+        goto Done
+    }
+    doWork()
+Done:
+    return
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        let condition_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Condition))
+            .count();
+        // if-condition + goto-as-branch = 2 Condition nodes
+        assert_eq!(condition_count, 2);
+    }
+
+    #[test]
+    fn test_labeled_statement_wrapping_loop_is_walked() {
+        // Regression: labeled_statement previously matched the catch-all
+        // branch, which added a single generic Statement node instead of
+        // descending into the labeled loop - completely dropping the
+        // loop's own control flow from the CFG.
+        let source = r#"
+package main
+func test() {
+Loop:
+    for i := 0; i < 10; i++ {
+        if i == 5 {
+            break Loop
+        }
+    }
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
+        let condition_count = cfg
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Condition))
+            .count();
+        assert!(
+            condition_count >= 1,
+            "labeled for-loop's inner `if` must still be walked, got {} Condition nodes",
+            condition_count
+        );
+    }
+
+    #[test]
+    fn test_label_after_goto_does_not_panic() {
+        // Dead code (after goto) reaching a label must not panic when
+        // building the CFG.
+        let source = r#"
+package main
+func test(x int) {
+    goto Done
+    doUnreachable()
+Done:
+    doWork()
+}
+"#;
+        let cfg = build_cfg(source);
+        cfg.validate().unwrap();
     }
 }

--- a/tests/golden/go-go_specific.json
+++ b/tests/golden/go-go_specific.json
@@ -5,19 +5,19 @@
     "line": 113,
     "language": "Go",
     "metrics": {
-      "cc": 8,
+      "cc": 17,
       "nd": 3,
       "fo": 5,
       "ns": 4,
       "loc": 39
     },
     "risk": {
-      "r_cc": 3.169925001442312,
+      "r_cc": 4.169925001442312,
       "r_nd": 3.0,
       "r_fo": 2.584962500721156,
       "r_ns": 4.0
     },
-    "lrs": 9.920902501875004,
+    "lrs": 10.920902501875005,
     "band": "critical"
   },
   {
@@ -26,20 +26,20 @@
     "line": 99,
     "language": "Go",
     "metrics": {
-      "cc": 5,
+      "cc": 8,
       "nd": 2,
       "fo": 2,
       "ns": 1,
       "loc": 11
     },
     "risk": {
-      "r_cc": 2.584962500721156,
+      "r_cc": 3.169925001442312,
       "r_nd": 2.0,
       "r_fo": 1.584962500721156,
       "r_ns": 1.0
     },
-    "lrs": 5.835940001153849,
-    "band": "moderate"
+    "lrs": 6.420902501875005,
+    "band": "high"
   },
   {
     "file": "tests/fixtures/go/go_specific.go",
@@ -64,44 +64,23 @@
   },
   {
     "file": "tests/fixtures/go/go_specific.go",
-    "function": "SelectWithDefault",
-    "line": 84,
-    "language": "Go",
-    "metrics": {
-      "cc": 6,
-      "nd": 1,
-      "fo": 1,
-      "ns": 0,
-      "loc": 12
-    },
-    "risk": {
-      "r_cc": 2.807354922057604,
-      "r_nd": 1.0,
-      "r_fo": 1.0,
-      "r_ns": 0.0
-    },
-    "lrs": 4.207354922057604,
-    "band": "moderate"
-  },
-  {
-    "file": "tests/fixtures/go/go_specific.go",
     "function": "ConditionalDefer",
     "line": 24,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 5,
       "nd": 1,
       "fo": 1,
       "ns": 1,
       "loc": 5
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.584962500721156,
       "r_nd": 1.0,
       "r_fo": 1.0,
       "r_ns": 1.0
     },
-    "lrs": 4.1,
+    "lrs": 4.684962500721156,
     "band": "moderate"
   },
   {
@@ -110,19 +89,61 @@
     "line": 52,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 5,
       "nd": 1,
       "fo": 1,
       "ns": 1,
       "loc": 5
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.584962500721156,
       "r_nd": 1.0,
       "r_fo": 1.0,
       "r_ns": 1.0
     },
-    "lrs": 4.1,
+    "lrs": 4.684962500721156,
+    "band": "moderate"
+  },
+  {
+    "file": "tests/fixtures/go/go_specific.go",
+    "function": "SelectWithDefault",
+    "line": 84,
+    "language": "Go",
+    "metrics": {
+      "cc": 8,
+      "nd": 1,
+      "fo": 1,
+      "ns": 0,
+      "loc": 12
+    },
+    "risk": {
+      "r_cc": 3.169925001442312,
+      "r_nd": 1.0,
+      "r_fo": 1.0,
+      "r_ns": 0.0
+    },
+    "lrs": 4.569925001442312,
+    "band": "moderate"
+  },
+  {
+    "file": "tests/fixtures/go/go_specific.go",
+    "function": "SimpleSelect",
+    "line": 70,
+    "language": "Go",
+    "metrics": {
+      "cc": 6,
+      "nd": 1,
+      "fo": 1,
+      "ns": 0,
+      "loc": 11
+    },
+    "risk": {
+      "r_cc": 2.807354922057604,
+      "r_nd": 1.0,
+      "r_fo": 1.0,
+      "r_ns": 0.0
+    },
+    "lrs": 4.207354922057604,
     "band": "moderate"
   },
   {
@@ -144,27 +165,6 @@
       "r_ns": 1.0
     },
     "lrs": 4.1,
-    "band": "moderate"
-  },
-  {
-    "file": "tests/fixtures/go/go_specific.go",
-    "function": "SimpleSelect",
-    "line": 70,
-    "language": "Go",
-    "metrics": {
-      "cc": 5,
-      "nd": 1,
-      "fo": 1,
-      "ns": 0,
-      "loc": 11
-    },
-    "risk": {
-      "r_cc": 2.584962500721156,
-      "r_nd": 1.0,
-      "r_fo": 1.0,
-      "r_ns": 0.0
-    },
-    "lrs": 3.984962500721156,
     "band": "moderate"
   },
   {

--- a/tests/golden/go-loops.json
+++ b/tests/golden/go-loops.json
@@ -5,19 +5,19 @@
     "line": 13,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 7,
       "nd": 2,
       "fo": 0,
       "ns": 0,
       "loc": 7
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 3.0,
       "r_nd": 2.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.6,
+    "lrs": 4.6,
     "band": "moderate"
   },
   {
@@ -26,19 +26,19 @@
     "line": 23,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 7,
       "nd": 2,
       "fo": 0,
       "ns": 0,
       "loc": 7
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 3.0,
       "r_nd": 2.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.6,
+    "lrs": 4.6,
     "band": "moderate"
   },
   {
@@ -47,19 +47,19 @@
     "line": 33,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 7,
       "nd": 2,
       "fo": 0,
       "ns": 0,
       "loc": 7
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 3.0,
       "r_nd": 2.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.6,
+    "lrs": 4.6,
     "band": "moderate"
   },
   {
@@ -68,19 +68,19 @@
     "line": 43,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 7,
       "nd": 2,
       "fo": 0,
       "ns": 0,
       "loc": 8
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 3.0,
       "r_nd": 2.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.6,
+    "lrs": 4.6,
     "band": "moderate"
   },
   {
@@ -89,19 +89,19 @@
     "line": 72,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 7,
       "nd": 2,
       "fo": 0,
       "ns": 0,
       "loc": 9
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 3.0,
       "r_nd": 2.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.6,
+    "lrs": 4.6,
     "band": "moderate"
   },
   {
@@ -110,20 +110,20 @@
     "line": 5,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 5,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 5
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.584962500721156,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 2.8,
-    "band": "low"
+    "lrs": 3.384962500721156,
+    "band": "moderate"
   },
   {
     "file": "tests/fixtures/go/loops.go",
@@ -131,20 +131,20 @@
     "line": 54,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 5,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 6
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.584962500721156,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 2.8,
-    "band": "low"
+    "lrs": 3.384962500721156,
+    "band": "moderate"
   },
   {
     "file": "tests/fixtures/go/loops.go",
@@ -152,19 +152,19 @@
     "line": 63,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 5,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 6
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.584962500721156,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 2.8,
-    "band": "low"
+    "lrs": 3.384962500721156,
+    "band": "moderate"
   }
 ]

--- a/tests/golden/go-simple.json
+++ b/tests/golden/go-simple.json
@@ -5,19 +5,19 @@
     "line": 39,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 7,
       "nd": 1,
       "fo": 0,
       "ns": 3,
       "loc": 9
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 3.0,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 3.0
     },
-    "lrs": 4.8999999999999995,
+    "lrs": 5.8999999999999995,
     "band": "moderate"
   },
   {
@@ -26,19 +26,19 @@
     "line": 20,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 6,
       "nd": 1,
       "fo": 0,
       "ns": 2,
       "loc": 7
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.807354922057604,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 2.0
     },
-    "lrs": 4.199999999999999,
+    "lrs": 5.007354922057605,
     "band": "moderate"
   },
   {
@@ -47,19 +47,19 @@
     "line": 30,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 5,
       "nd": 1,
       "fo": 0,
       "ns": 2,
       "loc": 6
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.584962500721156,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 2.0
     },
-    "lrs": 4.199999999999999,
+    "lrs": 4.784962500721155,
     "band": "moderate"
   },
   {
@@ -68,20 +68,20 @@
     "line": 12,
     "language": "Go",
     "metrics": {
-      "cc": 3,
+      "cc": 5,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 5
     },
     "risk": {
-      "r_cc": 2.0,
+      "r_cc": 2.584962500721156,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 2.8,
-    "band": "low"
+    "lrs": 3.384962500721156,
+    "band": "moderate"
   },
   {
     "file": "tests/fixtures/go/simple.go",

--- a/tests/golden/go-switch.json
+++ b/tests/golden/go-switch.json
@@ -1,44 +1,23 @@
 [
   {
     "file": "tests/fixtures/go/switch.go",
-    "function": "SimpleSwitch",
-    "line": 5,
-    "language": "Go",
-    "metrics": {
-      "cc": 6,
-      "nd": 1,
-      "fo": 0,
-      "ns": 3,
-      "loc": 10
-    },
-    "risk": {
-      "r_cc": 2.807354922057604,
-      "r_nd": 1.0,
-      "r_fo": 0.0,
-      "r_ns": 3.0
-    },
-    "lrs": 5.707354922057604,
-    "band": "moderate"
-  },
-  {
-    "file": "tests/fixtures/go/switch.go",
     "function": "NestedSwitch",
     "line": 45,
     "language": "Go",
     "metrics": {
-      "cc": 7,
+      "cc": 11,
       "nd": 2,
       "fo": 0,
       "ns": 0,
       "loc": 13
     },
     "risk": {
-      "r_cc": 3.0,
+      "r_cc": 3.584962500721156,
       "r_nd": 2.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 4.6,
+    "lrs": 5.184962500721156,
     "band": "moderate"
   },
   {
@@ -47,19 +26,19 @@
     "line": 29,
     "language": "Go",
     "metrics": {
-      "cc": 6,
+      "cc": 8,
       "nd": 1,
       "fo": 0,
       "ns": 1,
       "loc": 13
     },
     "risk": {
-      "r_cc": 2.807354922057604,
+      "r_cc": 3.169925001442312,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 1.0
     },
-    "lrs": 4.307354922057605,
+    "lrs": 4.669925001442312,
     "band": "moderate"
   },
   {
@@ -68,19 +47,19 @@
     "line": 72,
     "language": "Go",
     "metrics": {
-      "cc": 6,
+      "cc": 8,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 10
     },
     "risk": {
-      "r_cc": 2.807354922057604,
+      "r_cc": 3.169925001442312,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.6073549220576044,
+    "lrs": 3.969925001442312,
     "band": "moderate"
   },
   {
@@ -89,19 +68,19 @@
     "line": 18,
     "language": "Go",
     "metrics": {
-      "cc": 5,
+      "cc": 7,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 8
     },
     "risk": {
-      "r_cc": 2.584962500721156,
+      "r_cc": 3.0,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.384962500721156,
+    "lrs": 3.8,
     "band": "moderate"
   },
   {
@@ -110,19 +89,19 @@
     "line": 61,
     "language": "Go",
     "metrics": {
-      "cc": 5,
+      "cc": 7,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 8
     },
     "risk": {
-      "r_cc": 2.584962500721156,
+      "r_cc": 3.0,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.384962500721156,
+    "lrs": 3.8,
     "band": "moderate"
   },
   {
@@ -131,19 +110,19 @@
     "line": 85,
     "language": "Go",
     "metrics": {
-      "cc": 5,
+      "cc": 7,
       "nd": 1,
       "fo": 0,
       "ns": 0,
       "loc": 8
     },
     "risk": {
-      "r_cc": 2.584962500721156,
+      "r_cc": 3.0,
       "r_nd": 1.0,
       "r_fo": 0.0,
       "r_ns": 0.0
     },
-    "lrs": 3.384962500721156,
+    "lrs": 3.8,
     "band": "moderate"
   }
 ]

--- a/tests/golden/go-switch.json
+++ b/tests/golden/go-switch.json
@@ -1,6 +1,27 @@
 [
   {
     "file": "tests/fixtures/go/switch.go",
+    "function": "SimpleSwitch",
+    "line": 5,
+    "language": "Go",
+    "metrics": {
+      "cc": 8,
+      "nd": 1,
+      "fo": 0,
+      "ns": 3,
+      "loc": 10
+    },
+    "risk": {
+      "r_cc": 3.169925001442312,
+      "r_nd": 1.0,
+      "r_fo": 0.0,
+      "r_ns": 3.0
+    },
+    "lrs": 6.069925001442312,
+    "band": "high"
+  },
+  {
+    "file": "tests/fixtures/go/switch.go",
     "function": "NestedSwitch",
     "line": 45,
     "language": "Go",


### PR DESCRIPTION
## Summary

Issue #140 noted the Go CFG builder/parser has the thinnest test coverage of any language (9 tests vs. C's 40) and asked for an audit of Go-specific constructs (goroutines, `select`, `defer`, labeled `break`/`continue`/`goto`, type switches) plus regression tests. The audit found the coverage gap was hiding several real, significant CFG-correctness bugs in `hotspots-core/src/language/go/cfg_builder.rs`:

1. **`statement_list` never dispatched (the big one).** tree-sitter-go wraps every sequence of statements — a function body, an `if`/`for` block, a `switch`/`select` case body — in a `statement_list` node. `visit_node`'s catch-all arm treated this wrapper as one opaque, un-dispatched statement instead of descending into its children. Any block with more than one top-level statement collapsed into a single generic node, and any control-flow statement (`if`, `for`, `switch`, ...) that wasn't the sole statement in its block was silently skipped rather than walked. This was invisible in the original 9 tests because they only ever used single-statement bodies. Fixed by adding an explicit `"statement_list"` match arm that flattens into its children.
2. **Type switch cases were dropped.** `visit_type_switch` delegated to `visit_switch`, which only recognized `expression_case`/`default_case` — but `switch x.(type) { case T: ... }` produces `type_case` nodes. Non-default type-switch branches were silently skipped.
3. **Switch default fallthrough edge was spurious.** `visit_switch` unconditionally added a `condition -> join` "no case matched" edge even when a `default` case exists (which guarantees a case always executes), inflating CC. Fixed to only add that edge when there's no default (matching the `has_default` pattern already used in the Java builder).
4. **`break`/`continue` ignored labels and switch/select never had their own break target.** Labeled `break`/`continue` always targeted the innermost loop regardless of the label. Unlabeled `break` inside a `switch`/`select` nested in a loop was silently dropped (should exit only the switch/select) because those constructs never pushed a break context.
5. **`goto`/labeled statements weren't handled at all**, falling into the same `statement_list`-adjacent catch-all — a labeled loop's entire body (and control flow) was replaced by one generic node. Added `goto_statement` (approximated as a branch to exit, mirroring the C builder's existing approximation) and `labeled_statement` (descends into the wrapped statement and threads the label to the following loop/switch/select for label-aware break/continue).

Every function with real branching in the existing Go golden fixtures now reports meaningfully higher (and correct) CC — `nd`/`fo`/`ns`/`loc` are unchanged, and straight-line-only functions are unaffected (the `E - N + 2` formula is invariant to node count in a pure sequential chain, which is also why these golden files hadn't caught the bug before).

## Linked Issues

Closes #140.

## Test Plan

- [x] `cargo test --workspace` — 494 hotspots-core unit tests + all integration suites, 0 failures
- [x] 20 new regression tests added in `hotspots-core/src/language/go/cfg_builder.rs` covering: goroutine bodies not walked into, defer not forking/branching, `select` branching like a switch (with/without default, break-scoping in a loop), type switches visiting every case, switch default-vs-no-default fallthrough edges, labeled `break`/`continue` to an outer loop, labeled break out of a switch, unlabeled break in a switch not escaping the enclosing loop, `goto`/labeled-statement handling and dead-code-after-goto not panicking
- [x] Updated 4 golden fixtures (`go-simple.json`, `go-loops.json`, `go-switch.json`, `go-go_specific.json`) to the now-correct CC values produced by the `statement_list` fix — diffed function-by-function against the pre-fix output to confirm only `cc` changed (never `nd`/`fo`/`ns`/`loc`), and confirmed every change is an increase consistent with previously-dropped branches now being counted

## Pre-merge Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Changelog entry added under `[Unreleased]`
- [x] Committed through the real pre-commit hook (fmt/clippy/test), not `--no-verify`