### PR TITLE
Add dead zone to cold-start Gini routing threshold

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -157,6 +157,21 @@ Both anomaly routes (gate 2 and the low-Gini branch of gate 3) use the same
 `IsolationForest` implementation — memory-bounded, streaming, no full-matrix
 intermediate structure. Neither requires a `.hotspots/ranker.json` model file.
 
+**Gini dead zone.** The Gini-coefficient gate is stateless and per-run — a repo whose
+Gini sits just under the 0.55 low threshold could flip from `formula` to `anomaly` on
+a marginal commit. Set `cold_start_gini_dead_zone` in `.hotspotsrc.json` (default `0.0`)
+to widen the ambiguous middle zone that already defaults to `formula`: the effective
+low threshold becomes `0.55 - cold_start_gini_dead_zone`, so Gini values in
+`[0.55 - cold_start_gini_dead_zone, 0.55)` route to `formula` instead of `anomaly`.
+The 0.55 and 0.60 constants themselves are unchanged; the dead zone only shrinks the
+`anomaly` region. Must be non-negative and less than 0.55.
+
+```json
+{
+  "cold_start_gini_dead_zone": 0.03
+}
+```
+
 ### `hotspots prune`
 
 Remove unreachable snapshots (after force-push or branch deletion).

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -330,7 +330,10 @@ fn handle_cold_start(
     snapshot.populate_history_signals(&repo_root);
     snapshot.populate_authors_90d(&repo_root);
 
-    let train_cfg = hotspots_core::trainer::TrainConfig::default();
+    let train_cfg = hotspots_core::trainer::TrainConfig {
+        gini_dead_zone: resolved_config.cold_start_gini_dead_zone,
+        ..Default::default()
+    };
     let result = hotspots_core::trainer::cold_start_rank(&snapshot, &repo_root, &train_cfg);
 
     let route_label = match result.route {

--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -163,6 +163,16 @@ pub struct HotspotsConfig {
     /// Per-repo severity overrides for blocking policies.
     #[serde(default)]
     pub policy: Option<PolicyConfig>,
+
+    /// Dead-zone width (in Gini points) subtracted from `LOW_GINI` before the
+    /// cold-start router (F62/F63) switches from the Formula route to the
+    /// Anomaly route (default: 0.0, no dead zone). Widens the ambiguous middle
+    /// zone that already defaults to Formula, so a repo whose commit-count Gini
+    /// sits just under 0.55 doesn't flip ranking strategy on a marginal commit.
+    /// Does not change the `HIGH_GINI` (0.60) or `LOW_GINI` (0.55) constants
+    /// themselves. Must be non-negative and less than `LOW_GINI`.
+    #[serde(default)]
+    pub cold_start_gini_dead_zone: Option<f64>,
 }
 
 /// Severity for a blocking policy, as configured per-repo.
@@ -337,6 +347,8 @@ pub struct ResolvedConfig {
     /// Filters
     pub min_lrs: Option<f64>,
     pub top_n: Option<usize>,
+    /// Cold-start Gini-routing dead-zone width (see `HotspotsConfig::cold_start_gini_dead_zone`)
+    pub cold_start_gini_dead_zone: f64,
     /// Co-change mining parameters
     pub co_change_window_days: u64,
     pub co_change_min_count: usize,
@@ -424,6 +436,21 @@ fn validate_scalar_fields(c: &HotspotsConfig) -> Result<()> {
     if let Some(k) = c.betweenness_approx_k {
         if k == 0 {
             anyhow::bail!("betweenness_approx_k must be at least 1");
+        }
+    }
+    if let Some(dz) = c.cold_start_gini_dead_zone {
+        if dz < 0.0 {
+            anyhow::bail!(
+                "cold_start_gini_dead_zone must be non-negative (got {})",
+                dz
+            );
+        }
+        if dz >= crate::trainer::LOW_GINI {
+            anyhow::bail!(
+                "cold_start_gini_dead_zone ({}) must be less than LOW_GINI ({})",
+                dz,
+                crate::trainer::LOW_GINI
+            );
         }
     }
     Ok(())
@@ -814,6 +841,7 @@ impl HotspotsConfig {
             betweenness_exact_threshold: self.betweenness_exact_threshold.unwrap_or(2000),
             betweenness_approx_k: self.betweenness_approx_k.unwrap_or(256),
             callgraph_skip_above: self.callgraph_skip_above.unwrap_or(usize::MAX),
+            cold_start_gini_dead_zone: self.cold_start_gini_dead_zone.unwrap_or(0.0),
             config_path: None,
             exclude_is_custom: !self.exclude.is_empty(),
         })
@@ -1182,6 +1210,40 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = discover_config(dir.path()).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_cold_start_gini_dead_zone_defaults_to_zero() {
+        let resolved = HotspotsConfig::default().resolve().unwrap();
+        assert_eq!(resolved.cold_start_gini_dead_zone, 0.0);
+    }
+
+    #[test]
+    fn test_cold_start_gini_dead_zone_resolves_from_config() {
+        let raw = HotspotsConfig {
+            cold_start_gini_dead_zone: Some(0.05),
+            ..Default::default()
+        };
+        let resolved = raw.resolve().unwrap();
+        assert_eq!(resolved.cold_start_gini_dead_zone, 0.05);
+    }
+
+    #[test]
+    fn test_cold_start_gini_dead_zone_rejects_negative() {
+        let raw = HotspotsConfig {
+            cold_start_gini_dead_zone: Some(-0.1),
+            ..Default::default()
+        };
+        assert!(raw.validate().is_err());
+    }
+
+    #[test]
+    fn test_cold_start_gini_dead_zone_rejects_at_or_above_low_gini() {
+        let raw = HotspotsConfig {
+            cold_start_gini_dead_zone: Some(crate::trainer::LOW_GINI),
+            ..Default::default()
+        };
+        assert!(raw.validate().is_err());
     }
 
     #[test]

--- a/hotspots-core/src/trainer.rs
+++ b/hotspots-core/src/trainer.rs
@@ -379,6 +379,10 @@ pub struct TrainConfig {
     /// When set, only commits before this date are used as training labels.
     /// Useful for matching a specific benchmark label window.
     pub label_before: Option<String>,
+    /// Dead-zone width (in Gini points) subtracted from `LOW_GINI` before
+    /// `cold_start_rank()` switches from the `Formula` route to the `Anomaly`
+    /// route (default: 0.0, no dead zone). See `cold_start_rank` for details.
+    pub gini_dead_zone: f64,
 }
 
 impl Default for TrainConfig {
@@ -390,6 +394,7 @@ impl Default for TrainConfig {
             seed: 42,
             blame_labels: false,
             label_before: None,
+            gini_dead_zone: 0.0,
         }
     }
 }
@@ -813,11 +818,19 @@ pub fn gini_coefficient(values: &[f64]) -> f64 {
 /// Routes via the Gini coefficient of `commit_count` across all functions (F62):
 /// - `Gini >= HIGH_GINI` (or the 0.55-0.60 middle zone) → `Formula`: rank by the
 ///   existing `activity_risk`/`lrs` score, no new model needed.
-/// - `Gini < LOW_GINI` → `Anomaly`: fit a label-free `IsolationForest` on the 8-feature
-///   cold-start vector (`cold_start_features`) and rank by anomaly score.
+/// - `Gini < LOW_GINI - cfg.gini_dead_zone` → `Anomaly`: fit a label-free
+///   `IsolationForest` on the 8-feature cold-start vector (`cold_start_features`)
+///   and rank by anomaly score.
 /// - Uniform-prior guard (checked first): if the top 10% of files by `commit_count`
 ///   account for less than 20% of total commits, no file stands out even by raw count
 ///   — return a uniform prior rather than a manufactured ranking.
+///
+/// `cfg.gini_dead_zone` (default `0.0`) widens the ambiguous middle zone that
+/// already defaults to `Formula` by lowering the effective `Anomaly` boundary:
+/// a repo whose Gini sits inside `[LOW_GINI - gini_dead_zone, LOW_GINI)` now
+/// routes to `Formula` instead of flipping to `Anomaly`, damping boundary
+/// flicker from marginal commits. `HIGH_GINI` and `LOW_GINI` themselves are
+/// unchanged — the dead zone only shrinks the `Anomaly` region.
 ///
 /// Two streaming passes over `snapshot.functions` on the `Anomaly` route (fit, then
 /// score) — no intermediate full-matrix structure is built at any point.
@@ -900,8 +913,9 @@ pub fn cold_start_rank(
     }
 
     let gini = gini_coefficient(&commit_counts);
+    let effective_low_gini = LOW_GINI - cfg.gini_dead_zone;
 
-    if gini < LOW_GINI {
+    if gini < effective_low_gini {
         return anomaly_route();
     }
 
@@ -1801,6 +1815,62 @@ mod tests {
         for w in result.ranked.windows(2) {
             assert!(w[0].score >= w[1].score);
         }
+    }
+
+    #[test]
+    fn cold_start_regression_boundaries_unchanged_with_zero_dead_zone() {
+        // gini ≈ 0.518, just under LOW_GINI (0.55) — with the default (0.0) dead
+        // zone this must still route to Anomaly exactly as before the hysteresis
+        // change (LOW_GINI/HIGH_GINI values themselves are untouched by this issue).
+        let mut counts = vec![1u32; 19];
+        counts.push(25);
+        let snap = make_snapshot_with_commit_counts(&counts);
+        let gini = gini_coefficient(&counts.iter().map(|&c| c as f64).collect::<Vec<_>>());
+        assert!(
+            gini < LOW_GINI && gini > LOW_GINI - 0.05,
+            "test fixture gini {gini} out of expected range"
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = cold_start_rank(&snap, dir.path(), &TrainConfig::default());
+        assert_eq!(result.route, ColdStartRoute::Anomaly);
+    }
+
+    #[test]
+    fn cold_start_dead_zone_routes_boundary_gini_to_formula() {
+        // Same fixture as above (gini ≈ 0.518, just under LOW_GINI), but with a
+        // dead zone wide enough to pull the effective Anomaly threshold below the
+        // fixture's gini — the boundary value should now route to Formula instead
+        // of flipping to Anomaly.
+        let mut counts = vec![1u32; 19];
+        counts.push(25);
+        let snap = make_snapshot_with_commit_counts(&counts);
+        let gini = gini_coefficient(&counts.iter().map(|&c| c as f64).collect::<Vec<_>>());
+        let dead_zone = (LOW_GINI - gini) + 0.01;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = TrainConfig {
+            gini_dead_zone: dead_zone,
+            ..Default::default()
+        };
+        let result = cold_start_rank(&snap, dir.path(), &cfg);
+        assert_eq!(result.route, ColdStartRoute::Formula);
+    }
+
+    #[test]
+    fn cold_start_high_gini_route_unaffected_by_dead_zone() {
+        // gini ≈ 0.56, already >= LOW_GINI — a dead zone only shrinks the Anomaly
+        // region below LOW_GINI, so this must remain Formula regardless.
+        let mut counts = vec![1u32; 20];
+        counts[0] = 30;
+        let snap = make_snapshot_with_commit_counts(&counts);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = TrainConfig {
+            gini_dead_zone: 0.1,
+            ..Default::default()
+        };
+        let result = cold_start_rank(&snap, dir.path(), &cfg);
+        assert_eq!(result.route, ColdStartRoute::Formula);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a configurable dead-zone band around the cold-start Gini-coefficient routing threshold (`LOW_GINI` = 0.55) so a repo whose commit-count Gini sits just under the boundary doesn't flip from `Formula` to `Anomaly` ranking on a marginal commit.
- New `TrainConfig.gini_dead_zone: f64` (default `0.0`) lowers the effective Anomaly threshold to `LOW_GINI - gini_dead_zone`; values in `[LOW_GINI - gini_dead_zone, LOW_GINI)` now route to `Formula` instead of `Anomaly`. `LOW_GINI` (0.55) and `HIGH_GINI` (0.60) themselves are unchanged.
- New `HotspotsConfig.cold_start_gini_dead_zone: Option<f64>` config field (validated non-negative and `< LOW_GINI`), resolved into `ResolvedConfig.cold_start_gini_dead_zone` and wired into `hotspots analyze --cold-start` via `TrainConfig`.
- Documents the new dead zone in `docs/REFERENCE.md` under Cold-Start Ranking.

## Interpretation of "hysteresis"

The issue was explicitly ambiguous between two readings:
1. **Stateless dead-zone widening** — no cross-run state, just a wider band around the existing boundary.
2. **Stateful cross-run persistence** — remember the previous routing decision and require the Gini to cross the threshold by some margin (or for N consecutive runs) before flipping.

I implemented **(1), stateless dead-zone widening**. Reasons:
- `cold_start_rank()` is a pure function of a single snapshot with no notion of "previous run" today, and the issue itself says to prefer the smaller, stateless interpretation unless the codebase already has infrastructure for persisting prior routing decisions across runs — it doesn't (no `.hotspots` cache dir entry or model field stores a prior cold-start route).
- `policy.rs`'s watch/attention hysteresis (`evaluate_watch_threshold` / `evaluate_attention_threshold`) is also fundamentally a **band check**, not persisted history — it compares a single delta's `before`/`after` LRS against `[min, max)` ranges to catch a function *entering* a range. Cold-start routing has no `before`/`after` pair (it's a first-run classification), so the closest faithful mirror of that mechanism is "use a band around the boundary," not inventing new persisted state.
- Widening the band is minimal, requires no new storage format, and is fully covered by unit tests without needing multi-run fixtures.

## Files changed

- `hotspots-core/src/trainer.rs` — `TrainConfig.gini_dead_zone` field, routing logic, new tests
- `hotspots-core/src/config.rs` — `HotspotsConfig.cold_start_gini_dead_zone`, `ResolvedConfig.cold_start_gini_dead_zone`, validation, new tests
- `hotspots-cli/src/cmd/analyze.rs` — wires `resolved_config.cold_start_gini_dead_zone` into `TrainConfig` for `--cold-start`
- `docs/REFERENCE.md` — documents the new config field

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (full workspace, including new trainer/config tests)
- [x] Regression test confirms Gini values outside the dead zone still route exactly as before (`>= 0.60` Formula, `< 0.55` Anomaly with default `gini_dead_zone: 0.0`)
- [x] New tests exercise values inside the dead zone routing to `Formula` instead of `Anomaly`

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)