### PR TITLE
fix: give rayon worker threads a larger stack to prevent overflow on deep CFG builds

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -156,12 +156,18 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
     } = args;
 
     // Configure the global rayon thread pool before any parallel work begins.
+    // Worker threads default to a 2MB stack (std::thread default), which is too
+    // small for the recursive-descent CFG builders on deeply nested or generated
+    // source files (e.g. rust-lang/rust's tests/ui/ fixtures) and can overflow
+    // and abort the whole process. Give worker threads a larger stack unconditionally.
     // Errors are ignored: build_global() fails if rayon was already initialized
     // (e.g. in tests), which is harmless.
-    if let Some(n) = jobs {
-        let _ = rayon::ThreadPoolBuilder::new()
-            .num_threads(n)
-            .build_global();
+    {
+        let mut builder = rayon::ThreadPoolBuilder::new().stack_size(32 * 1024 * 1024);
+        if let Some(n) = jobs {
+            builder = builder.num_threads(n);
+        }
+        let _ = builder.build_global();
     }
 
     let normalized_path = if path.is_relative() {


### PR DESCRIPTION
## Summary
- Analyzing `rust-lang/rust` with `--per-function-touches` crashed the CLI with SIGABRT (exit -6) in nightly hotspots-cloud crawl runs
- Reproduced locally: a rayon worker thread overflows its stack while building CFGs for deeply nested / generated fixture files (e.g. under `tests/ui/`) — the recursive-descent CFG builders have no depth bound and the default 2MB worker stack isn't enough
- Fix: configure the global rayon thread pool with a 32MB worker stack size unconditionally (previously stack size was never set, only `--jobs`/`num_threads` was configurable)

## Test plan
- [x] `cargo test` (497 tests passed, via commit hook)
- [x] Reproduced the crash on a real `--depth=100` clone of `rust-lang/rust` with the unpatched binary: `thread '<unknown>' has overflowed its stack, fatal runtime error: stack overflow, aborting` (exit 134/-6)
- [x] Re-ran the identical command against the patched build: completed successfully (exit 0), full snapshot JSON produced for all 154,699 functions, no crash

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)