### PR TITLE
feat: add schema_version field to HotspotsConfig

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -432,6 +432,7 @@ Validate: `hotspots config validate` / Inspect resolved: `hotspots config show`
 
 ```json
 {
+  "schema_version": 1,
   "include": ["src/**/*.ts"],
   "exclude": [
     "**/*.test.ts", "**/*.spec.ts",
@@ -478,6 +479,12 @@ Validate: `hotspots config validate` / Inspect resolved: `hotspots config show`
 - `policy.*` values must be one of `"block"`, `"warn"`, `"off"`
 - `policy.<name>_reason` is **required** (non-empty) whenever `policy.<name>` is not `"block"`
 - Unknown fields are rejected (to catch typos)
+- `schema_version` must not exceed the version this build of hotspots supports
+
+**`schema_version`:** defaults to the current config schema version (currently `1`) when
+omitted, so existing `.hotspotsrc.json` files without it keep working unchanged. Bumped
+only when a breaking change to weight/threshold semantics needs migration or explicit
+detection, mirroring `schema_version` on snapshot and delta files.
 
 **`policy`:** severity overrides for the two blocking CI policies. Both default to
 `"block"`. `critical-introduction` fires identically whether a function is brand-new or

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -531,6 +531,21 @@ changes on every release; `formula_version` does not — use it in `hotspots
 diff`/`trends` tooling to tell a score delta caused by a tool upgrade apart
 from one caused by a real code change.
 
+**`formula_version` vs. config `schema_version` — not the same thing.**
+`formula_version` tracks changes to hotspots' *built-in default* weights/thresholds
+(`ScoringWeights::default()` etc.) and is unaffected by a user's own
+`.hotspotsrc.json` — a repo with fully custom weights sees the same
+`formula_version` as one with no config at all, because *their* scoring didn't
+change even when the shipped defaults did. Config `schema_version` (above) tracks
+the *shape/meaning* of the config file format itself — e.g. a field being renamed
+or changing units — independent of what any particular default value is. A release
+that changes a default weight's value bumps `formula_version` only; a release that
+changes what a config field *means* bumps `schema_version` (and `formula_version`
+too, if that also changes computed scores). Note `formula_version` today only
+covers default-value changes, not changes to the scoring formula's structure
+(e.g. adding/removing a term from `compute_activity_risk`) — a structural change
+is not guaranteed to bump it.
+
 ### Function fields (v2 / `--all-functions`)
 
 ```json

--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -75,10 +75,27 @@ const DEFAULT_EXCLUDES: &[&str] = &[
     "**/contrib/**",
 ];
 
+/// Current schema version for `.hotspotsrc.json` / `hotspots.config.json` files.
+///
+/// Mirrors `SNAPSHOT_SCHEMA_VERSION` / `DELTA_SCHEMA_VERSION`: bump this when a
+/// breaking change to weight/threshold semantics requires migration or explicit
+/// detection rather than silent reinterpretation.
+pub const CONFIG_SCHEMA_VERSION: u32 = 1;
+
+fn default_config_schema_version() -> u32 {
+    CONFIG_SCHEMA_VERSION
+}
+
 /// Hotspots configuration loaded from a JSON config file
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HotspotsConfig {
+    /// Schema version of this config file (default: `CONFIG_SCHEMA_VERSION`).
+    /// Existing config files on disk predate this field, so it defaults to the
+    /// current version rather than requiring every user config to set it.
+    #[serde(default = "default_config_schema_version")]
+    pub schema_version: u32,
+
     /// Glob patterns for files to include (default: all supported extensions)
     #[serde(default)]
     pub include: Vec<String>,
@@ -163,6 +180,32 @@ pub struct HotspotsConfig {
     /// Per-repo severity overrides for blocking policies.
     #[serde(default)]
     pub policy: Option<PolicyConfig>,
+}
+
+impl Default for HotspotsConfig {
+    fn default() -> Self {
+        HotspotsConfig {
+            schema_version: CONFIG_SCHEMA_VERSION,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            thresholds: None,
+            weights: None,
+            warning_thresholds: None,
+            min_lrs: None,
+            top: None,
+            scoring: None,
+            co_change_window_days: None,
+            co_change_min_count: None,
+            per_function_touches: None,
+            hybrid_touch_threshold: None,
+            driver_threshold_percentile: None,
+            betweenness_exact_threshold: None,
+            betweenness_approx_k: None,
+            callgraph_skip_above: None,
+            patterns: None,
+            policy: None,
+        }
+    }
 }
 
 /// Severity for a blocking policy, as configured per-repo.
@@ -374,6 +417,14 @@ pub struct ResolvedConfig {
 impl HotspotsConfig {
     /// Validate the configuration for logical errors
     pub fn validate(&self) -> Result<()> {
+        if self.schema_version > CONFIG_SCHEMA_VERSION {
+            anyhow::bail!(
+                "config schema_version {} is newer than supported version {}; \
+                 upgrade hotspots to read this config",
+                self.schema_version,
+                CONFIG_SCHEMA_VERSION
+            );
+        }
         if let Some(ref t) = self.thresholds {
             validate_thresholds(t)?;
         }
@@ -998,6 +1049,23 @@ mod tests {
         let json = r#"{"unknown_field": true}"#;
         let result: Result<HotspotsConfig, _> = serde_json::from_str(json);
         assert!(result.is_err(), "unknown fields should be rejected");
+    }
+
+    #[test]
+    fn test_schema_version_defaults_when_omitted() {
+        // Existing config files on disk predate schema_version and must keep working.
+        let json = r#"{}"#;
+        let config: HotspotsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.schema_version, CONFIG_SCHEMA_VERSION);
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_schema_version_newer_than_supported_rejected() {
+        let json = r#"{"schema_version": 999}"#;
+        let config: HotspotsConfig = serde_json::from_str(json).unwrap();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("schema_version"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a `schema_version` field to `HotspotsConfig`, mirroring the pattern already used by `SNAPSHOT_SCHEMA_VERSION` / `DELTA_SCHEMA_VERSION`, so future breaking changes to weight/threshold semantics have a migration/detection path.
- New `CONFIG_SCHEMA_VERSION` constant (currently `1`). The field defaults to the current version via `#[serde(default = "default_config_schema_version")]`, so existing `.hotspotsrc.json` / `hotspots.config.json` files without it keep working unchanged.
- `HotspotsConfig::validate()` rejects a config whose `schema_version` is newer than what this build supports, matching the rejection pattern used for snapshots.
- Kept `deny_unknown_fields` discipline intact; `HotspotsConfig`'s `Default` impl is now manual (still equivalent to the old derived values) since the derived `Default` would otherwise set `schema_version` to `0` instead of the current version.
- Updated `docs/REFERENCE.md`'s full config schema example and validation rules to document `schema_version`.

Closes #167

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (500 passed in hotspots-core, plus full workspace suite via pre-commit hook)
- [x] Added `test_schema_version_defaults_when_omitted` and `test_schema_version_newer_than_supported_rejected` in `hotspots-core/src/config.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)