### PR TITLE
fix: add cold_start_gini_dead_zone to HotspotsConfig::default

### DIFF
--- a/hotspots-core/src/config.rs
+++ b/hotspots-core/src/config.rs
@@ -214,6 +214,7 @@ impl Default for HotspotsConfig {
             callgraph_skip_above: None,
             patterns: None,
             policy: None,
+            cold_start_gini_dead_zone: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
`main` is currently broken: CI fails on both merge commits since PR #181 landed (`d62cc8c`, `a1b2c33`) with `error[E0063]: missing field 'cold_start_gini_dead_zone' in initializer of 'config::HotspotsConfig'` at `hotspots-core/src/config.rs:197`.

Root cause: PR #175 (schema_version) made `HotspotsConfig`'s `Default` impl manual (previously derived). PR #181 added the `cold_start_gini_dead_zone` field and updated other construction sites, but was authored/reviewed against a `main` that predated #175's manual `Default` impl, so that one site was never updated. Both PRs were individually green — this is an integration break between two independently-correct PRs, not a bug in either one.

## Fix
Add the missing field to the manual `Default` impl (`None`, matching every other `Option` field's default).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (522 passed)