### PR TITLE
feat: smooth suppression gate verdict across runs

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -31,6 +31,7 @@ hotspots analyze <PATH> [OPTIONS]
 | `--include-models` | off | Add model risk map to JSON/HTML (snapshot only) |
 | `--callgraph-skip-above N` | 50000 | Skip betweenness centrality if call graph > N edges |
 | `--skip-gate` | off | Disable suppression gate P@10 check |
+| — | — | Suppression gate verdicts are smoothed: `Suppressed` is only reported after 3 consecutive raw `Suppressed` readings across runs, tracked in `.hotspots/gate_history.json` |
 | `--cold-start` | off | Gini/label-density-gated ranking with no trained ranker required — see [Cold-Start Ranking](#cold-start-ranking) |
 | `-j N` / `--jobs N` | CPU count | Parallel worker threads |
 

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -3,7 +3,7 @@ use crate::util::{find_repo_root, write_html_report};
 use crate::{OutputFormat, OutputLevel, OutputMode};
 use anyhow::Context;
 use hotspots_core::delta::Delta;
-use hotspots_core::gate::{check_gate, GateConfig, GateVerdict};
+use hotspots_core::gate::{check_gate_smoothed, GateConfig, GateVerdict};
 use hotspots_core::snapshot::{self, Snapshot};
 use hotspots_core::TouchMode;
 use hotspots_core::{analyze_with_progress, AnalysisOptions};
@@ -585,11 +585,14 @@ fn handle_snapshot_mode(
 
     // Suppression gate: check if the activity ranker is working on this repo.
     // Run on the full sorted snapshot (before top-N truncation) so calibration
-    // sees a representative top-50.
+    // sees a representative top-50. The verdict is smoothed across runs
+    // (`.hotspots/gate_history.json`) so a single sparse/bursty 90-day window
+    // can't flip the reported verdict — see `GateConfig::consecutive_suppressed`.
     // Inconclusive is silent — it fires on greenfield repos or non-conventional
     // commit histories and is not actionable.
     if !skip_gate {
-        let gate_verdict = check_gate(repo_root, &snapshot.functions, &GateConfig::default());
+        let gate_verdict =
+            check_gate_smoothed(repo_root, &snapshot.functions, &GateConfig::default());
         if let GateVerdict::Suppressed {
             p_at_10, threshold, ..
         } = &gate_verdict

--- a/hotspots-core/src/gate.rs
+++ b/hotspots-core/src/gate.rs
@@ -22,11 +22,24 @@
 //! The binary labels come from an on-the-fly commit scan — no pre-built holdout
 //! required. The 90-day window matches the prediction horizon in both the ranker
 //! and the LLM fallback prompt.
+//!
+//! ## Verdict smoothing
+//!
+//! A single 90-day window can be sparse or bursty (a repo with few fix commits
+//! that quarter can flip P@10 across the threshold from run to run without any
+//! real change in ranker quality). [`check_gate_smoothed`] guards against this
+//! by requiring `consecutive_suppressed` back-to-back raw `Suppressed` readings
+//! before the *reported* verdict flips to `Suppressed`. Raw readings are
+//! persisted to `.hotspots/gate_history.json` (reusing the repo's existing
+//! `.hotspots/` state directory) so the count survives across CLI invocations.
+//! `Inconclusive` readings do not count as either a hit or a miss — they are
+//! passed through unchanged and do not reset or extend the streak.
 
 use crate::snapshot::FunctionSnapshot;
 use crate::trainer::{make_rel, repo_prefixes};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Result of the suppression gate check.
@@ -70,6 +83,13 @@ pub struct GateConfig {
     pub cal_n: usize,
     /// P@10 below this → suppress the ranker.
     pub threshold: f64,
+    /// Number of consecutive raw `Suppressed` readings (across historical runs,
+    /// via `check_gate_smoothed`) required before the reported verdict flips to
+    /// `Suppressed`. Defaults to 3: `hotspots analyze` typically runs on every
+    /// push or on a daily CI schedule, so 3 consecutive readings corresponds to
+    /// roughly 3 runs of sustained failure — enough to rule out a single sparse
+    /// or bursty 90-day window while still reacting within a few days.
+    pub consecutive_suppressed: usize,
 }
 
 impl Default for GateConfig {
@@ -78,6 +98,7 @@ impl Default for GateConfig {
             window_days: 90,
             cal_n: 50,
             threshold: 0.5,
+            consecutive_suppressed: 3,
         }
     }
 }
@@ -134,6 +155,96 @@ pub fn check_gate(
             fix_files_found: fix_files.len(),
         }
     }
+}
+
+/// On-disk record of recent raw (unsmoothed) gate readings, oldest first.
+/// Capped to `consecutive_suppressed` entries — that's all `smooth_verdict`
+/// needs to decide whether the streak is unbroken.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct GateHistory {
+    /// `true` for a raw `Suppressed` reading, `false` for `Pass`.
+    readings: Vec<bool>,
+}
+
+fn gate_history_path(repo_root: &Path) -> PathBuf {
+    crate::snapshot::hotspots_dir(repo_root).join("gate_history.json")
+}
+
+fn load_gate_history(path: &Path) -> GateHistory {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_gate_history(path: &Path, history: &GateHistory) {
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    if let Ok(json) = serde_json::to_string(history) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+/// Fold one new raw reading into `history` and decide the smoothed verdict.
+///
+/// `Inconclusive` readings pass through untouched — they neither extend nor
+/// reset the consecutive-`Suppressed` streak, since they carry no signal about
+/// ranker quality either way. A raw `Suppressed` reading is only reported as
+/// `Suppressed` once the last `consecutive_suppressed` readings (including
+/// this one) are all `Suppressed`; otherwise it is reported as `Pass` (with
+/// the same `p_at_10`/`fix_files_found` the raw reading computed) so the
+/// streak can still be observed without flipping CI red prematurely.
+fn smooth_verdict(
+    raw: GateVerdict,
+    history: &mut GateHistory,
+    consecutive_suppressed: usize,
+) -> GateVerdict {
+    let consecutive_suppressed = consecutive_suppressed.max(1);
+
+    if matches!(raw, GateVerdict::Inconclusive { .. }) {
+        return raw;
+    }
+
+    history.readings.push(raw.is_suppressed());
+    let len = history.readings.len();
+    if len > consecutive_suppressed {
+        history.readings.drain(0..len - consecutive_suppressed);
+    }
+
+    let streak_complete = history.readings.len() == consecutive_suppressed
+        && history.readings.iter().all(|&suppressed| suppressed);
+
+    match raw {
+        GateVerdict::Suppressed {
+            p_at_10,
+            fix_files_found,
+            ..
+        } if !streak_complete => GateVerdict::Pass {
+            p_at_10,
+            fix_files_found,
+        },
+        other => other,
+    }
+}
+
+/// Like [`check_gate`], but smooths the verdict across historical runs: the
+/// reported verdict only flips to `Suppressed` after `config.consecutive_suppressed`
+/// back-to-back raw `Suppressed` readings. Reading history is persisted to
+/// `.hotspots/gate_history.json` under `repo_root`.
+pub fn check_gate_smoothed(
+    repo_root: &Path,
+    functions: &[FunctionSnapshot],
+    config: &GateConfig,
+) -> GateVerdict {
+    let raw = check_gate(repo_root, functions, config);
+    let history_path = gate_history_path(repo_root);
+    let mut history = load_gate_history(&history_path);
+    let smoothed = smooth_verdict(raw, &mut history, config.consecutive_suppressed);
+    save_gate_history(&history_path, &history);
+    smoothed
 }
 
 /// Scan git history for files touched by fix commits in the last `window_days` days.
@@ -278,5 +389,88 @@ mod tests {
             threshold: 0.5
         }
         .is_suppressed());
+    }
+
+    fn suppressed(p_at_10: f64) -> GateVerdict {
+        GateVerdict::Suppressed {
+            p_at_10,
+            fix_files_found: 1,
+            threshold: 0.5,
+        }
+    }
+
+    fn pass(p_at_10: f64) -> GateVerdict {
+        GateVerdict::Pass {
+            p_at_10,
+            fix_files_found: 1,
+        }
+    }
+
+    #[test]
+    fn test_smooth_verdict_oscillating_never_flips() {
+        // Suppressed, Pass, Suppressed, Pass, ... never produces 2 consecutive
+        // raw Suppressed readings, so the smoothed verdict should never flip.
+        let mut history = GateHistory::default();
+        let raws = [
+            suppressed(0.1),
+            pass(0.9),
+            suppressed(0.0),
+            pass(0.8),
+            suppressed(0.2),
+        ];
+        for raw in raws {
+            let smoothed = smooth_verdict(raw, &mut history, 2);
+            assert!(
+                !smoothed.is_suppressed(),
+                "oscillating readings should not flip the smoothed verdict"
+            );
+        }
+    }
+
+    #[test]
+    fn test_smooth_verdict_n_consecutive_flips() {
+        // 3 consecutive Suppressed readings should flip the smoothed verdict
+        // once the streak is complete, but not before.
+        let mut history = GateHistory::default();
+        assert!(!smooth_verdict(suppressed(0.1), &mut history, 3).is_suppressed());
+        assert!(!smooth_verdict(suppressed(0.1), &mut history, 3).is_suppressed());
+        assert!(smooth_verdict(suppressed(0.1), &mut history, 3).is_suppressed());
+    }
+
+    #[test]
+    fn test_smooth_verdict_pass_resets_streak() {
+        let mut history = GateHistory::default();
+        assert!(!smooth_verdict(suppressed(0.1), &mut history, 2).is_suppressed());
+        assert!(!smooth_verdict(pass(0.9), &mut history, 2).is_suppressed());
+        // Streak was broken by the Pass reading, so one more Suppressed isn't enough.
+        assert!(!smooth_verdict(suppressed(0.1), &mut history, 2).is_suppressed());
+        assert!(smooth_verdict(suppressed(0.1), &mut history, 2).is_suppressed());
+    }
+
+    #[test]
+    fn test_smooth_verdict_inconclusive_passthrough() {
+        // Inconclusive readings are neither smoothed nor do they affect the streak.
+        let mut history = GateHistory::default();
+        assert!(!smooth_verdict(suppressed(0.1), &mut history, 2).is_suppressed());
+        let inconclusive = GateVerdict::Inconclusive {
+            reason: "no fix commits found".to_string(),
+        };
+        let result = smooth_verdict(inconclusive.clone(), &mut history, 2);
+        assert_eq!(result, inconclusive);
+        // The streak from before the Inconclusive reading is preserved.
+        assert!(smooth_verdict(suppressed(0.1), &mut history, 2).is_suppressed());
+    }
+
+    #[test]
+    fn test_check_gate_smoothed_persists_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo_root = dir.path();
+        // Not a git repo, so scan_fix_files fails and check_gate returns
+        // Inconclusive on every call — this just verifies check_gate_smoothed
+        // runs end-to-end (I/O path) without panicking and passes Inconclusive
+        // through unchanged.
+        let functions = stub_fns(&["a.rs"]);
+        let verdict = check_gate_smoothed(repo_root, &functions, &GateConfig::default());
+        assert!(matches!(verdict, GateVerdict::Inconclusive { .. }));
     }
 }


