### PR TITLE
feat: add formula_version to snapshot AnalysisInfo

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -119,3 +119,28 @@ a future trailing-window replacement, per the brief's "Do not" section.
 **Status:** done — branch `fix/burst-score-remove-from-live-score`, PR #126,
 `cargo test` passing (452 tests). Tracker row `burst-score-remove-from-live` still
 needs to flip from `pending` to `promoted` once merged.
+
+---
+
+## Task: F05 multi-axis hotspot report (`--axes` flag)
+
+**Brief:** `/Users/stephencollins/projects/stephencollins.tech-repos/hotspots-research/docs/promotion-briefs/f05-multi-axis-report.md`
+
+Implement the promotion brief above in this repo. Create a new branch first
+(`feat/f05-multi-axis-report`), implement exactly what's specified (`--axes` flag on
+`hotspots analyze`, `HotspotAxis` enum with `Risk`/`Coupling`/`Ownership` variants,
+`rank_by_axis` function, three sequential output sections), run `cargo test`, and
+report back — do not push or open a PR.
+
+Note: the brief was revised 2026-08-31 after the original draft (Ownership axis via
+`1.0 - author_entropy_normalized`) was found stale against a later research finding
+(F102) — the Ownership axis field is now `newcomer_rate`, a genuinely new signal not
+present anywhere in `hotspots-core` today. Read the brief's "Files to change" section
+carefully: this requires adding a first-commit-per-author map and a 90-day-window
+newcomer-fraction computation to `history_signals.rs`'s existing single-pass commit
+walk, not just wiring up an existing field. The brief includes the exact formula
+(verified against the Python reference implementation) and a port-fidelity unit test
+— follow both precisely, this is the part most likely to be subtly wrong if
+reimplemented from the English description alone.
+
+**Status:** not started.

--- a/TASKS.md
+++ b/TASKS.md
@@ -119,28 +119,3 @@ a future trailing-window replacement, per the brief's "Do not" section.
 **Status:** done — branch `fix/burst-score-remove-from-live-score`, PR #126,
 `cargo test` passing (452 tests). Tracker row `burst-score-remove-from-live` still
 needs to flip from `pending` to `promoted` once merged.
-
----
-
-## Task: F05 multi-axis hotspot report (`--axes` flag)
-
-**Brief:** `/Users/stephencollins/projects/stephencollins.tech-repos/hotspots-research/docs/promotion-briefs/f05-multi-axis-report.md`
-
-Implement the promotion brief above in this repo. Create a new branch first
-(`feat/f05-multi-axis-report`), implement exactly what's specified (`--axes` flag on
-`hotspots analyze`, `HotspotAxis` enum with `Risk`/`Coupling`/`Ownership` variants,
-`rank_by_axis` function, three sequential output sections), run `cargo test`, and
-report back — do not push or open a PR.
-
-Note: the brief was revised 2026-08-31 after the original draft (Ownership axis via
-`1.0 - author_entropy_normalized`) was found stale against a later research finding
-(F102) — the Ownership axis field is now `newcomer_rate`, a genuinely new signal not
-present anywhere in `hotspots-core` today. Read the brief's "Files to change" section
-carefully: this requires adding a first-commit-per-author map and a 90-day-window
-newcomer-fraction computation to `history_signals.rs`'s existing single-pass commit
-walk, not just wiring up an existing field. The brief includes the exact formula
-(verified against the Python reference implementation) and a port-fidelity unit test
-— follow both precisely, this is the part most likely to be subtly wrong if
-reimplemented from the English description alone.
-
-**Status:** not started.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -517,6 +517,13 @@ workflow file can remove a required check — but it does mean the change can't 
 
 Always check `schema_version` before consuming output in tooling.
 
