### PR TITLE
feat: add Centrality as a 4th --axes ranking section

### DIFF
--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -45,8 +45,8 @@ pub(crate) struct AnalyzeArgs {
     /// Rank via Gini-gated cold-start routing (F62/F63) instead of a trained ranker.
     /// Explicit opt-in only; reads no fix-commit label data.
     pub cold_start: bool,
-    /// Print three independent ranked sections (Risk, Coupling, Ownership)
-    /// instead of a single merged list (F05).
+    /// Print four independent ranked sections (Risk, Coupling, Ownership,
+    /// Centrality) instead of a single merged list (F05).
     pub axes: bool,
 }
 
@@ -372,10 +372,10 @@ fn handle_cold_start(
     Ok(())
 }
 
-/// `--axes` (F05): prints three independent ranked sections — Risk, Coupling,
-/// Ownership — in that fixed order, instead of a single merged list. Files
-/// may appear in more than one section; overlap is not deduplicated, and the
-/// axes are never blended into a composite score
+/// `--axes` (F05): prints four independent ranked sections — Risk, Coupling,
+/// Ownership, Centrality — in that fixed order, instead of a single merged
+/// list. Files may appear in more than one section; overlap is not
+/// deduplicated, and the axes are never blended into a composite score
 /// (`docs/promotion-briefs/f05-multi-axis-report.md`).
 fn handle_axes(
     path: &Path,
@@ -435,6 +435,7 @@ fn handle_axes(
         (HotspotAxis::Risk, "Risk Hotspots", "risk"),
         (HotspotAxis::Coupling, "Coupling Hotspots", "coupling"),
         (HotspotAxis::Ownership, "Ownership Hotspots", "ownership"),
+        (HotspotAxis::Centrality, "Centrality Hotspots", "centrality"),
     ];
 
     if matches!(format, OutputFormat::Json) {

--- a/hotspots-core/src/ranking.rs
+++ b/hotspots-core/src/ranking.rs
@@ -4,6 +4,10 @@
 //! low pairwise correlation (F05: coupling |r|=0.075, ownership |r|=0.104 vs
 //! defect risk). Each axis is ranked independently — do not blend them into
 //! a composite score, see `docs/promotion-briefs/f05-multi-axis-report.md`.
+//!
+//! Centrality is a presentation-only extension of the same unblended-axis
+//! design, reusing the already-shipped `callgraph.pagerank` field (no new
+//! snapshot field or formula) — see PR description for rationale.
 
 use crate::snapshot::FunctionSnapshot;
 use serde::Serialize;
@@ -20,6 +24,12 @@ pub enum HotspotAxis {
     /// Ownership churn, ranked by `newcomer_rate`. Files with no commits in
     /// the 90-day newcomer window (`newcomer_rate == None`) are excluded.
     Ownership,
+    /// Call-graph centrality, ranked by `callgraph.pagerank`. Files with no
+    /// call-graph data (`callgraph == None`) are excluded. PageRank is used
+    /// unblended — it already folds fan-in-weighted transitive importance
+    /// into one number, so no composite with fan-in/fan-out/betweenness is
+    /// introduced (see module doc: axes stay unblended).
+    Centrality,
 }
 
 /// One ranked entry: a file path and the axis-specific score it was ranked by.
@@ -34,8 +44,9 @@ pub struct RankedFile {
 /// value for the axis are excluded rather than sorted to the bottom (see
 /// `HotspotAxis` docs). Coupling and Ownership scores are file-level
 /// (identical across every function in a file), so deduping is a no-op for
-/// them; Risk (`activity_risk`/`lrs`) varies per function, so the max score
-/// among a file's functions is used to represent the file.
+/// them; Risk (`activity_risk`/`lrs`) and Centrality (`pagerank`) vary per
+/// function, so the max score among a file's functions is used to represent
+/// the file.
 pub fn rank_by_axis(
     entries: &[FunctionSnapshot],
     axis: HotspotAxis,
@@ -74,6 +85,7 @@ fn axis_score(f: &FunctionSnapshot, axis: HotspotAxis) -> Option<f64> {
         HotspotAxis::Risk => Some(f.activity_risk.unwrap_or(f.lrs)),
         HotspotAxis::Coupling => f.directed_coupling.filter(|&dc| dc != 0.0),
         HotspotAxis::Ownership => f.newcomer_rate,
+        HotspotAxis::Centrality => f.callgraph.as_ref().map(|cg| cg.pagerank),
     }
 }
 
@@ -83,6 +95,21 @@ mod tests {
     use crate::language::Language;
     use crate::report::MetricsReport;
     use crate::risk::RiskBand;
+    use crate::snapshot::CallGraphMetrics;
+
+    fn callgraph_with_pagerank(pagerank: f64) -> CallGraphMetrics {
+        CallGraphMetrics {
+            fan_in: 0,
+            fan_out: 0,
+            pagerank,
+            betweenness: 0.0,
+            scc_id: 0,
+            scc_size: 1,
+            is_entrypoint: false,
+            dependency_depth: None,
+            neighbor_churn: None,
+        }
+    }
 
     fn fixture(file: &str) -> FunctionSnapshot {
         FunctionSnapshot {
@@ -171,6 +198,34 @@ mod tests {
         let ranked = rank_by_axis(&entries, HotspotAxis::Ownership, 10);
         let files: Vec<&str> = ranked.iter().map(|r| r.file.as_str()).collect();
         assert_eq!(files, vec!["a.rs", "c.rs"]);
+    }
+
+    #[test]
+    fn multi_axis_centrality_ordering() {
+        let mut entries = vec![fixture("a.rs"), fixture("b.rs"), fixture("c.rs")];
+        entries[0].callgraph = Some(callgraph_with_pagerank(0.05));
+        entries[1].callgraph = Some(callgraph_with_pagerank(0.20));
+        entries[2].callgraph = Some(callgraph_with_pagerank(0.10));
+
+        let ranked = rank_by_axis(&entries, HotspotAxis::Centrality, 10);
+        let files: Vec<&str> = ranked.iter().map(|r| r.file.as_str()).collect();
+        assert_eq!(files, vec!["b.rs", "c.rs", "a.rs"]);
+    }
+
+    #[test]
+    fn multi_axis_centrality_excludes_missing_callgraph() {
+        let mut entries = vec![fixture("a.rs"), fixture("b.rs"), fixture("c.rs")];
+        entries[0].callgraph = Some(callgraph_with_pagerank(0.15));
+        entries[1].callgraph = None;
+        // c.rs: max-per-file across two functions sharing the same file
+        let mut c2 = fixture("c.rs");
+        entries[2].callgraph = Some(callgraph_with_pagerank(0.05));
+        c2.callgraph = Some(callgraph_with_pagerank(0.30));
+        entries.push(c2);
+
+        let ranked = rank_by_axis(&entries, HotspotAxis::Centrality, 10);
+        let files: Vec<&str> = ranked.iter().map(|r| r.file.as_str()).collect();
+        assert_eq!(files, vec!["c.rs", "a.rs"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `HotspotAxis::Centrality` to `hotspots-core/src/ranking.rs`, ranked by `callgraph.pagerank` — the same file-level, max-per-file dedup treatment as the `Risk` axis (pagerank varies per function, unlike the already-file-level `Coupling`/`Ownership` axes).
- Wires it into `hotspots analyze --axes` as a 4th section, "Centrality Hotspots", appended after Ownership in both text and JSON output.
- Files with no call-graph data (`callgraph == None`) are excluded from the ranking rather than sorted to the bottom, matching the existing Coupling/Ownership exclusion pattern.

**Stacked on #162** (F05 multi-axis report) — this branches off `feat/f05-multi-axis-report` since `HotspotAxis`/`rank_by_axis`/`--axes` don't exist on `main` yet. Should merge after #162.

## Why PageRank alone, unblended
This deliberately does *not* introduce a new composite formula (e.g. blending fan-in/fan-out/betweenness with hand-picked weights). PageRank already folds fan-in-weighted transitive importance into a single existing, already-shipped field (`CallGraphMetrics::pagerank`), so ranking by it alone stays faithful to F05's own principle: axes surface different files, and are never blended into a score whose weights would need separate validation. No new snapshot field, ranker, or formula is introduced — this is a presentation-only extension of an already-in-progress mechanism.

## Promotion-tracker note
No existing promotion brief validates a "Centrality axis" specifically (closest are F52 — call-graph centrality as a sub-signal, blocked on function-identity scheme design — and the not-started "Impact Hotspots" cross-repo task). Flagging this explicitly per this repo's brief-consumption rules: since the change reuses an already-validated, already-shipped field with no new formula, it was scoped without a new brief rather than blocked on one. Happy to add a tracker row if that's preferred going forward.

## Test plan
- [x] `cargo test --workspace` — 508 passed, 0 failed (2 new: `multi_axis_centrality_ordering`, `multi_axis_centrality_excludes_missing_callgraph`)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Manual smoke test: `hotspots analyze hotspots-core/src --axes --top 3` — confirmed 4 distinct sections, Centrality populated and independently ordered from Risk/Coupling/Ownership
- [x] `--format json --top 2` — confirmed `"centrality"` key present with `RankedFile[]` shape, `--top` respected
- [x] Verified default `hotspots analyze` (no `--axes`) output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)