### PR DESCRIPTION
## Summary
- Closes #170
- The suppression gate's Pass/Suppressed verdict (`hotspots-core/src/gate.rs`) was computed from a single rolling 90-day fix-commit window, so repos with sparse or bursty fix-commit history could see the CI-facing verdict oscillate week to week with no real change in ranker quality.
- Implemented the **N-consecutive-Suppressed-readings** approach (the first option offered in the issue), backed by run-history persistence, rather than the rolling-average alternative — reasoning below.

## Approach chosen and why
The codebase already has an established `.hotspots/` state directory used for cross-run persistence (`.hotspots/snapshots.db`, `.hotspots/ranker.json`, `~/.hotspots/update_check.json`), so adding `.hotspots/gate_history.json` to store recent raw verdict readings required no new infrastructure — it's the existing pattern, just a new file in it. This made the "N consecutive Suppressed readings" option cheaper to implement correctly than the rolling-average alternative: the gate's single 90-day window has no internal sub-periods to average over (it's one `git log --since=...` scan), so a rolling average would have required either shrinking the window into artificial sub-windows (accuracy tradeoff, more git subprocess calls) or misusing `cal_n` as a proxy for time, neither of which the issue asked for.

## Changes
- `hotspots-core/src/gate.rs`:
  - Added `GateConfig::consecutive_suppressed` (default `3`) — the number of consecutive raw `Suppressed` readings required before the smoothed verdict reports `Suppressed`. Documented the default choice (roughly matches 3 CI runs of sustained failure).
  - Added `check_gate_smoothed()`, which wraps `check_gate()` and applies smoothing via a new private `smooth_verdict()` (pure, unit-testable) plus history load/save helpers that persist `.hotspots/gate_history.json`.
  - `Inconclusive` readings pass through unchanged and don't affect the streak (matches existing "Inconclusive is silent/not actionable" behavior).
  - `check_gate()` itself is unchanged — existing callers/tests are unaffected.
- `hotspots-cli/src/cmd/analyze.rs`: switched the `analyze` gate check from `check_gate` to `check_gate_smoothed`; updated the surrounding comment.
- `docs/REFERENCE.md`: added a line noting the smoothing behavior and the history file location.

## Test plan
- [x] New unit tests in `gate.rs`: oscillating readings (Suppressed/Pass/Suppressed/Pass) never flip the smoothed verdict; N consecutive Suppressed readings do flip it; a Pass reading resets the streak; Inconclusive readings pass through without affecting the streak; `check_gate_smoothed` end-to-end I/O smoke test.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (full suite, 504+ tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)