+`analysis.formula_version` is a separate integer that tracks the scoring
+formula (default `ScoringWeights`, `LrsWeights`, `RiskThresholds`), bumped
+only when a default weight or threshold changes. `analysis.tool_version`
+changes on every release; `formula_version` does not — use it in `hotspots
+diff`/`trends` tooling to tell a score delta caused by a tool upgrade apart
+from one caused by a real code change.
+
 ### Function fields (v2 / `--all-functions`)
 
 ```json

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -1236,7 +1236,9 @@ pub(crate) fn build_snapshot_via_db(
     skip_touch_metrics: bool,
 ) -> anyhow::Result<Snapshot> {
     use hotspots_core::db::TempDb;
-    use hotspots_core::snapshot::{AnalysisInfo, CommitInfo, SNAPSHOT_SCHEMA_VERSION};
+    use hotspots_core::snapshot::{
+        AnalysisInfo, CommitInfo, FORMULA_VERSION, SNAPSHOT_SCHEMA_VERSION,
+    };
 
     let git_context =
         git::extract_git_context_at(repo_root).context("failed to extract git context")?;
@@ -1307,6 +1309,7 @@ pub(crate) fn build_snapshot_via_db(
         analysis: AnalysisInfo {
             scope: "full".to_string(),
             tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            formula_version: FORMULA_VERSION,
         },
         functions,
         summary: None,

--- a/hotspots-core/src/db/mod.rs
+++ b/hotspots-core/src/db/mod.rs
@@ -771,7 +771,7 @@ impl SnapshotDb {
 
     /// Load a snapshot for the given commit SHA, returning None if not found.
     pub fn load(&self, sha: &str) -> Result<Option<Snapshot>> {
-        use crate::snapshot::{AnalysisInfo, SNAPSHOT_SCHEMA_VERSION};
+        use crate::snapshot::{AnalysisInfo, FORMULA_VERSION, SNAPSHOT_SCHEMA_VERSION};
 
         // Type alias avoids clippy::type_complexity for the query row.
         type CommitRow = (
@@ -852,6 +852,7 @@ impl SnapshotDb {
             analysis: AnalysisInfo {
                 scope: "full".to_string(),
                 tool_version: env!("CARGO_PKG_VERSION").to_string(),
+                formula_version: FORMULA_VERSION,
             },
             functions,
             summary: None,

--- a/hotspots-core/src/models.rs
+++ b/hotspots-core/src/models.rs
@@ -713,6 +713,7 @@ mod tests {
             analysis: AnalysisInfo {
                 scope: ".".to_string(),
                 tool_version: "test".to_string(),
+                formula_version: crate::snapshot::FORMULA_VERSION,
             },
             functions,
             summary: None,

--- a/hotspots-core/src/sarif.rs
+++ b/hotspots-core/src/sarif.rs
@@ -250,6 +250,7 @@ mod tests {
             analysis: AnalysisInfo {
                 scope: ".".to_string(),
                 tool_version: "1.0.0".to_string(),
+                formula_version: 1,
             },
             functions,
             summary: None,

--- a/hotspots-core/src/snapshot.rs
+++ b/hotspots-core/src/snapshot.rs
@@ -44,6 +44,16 @@ pub enum TouchMode {
 pub const SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 const SNAPSHOT_SCHEMA_MIN_VERSION: u32 = 1;
 
+/// Version of the scoring formula (default `ScoringWeights`, `LrsWeights`,
+/// `RiskThresholds`). Bumped whenever a default weight or threshold changes,
+/// so `hotspots diff`/`trends` can distinguish a score delta caused by a tool
+/// upgrade from one caused by a real code change.
+pub const FORMULA_VERSION: u32 = 1;
+
+fn default_formula_version() -> u32 {
+    FORMULA_VERSION
+}
+
 /// Schema version for index
 const INDEX_SCHEMA_VERSION: u32 = 1;
 
@@ -91,6 +101,10 @@ pub struct AnalysisInfo {
     pub scope: String,
     #[serde(rename = "tool_version")]
     pub tool_version: String,
+    /// Version of the scoring formula that produced this snapshot's scores.
+    /// See `FORMULA_VERSION`.
+    #[serde(default = "default_formula_version")]
+    pub formula_version: u32,
 }
 
 /// Churn metrics for a file/function
@@ -518,6 +532,7 @@ impl Snapshot {
             analysis: AnalysisInfo {
                 scope: "full".to_string(),
                 tool_version: env!("CARGO_PKG_VERSION").to_string(),
+                formula_version: FORMULA_VERSION,
             },
             functions,
             summary: None,

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -1574,6 +1574,7 @@ mod tests {
             analysis: AnalysisInfo {
                 scope: "test".into(),
                 tool_version: "0.0.0".into(),
+                formula_version: 1,
             },
             functions,
             summary: None,
@@ -1749,6 +1750,7 @@ mod tests {
             analysis: AnalysisInfo {
                 scope: "test".into(),
                 tool_version: "0.0.0".into(),
+                formula_version: 1,
             },
             functions,
             summary: None,

--- a/hotspots-core/tests/trainer_tests.rs
+++ b/hotspots-core/tests/trainer_tests.rs
@@ -113,6 +113,7 @@ fn make_snapshot(functions: Vec<FunctionSnapshot>) -> Snapshot {
         analysis: AnalysisInfo {
             scope: "test".to_string(),
             tool_version: "0.0.0".to_string(),
+            formula_version: 1,
         },
         functions,
         summary: None,

--- a/schemas/hotspots-output.schema.json
+++ b/schemas/hotspots-output.schema.json
@@ -65,7 +65,7 @@
     "AnalysisInfo": {
       "type": "object",
       "description": "Metadata about the analysis run",
-      "required": ["scope", "tool_version"],
+      "required": ["scope", "tool_version", "formula_version"],
       "properties": {
         "scope": {
           "type": "string",
@@ -76,6 +76,10 @@
           "type": "string",
           "description": "Version of Hotspots that produced this output",
           "pattern": "^\\d+\\.\\d+\\.\\d+"
+        },
+        "formula_version": {
+          "type": "integer",
+          "description": "Version of the scoring formula (default ScoringWeights/LrsWeights/RiskThresholds) used to produce this output. Bumped whenever a default weight or threshold changes, independent of tool_version."
         }
       }
     },


### PR DESCRIPTION
## Summary
- Adds `formula_version` (u32, starting at 1, mirroring `SNAPSHOT_SCHEMA_VERSION` / `RankerModel.model_version`) to `AnalysisInfo` in snapshot output, alongside `tool_version`.
- New constant `FORMULA_VERSION` in `hotspots-core/src/snapshot.rs`, bumped whenever default `ScoringWeights`/`LrsWeights`/`RiskThresholds` change — lets `hotspots diff`/`trends` distinguish a score delta caused by a tool upgrade from one caused by a real code change.
- Deserialization is backward compatible via `#[serde(default = "default_formula_version")]` so older snapshots without the field still load.
- Updated all `AnalysisInfo` construction sites (production and test) and the JSON schema / docs.

## Files changed
- `hotspots-core/src/snapshot.rs` — `FORMULA_VERSION` const, `formula_version` field, default fn, constructor update
- `hotspots-core/src/db/mod.rs` — snapshot reconstruction from DB
- `hotspots-core/src/models.rs`, `hotspots-core/src/sarif.rs`, `hotspots-core/src/trainer.rs`, `hotspots-core/tests/trainer_tests.rs` — test fixtures
- `hotspots-cli/src/cmd/analyze.rs` — CLI snapshot construction
- `schemas/hotspots-output.schema.json` — schema property + required field
- `docs/REFERENCE.md` — documents the new field

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (all suites pass, including golden tests which don't embed `AnalysisInfo`)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)