### PR TITLE
fix: gate burst_score git log walk behind skip-touch-metrics

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -1308,10 +1308,12 @@ pub(crate) fn build_snapshot_via_db(
     };
 
     // Phase 5: remaining enrichment (touch, activity risk, percentiles, driver, quadrant).
-    let mut enricher = snapshot::SnapshotEnricher::new(snapshot)
-        .with_subsystems(repo_root)
-        .with_burst_score(repo_root);
+    let mut enricher = snapshot::SnapshotEnricher::new(snapshot).with_subsystems(repo_root);
     if !skip_touch_metrics {
+        // burst_score does its own full-history `git log` walk (history_signals::
+        // load_commits_with_author) — gate it alongside the other touch/churn git
+        // log calls so --skip-touch-metrics actually skips it too.
+        enricher = enricher.with_burst_score(repo_root);
         let needs_progress = matches!(
             touch_mode,
             TouchMode::PerFunction | TouchMode::Hybrid { .. }
@@ -1370,8 +1372,7 @@ pub(crate) fn build_enriched_snapshot(
 
     let total_functions = reports.len();
     let mut enricher = snapshot::SnapshotEnricher::new(Snapshot::new(git_context.clone(), reports))
-        .with_subsystems(repo_root)
-        .with_burst_score(repo_root);
+        .with_subsystems(repo_root);
 
     if !git_context.parent_shas.is_empty() {
         match git::extract_commit_churn_at(repo_root, &git_context.head_sha) {
@@ -1393,6 +1394,10 @@ pub(crate) fn build_enriched_snapshot(
     }
 
     if !skip_touch_metrics {
+        // burst_score does its own full-history `git log` walk (history_signals::
+        // load_commits_with_author) — gate it alongside the other touch/churn git
+        // log calls so --skip-touch-metrics actually skips it too.
+        enricher = enricher.with_burst_score(repo_root);
         let needs_progress = matches!(
             touch_mode,
             TouchMode::PerFunction | TouchMode::Hybrid { .. }

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -90,7 +90,8 @@ enum Commands {
         no_per_function_touches: bool,
 
         /// Skip all touch metrics entirely (no git log calls for churn/recency),
-        /// and skip directed coupling (also a git log walk).
+        /// skip directed coupling (also a git log walk), and skip burst_score
+        /// (also a full-history git log walk).
         /// Overrides --per-function-touches and --no-per-function-touches.
         /// Use for benchmarking pure analysis + call graph performance.
         #[arg(long, conflicts_with = "per_function_touches")]


### PR DESCRIPTION
## Summary
- `with_burst_score()` was called unconditionally in both `build_snapshot_via_db` and `build_enriched_snapshot`, bypassing `--skip-touch-metrics` and running an unbounded, unscoped full-history `git log --name-only --diff-filter=ACDMRT` walk regardless of repo size or the analyzed path.
- Found via a dogfood exercise: `hotspots analyze` hung past 30s on a single file (`src/compiler/binder.ts`) in the TypeScript repo (1.2GB `.git`) even with `--skip-touch-metrics` passed. Gating the call fixed it — same command now completes in 0.65s.
- Also updated the `--skip-touch-metrics` help text, which previously didn't mention burst_score at all.

(Replaces #156, which went stale and picked up a redundant cherry-pick of a fix already merged separately as #153 — closed for the same reason as #157.)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`
- [x] Manually reproduced the hang on `microsoft/TypeScript`'s `src/compiler/binder.ts` before the fix, confirmed resolved after

🤖 Generated with [Claude Code](https://claude.com/claude-code)