### PR TITLE
fix: gate burst_score git log walk behind skip-touch-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+- `prune` test helper's `git_at` no longer inherits `GIT_DIR`/`GIT_WORK_TREE`/etc. from the invoking process — under `git commit`'s pre-commit hook, these were previously inherited by `cargo test`'s own subprocess `git` calls, silently redirecting supposedly-isolated tempdir git operations onto the real repository (observed corrupting this repo's own `.git/config`)
+
 ## [1.35.2] - 2026-08-28
 
 ### Bug Fixes

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -1308,10 +1308,12 @@ pub(crate) fn build_snapshot_via_db(
     };
 
     // Phase 5: remaining enrichment (touch, activity risk, percentiles, driver, quadrant).
-    let mut enricher = snapshot::SnapshotEnricher::new(snapshot)
-        .with_subsystems(repo_root)
-        .with_burst_score(repo_root);
+    let mut enricher = snapshot::SnapshotEnricher::new(snapshot).with_subsystems(repo_root);
     if !skip_touch_metrics {
+        // burst_score does its own full-history `git log` walk (history_signals::
+        // load_commits_with_author) — gate it alongside the other touch/churn git
+        // log calls so --skip-touch-metrics actually skips it too.
+        enricher = enricher.with_burst_score(repo_root);
         let needs_progress = matches!(
             touch_mode,
             TouchMode::PerFunction | TouchMode::Hybrid { .. }
@@ -1370,8 +1372,7 @@ pub(crate) fn build_enriched_snapshot(
 
     let total_functions = reports.len();
     let mut enricher = snapshot::SnapshotEnricher::new(Snapshot::new(git_context.clone(), reports))
-        .with_subsystems(repo_root)
-        .with_burst_score(repo_root);
+        .with_subsystems(repo_root);
 
     if !git_context.parent_shas.is_empty() {
         match git::extract_commit_churn_at(repo_root, &git_context.head_sha) {
@@ -1393,6 +1394,10 @@ pub(crate) fn build_enriched_snapshot(
     }
 
     if !skip_touch_metrics {
+        // burst_score does its own full-history `git log` walk (history_signals::
+        // load_commits_with_author) — gate it alongside the other touch/churn git
+        // log calls so --skip-touch-metrics actually skips it too.
+        enricher = enricher.with_burst_score(repo_root);
         let needs_progress = matches!(
             touch_mode,
             TouchMode::PerFunction | TouchMode::Hybrid { .. }

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -90,7 +90,8 @@ enum Commands {
         no_per_function_touches: bool,
 
         /// Skip all touch metrics entirely (no git log calls for churn/recency),
-        /// and skip directed coupling (also a git log walk).
+        /// skip directed coupling (also a git log walk), and skip burst_score
+        /// (also a full-history git log walk).
         /// Overrides --per-function-touches and --no-per-function-touches.
         /// Use for benchmarking pure analysis + call graph performance.
         #[arg(long, conflicts_with = "per_function_touches")]

--- a/hotspots-core/src/prune.rs
+++ b/hotspots-core/src/prune.rs
@@ -53,13 +53,32 @@ pub struct PruneResult {
     pub unreachable_kept_count: usize,
 }
 
+/// Environment variables git uses to locate a repository, bypassing normal
+/// cwd-based discovery. If the calling process inherited one of these (e.g.
+/// `GIT_DIR`, set by git itself for hook subprocesses), passing only
+/// `current_dir` below is not enough to sandbox `git` to `repo_path` — a
+/// var like `GIT_DIR` takes priority and silently redirects the command at
+/// the *caller's* repository instead. Every call site here operates on a
+/// repo identified explicitly by `repo_path`, so none of these should ever
+/// be inherited.
+const GIT_ENV_VARS_TO_CLEAR: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+];
+
 /// Execute a git command in a specific directory
 fn git_at(repo_path: &Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
-        .current_dir(repo_path)
-        .args(args)
-        .output()
-        .context("failed to invoke git")?;
+    let mut command = Command::new("git");
+    command.current_dir(repo_path).args(args);
+    for var in GIT_ENV_VARS_TO_CLEAR {
+        command.env_remove(var);
+    }
+    let output = command.output().context("failed to invoke git")?;
 
     if !output.status.success() {
         anyhow::bail!(
@@ -289,6 +308,60 @@ mod tests {
         }
 
         (dir, sha)
+    }
+
+    #[test]
+    fn test_git_at_ignores_inherited_git_dir() {
+        // Regression test: git_at is called from within `cargo test`, which
+        // may itself be a child of `git commit`'s pre-commit hook — a
+        // context where git sets GIT_DIR/GIT_WORK_TREE in the environment
+        // for hook subprocesses. Before this fix, `git_at` only passed
+        // `current_dir`, so an inherited GIT_DIR silently overrode it and
+        // every "isolated" tempdir git command (git init, git config, git
+        // commit) actually operated on whatever GIT_DIR pointed at instead
+        // — this is exactly how a prune test once corrupted this repo's own
+        // real .git/config with `user.email=test@example.com`.
+        let real_repo = tempfile::tempdir().unwrap();
+        git_at(real_repo.path(), &["init", "-q"]).unwrap();
+        let real_git_dir = real_repo.path().join(".git");
+        assert!(real_git_dir.exists());
+
+        // SAFETY: single-threaded test process section; no other test reads
+        // these vars. Simulate a hook-inherited GIT_DIR/GIT_WORK_TREE
+        // pointing at `real_repo`, then run git_at against a *different*,
+        // unrelated tempdir the way `repo_with_tag_only_commit` does.
+        unsafe {
+            std::env::set_var("GIT_DIR", real_git_dir.to_str().unwrap());
+            std::env::set_var("GIT_WORK_TREE", real_repo.path().to_str().unwrap());
+        }
+        let result = std::panic::catch_unwind(|| {
+            let victim = tempfile::tempdir().unwrap();
+            git_at(victim.path(), &["init", "-q"]).unwrap();
+            git_at(
+                victim.path(),
+                &["config", "user.email", "victim@example.com"],
+            )
+            .unwrap();
+            victim
+        });
+        unsafe {
+            std::env::remove_var("GIT_DIR");
+            std::env::remove_var("GIT_WORK_TREE");
+        }
+        let victim = result.expect("git_at must not panic under an inherited GIT_DIR");
+
+        // The victim tempdir must have its own independent .git with the
+        // config write actually applied there...
+        let victim_email = git_at(victim.path(), &["config", "user.email"]).unwrap();
+        assert_eq!(victim_email, "victim@example.com");
+
+        // ...and the "real" repo (simulating this actual project's .git)
+        // must be completely untouched by the victim's git init/config.
+        let real_config = std::fs::read_to_string(real_git_dir.join("config")).unwrap();
+        assert!(
+            !real_config.contains("victim@example.com"),
+            "git_at leaked a nested test's git config into the inherited GIT_DIR's repo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `with_burst_score()` was called unconditionally in both `build_snapshot_via_db` and `build_enriched_snapshot`, bypassing `--skip-touch-metrics` and running an unbounded, unscoped full-history `git log --name-only --diff-filter=ACDMRT` walk regardless of repo size or the analyzed path.
- Found via a dogfood exercise: `hotspots analyze` hung past 30s on a single file (`src/compiler/binder.ts`) in the TypeScript repo (1.2GB `.git`) even with `--skip-touch-metrics` passed. Gating the call fixed it — same command now completes in 0.65s.
- Also updated the `--skip-touch-metrics` help text, which previously didn't mention burst_score at all.

## Note on branch contents
This branch also carries `715e0e1` (`fix: sandbox git_at from inherited GIT_DIR in prune tests`), cherry-picked from the already-tested but unmerged `fix/prune-test-git-env-leak` branch — needed to get a clean pre-commit hook run in this environment. That fix is also going up as its own PR; once either merges, this diff will shrink to just the burst_score change.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (471 passed)
- [x] Manually reproduced the hang on `microsoft/TypeScript`'s `src/compiler/binder.ts` before the fix, confirmed resolved after

🤖 Generated with [Claude Code](https://claude.com/claude-code)