### PR TITLE
refactor: collapse touch-metrics flags into --touch-mode

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -24,9 +24,11 @@ hotspots analyze <PATH> [OPTIONS]
 | `--policy` | off | Evaluate policies; exit 1 on blocking violations (delta only) |
 | `--force` | off | Overwrite existing snapshot |
 | `--no-persist` | off | Skip writing snapshot to disk |
-| `--per-function-touches` | off | Use `git log -L` for precise touch counts (slow cold start) |
-| `--no-per-function-touches` | off | Force file-level touch batching |
-| `--skip-touch-metrics` | off | Skip all git log I/O (touch counts reported as 0) |
+| `--touch-mode` | `auto` | `auto`, `per-function`, `file`, `hybrid[:N]` (default N=5), or `none` — see below |
+| `--per-function-touches` | off | **Deprecated**, use `--touch-mode per-function`. Use `git log -L` for precise touch counts (slow cold start) |
+| `--no-per-function-touches` | off | **Deprecated**, use `--touch-mode file`. Force file-level touch batching |
+| `--skip-touch-metrics` | off | **Deprecated**, use `--touch-mode none`. Skip all git log I/O (touch counts reported as 0) |
+| `--hybrid-touches N` | — | **Deprecated**, use `--touch-mode hybrid:N`. File-level first, per-function for files with touch_count_30d >= N |
 | `--all-functions` | off | Output flat array instead of triage buckets (snapshot JSON only) |
 | `--include-models` | off | Add model risk map to JSON/HTML (snapshot only) |
 | `--callgraph-skip-above N` | 50000 | Skip betweenness centrality if call graph > N edges |
@@ -42,6 +44,21 @@ hotspots analyze <PATH> [OPTIONS]
 - SARIF requires `--mode snapshot`; HTML requires `--mode snapshot` or `--mode delta`
 - `--policy` requires `--mode delta`
 - `--cold-start` is not compatible with `--mode` — it bypasses the trained-ranker/snapshot pipeline entirely
+- `--touch-mode` conflicts with each of the four deprecated flags above; the deprecated flags still work on their own (each prints a one-line warning to stderr) and remain mutually compatible with each other, resolved with the same precedence as before
+
+#### `--touch-mode`
+
+Controls how touch metrics (git churn/recency) are computed:
+
+| Value | Behavior |
+|---|---|
+| `auto` (default) | Use the resolved config's `per_function_touches`/`hybrid_touch_threshold`, falling back to `hybrid:5` |
+| `per-function` | `git log -L` per function — accurate, but O(functions) cold-start git calls, cached in `.hotspots/touch-cache.json.zst` |
+| `file` | File-level batching — fast, one `git log` call per unique file |
+| `hybrid` / `hybrid:N` | File-level first; per-function only for files with `touch_count_30d >= N` (N defaults to 5) |
+| `none` | Skip touch metrics, directed coupling, and burst_score entirely — no git log calls at all |
+
+`--per-function-touches`, `--no-per-function-touches`, `--skip-touch-metrics`, and `--hybrid-touches` are deprecated aliases for `per-function`, `file`, `none`, and `hybrid:N` respectively. They still work but print a deprecation warning; use `--touch-mode` in new scripts and CI configs.
 
 ### `hotspots diff <base> <head>`
 

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -40,6 +40,9 @@ pub(crate) struct AnalyzeArgs {
     pub skip_touch_metrics: bool,
     /// Hybrid touch threshold: file-level first, per-function for files with ≥N touches/30d.
     pub hybrid_touches: Option<usize>,
+    /// `--touch-mode`: supersedes per_function_touches/no_per_function_touches/
+    /// skip_touch_metrics/hybrid_touches (kept as deprecated aliases).
+    pub touch_mode: Option<TouchModeArg>,
     /// Skip the suppression gate check entirely.
     pub skip_gate: bool,
     /// Rank via Gini-gated cold-start routing (F62/F63) instead of a trained ranker.
@@ -155,6 +158,7 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         no_per_function_touches,
         skip_touch_metrics,
         hybrid_touches,
+        touch_mode,
         all_functions,
         include_models,
         explain_patterns,
@@ -165,6 +169,13 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         cold_start,
         axes,
     } = args;
+
+    warn_deprecated_touch_flags(
+        no_per_function_touches,
+        per_function_touches,
+        skip_touch_metrics,
+        hybrid_touches,
+    );
 
     // Configure the global rayon thread pool before any parallel work begins.
     // Worker threads default to a 2MB stack (std::thread default), which is too
@@ -202,17 +213,14 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
 
     let effective_min_lrs = min_lrs.or(resolved_config.min_lrs);
     let effective_top = top.or(resolved_config.top_n);
-    let touch_args = TouchArgs {
-        no_per_function: no_per_function_touches,
-        per_function: per_function_touches,
-        hybrid: hybrid_touches,
-        skip: skip_touch_metrics,
-    };
-    let effective_touch_mode = resolve_touch_mode(
-        touch_args.no_per_function,
-        touch_args.per_function,
-        touch_args.hybrid.or(resolved_config.hybrid_touch_threshold),
+    let (effective_touch_mode, effective_skip_touch_metrics) = resolve_touch_mode_and_skip(
+        touch_mode,
+        no_per_function_touches,
+        per_function_touches,
+        hybrid_touches,
+        skip_touch_metrics,
         resolved_config.per_function_touches,
+        resolved_config.hybrid_touch_threshold,
     );
 
     if cold_start {
@@ -255,7 +263,7 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
                 explain_patterns,
                 source_url,
                 callgraph_skip_above,
-                skip_touch_metrics: touch_args.skip,
+                skip_touch_metrics: effective_skip_touch_metrics,
                 skip_gate,
             },
         );
@@ -289,7 +297,7 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
                 explain_patterns,
                 source_url,
                 callgraph_skip_above,
-                skip_touch_metrics: touch_args.skip,
+                skip_touch_metrics: effective_skip_touch_metrics,
                 skip_gate,
             },
         );
@@ -305,13 +313,6 @@ pub(crate) fn handle_analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
         effective_top,
         &resolved_config,
     )
-}
-
-struct TouchArgs {
-    no_per_function: bool,
-    per_function: bool,
-    hybrid: Option<usize>,
-    skip: bool,
 }
 
 /// `hotspots analyze --cold-start`: Gini-gated cold-start routing (F62/F63).
@@ -1668,13 +1669,14 @@ fn rewrite_worktree_paths(snapshot: &mut Snapshot, worktree_prefix: &str, repo_p
     }
 }
 
+const DEFAULT_HYBRID_THRESHOLD: usize = 5;
+
 fn resolve_touch_mode(
     no_per_function: bool,
     per_function: bool,
     hybrid_threshold: Option<usize>,
     config_per_function: bool,
 ) -> TouchMode {
-    const DEFAULT_HYBRID_THRESHOLD: usize = 5;
     if no_per_function {
         TouchMode::File
     } else if let Some(threshold) = hybrid_threshold {
@@ -1685,6 +1687,106 @@ fn resolve_touch_mode(
         TouchMode::Hybrid {
             threshold: DEFAULT_HYBRID_THRESHOLD,
         }
+    }
+}
+
+/// `--touch-mode` value (see issue #184). Supersedes `--per-function-touches`,
+/// `--no-per-function-touches`, `--skip-touch-metrics`, and `--hybrid-touches`,
+/// which are kept as deprecated aliases.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum TouchModeArg {
+    /// Use the resolved config's `per_function_touches`/`hybrid_touch_threshold`,
+    /// falling back to hybrid with the default threshold — today's implicit default.
+    Auto,
+    PerFunction,
+    File,
+    /// `hybrid` (bare) uses `DEFAULT_HYBRID_THRESHOLD`; `hybrid:N` uses N.
+    Hybrid(Option<usize>),
+    /// Skip all touch metrics, directed coupling, and burst_score (no git log calls).
+    None,
+}
+
+pub(crate) fn parse_touch_mode_arg(s: &str) -> Result<TouchModeArg, String> {
+    let s = s.trim();
+    if let Some(rest) = s.strip_prefix("hybrid") {
+        return if rest.is_empty() {
+            Ok(TouchModeArg::Hybrid(None))
+        } else {
+            let n_str = rest.strip_prefix(':').ok_or_else(|| {
+                format!("invalid --touch-mode '{s}': expected 'hybrid' or 'hybrid:N'")
+            })?;
+            let n: usize = n_str.parse().map_err(|_| {
+                format!("invalid --touch-mode '{s}': N must be a non-negative integer")
+            })?;
+            Ok(TouchModeArg::Hybrid(Some(n)))
+        };
+    }
+    match s {
+        "auto" => Ok(TouchModeArg::Auto),
+        "per-function" => Ok(TouchModeArg::PerFunction),
+        "file" => Ok(TouchModeArg::File),
+        "none" => Ok(TouchModeArg::None),
+        _ => Err(format!(
+            "invalid --touch-mode '{s}': expected one of auto, per-function, file, hybrid[:N], none"
+        )),
+    }
+}
+
+/// Resolves `--touch-mode` (or, absent that, the four deprecated legacy flags) plus
+/// config defaults into a `(TouchMode, skip_touch_metrics)` pair. `TouchMode` is
+/// meaningless when `skip_touch_metrics` is true — callers already gate all touch
+/// computation behind `!skip_touch_metrics` and never consult `TouchMode` otherwise.
+fn resolve_touch_mode_and_skip(
+    touch_mode_arg: Option<TouchModeArg>,
+    legacy_no_per_function: bool,
+    legacy_per_function: bool,
+    legacy_hybrid: Option<usize>,
+    legacy_skip: bool,
+    config_per_function: bool,
+    config_hybrid_threshold: Option<usize>,
+) -> (TouchMode, bool) {
+    match touch_mode_arg {
+        Some(TouchModeArg::Auto) | None => {
+            let touch_mode = resolve_touch_mode(
+                legacy_no_per_function,
+                legacy_per_function,
+                legacy_hybrid.or(config_hybrid_threshold),
+                config_per_function,
+            );
+            (touch_mode, legacy_skip)
+        }
+        Some(TouchModeArg::PerFunction) => (TouchMode::PerFunction, false),
+        Some(TouchModeArg::File) => (TouchMode::File, false),
+        Some(TouchModeArg::Hybrid(threshold)) => (
+            TouchMode::Hybrid {
+                threshold: threshold.unwrap_or(DEFAULT_HYBRID_THRESHOLD),
+            },
+            false,
+        ),
+        Some(TouchModeArg::None) => (TouchMode::File, true),
+    }
+}
+
+/// Prints a one-line deprecation notice for each deprecated touch-metrics flag
+/// actually used. No-op when `--touch-mode` was used instead (clap's `conflicts_with`
+/// already rejects combining them).
+fn warn_deprecated_touch_flags(
+    no_per_function_touches: bool,
+    per_function_touches: bool,
+    skip_touch_metrics: bool,
+    hybrid_touches: Option<usize>,
+) {
+    if no_per_function_touches {
+        eprintln!("warning: --no-per-function-touches is deprecated, use --touch-mode file");
+    }
+    if per_function_touches {
+        eprintln!("warning: --per-function-touches is deprecated, use --touch-mode per-function");
+    }
+    if skip_touch_metrics {
+        eprintln!("warning: --skip-touch-metrics is deprecated, use --touch-mode none");
+    }
+    if let Some(n) = hybrid_touches {
+        eprintln!("warning: --hybrid-touches is deprecated, use --touch-mode hybrid:{n}");
     }
 }
 
@@ -1733,4 +1835,175 @@ pub(crate) fn make_analysis_progress() -> Box<dyn Fn(usize, usize) + Send + Sync
             }
         }
     })
+}
+
+#[cfg(test)]
+mod touch_mode_tests {
+    use super::*;
+
+    #[test]
+    fn parse_touch_mode_arg_all_named_values() {
+        assert_eq!(parse_touch_mode_arg("auto"), Ok(TouchModeArg::Auto));
+        assert_eq!(
+            parse_touch_mode_arg("per-function"),
+            Ok(TouchModeArg::PerFunction)
+        );
+        assert_eq!(parse_touch_mode_arg("file"), Ok(TouchModeArg::File));
+        assert_eq!(parse_touch_mode_arg("none"), Ok(TouchModeArg::None));
+    }
+
+    #[test]
+    fn parse_touch_mode_arg_hybrid_bare_and_with_threshold() {
+        assert_eq!(
+            parse_touch_mode_arg("hybrid"),
+            Ok(TouchModeArg::Hybrid(None))
+        );
+        assert_eq!(
+            parse_touch_mode_arg("hybrid:12"),
+            Ok(TouchModeArg::Hybrid(Some(12)))
+        );
+        assert_eq!(
+            parse_touch_mode_arg("hybrid:0"),
+            Ok(TouchModeArg::Hybrid(Some(0)))
+        );
+    }
+
+    #[test]
+    fn parse_touch_mode_arg_rejects_garbage() {
+        assert!(parse_touch_mode_arg("bogus").is_err());
+        assert!(parse_touch_mode_arg("hybrid:").is_err());
+        assert!(parse_touch_mode_arg("hybrid:abc").is_err());
+        assert!(parse_touch_mode_arg("hybrid-5").is_err());
+        assert!(parse_touch_mode_arg("hybrid:-1").is_err());
+    }
+
+    #[test]
+    fn resolve_touch_mode_and_skip_auto_falls_back_to_config() {
+        // No --touch-mode, no legacy flags, config says per_function_touches=true.
+        let (mode, skip) = resolve_touch_mode_and_skip(None, false, false, None, false, true, None);
+        assert_eq!(mode, TouchMode::PerFunction);
+        assert!(!skip);
+
+        // No config either: default hybrid threshold.
+        let (mode, skip) =
+            resolve_touch_mode_and_skip(None, false, false, None, false, false, None);
+        assert_eq!(
+            mode,
+            TouchMode::Hybrid {
+                threshold: DEFAULT_HYBRID_THRESHOLD
+            }
+        );
+        assert!(!skip);
+    }
+
+    #[test]
+    fn resolve_touch_mode_and_skip_explicit_auto_matches_none() {
+        let (mode, skip) = resolve_touch_mode_and_skip(
+            Some(TouchModeArg::Auto),
+            false,
+            false,
+            None,
+            false,
+            true,
+            Some(9),
+        );
+        // Explicit `--touch-mode auto` still honors config hybrid_touch_threshold,
+        // same as omitting --touch-mode entirely (both resolve through resolve_touch_mode).
+        assert_eq!(mode, TouchMode::Hybrid { threshold: 9 });
+        assert!(!skip);
+    }
+
+    #[test]
+    fn resolve_touch_mode_and_skip_per_function() {
+        let (mode, skip) = resolve_touch_mode_and_skip(
+            Some(TouchModeArg::PerFunction),
+            false,
+            false,
+            None,
+            false,
+            false,
+            None,
+        );
+        assert_eq!(mode, TouchMode::PerFunction);
+        assert!(!skip);
+    }
+
+    #[test]
+    fn resolve_touch_mode_and_skip_file() {
+        let (mode, skip) = resolve_touch_mode_and_skip(
+            Some(TouchModeArg::File),
+            false,
+            false,
+            None,
+            false,
+            true, // config says per-function; --touch-mode file must still win
+            None,
+        );
+        assert_eq!(mode, TouchMode::File);
+        assert!(!skip);
+    }
+
+    #[test]
+    fn resolve_touch_mode_and_skip_hybrid_default_and_explicit_threshold() {
+        let (mode, skip) = resolve_touch_mode_and_skip(
+            Some(TouchModeArg::Hybrid(None)),
+            false,
+            false,
+            None,
+            false,
+            false,
+            None,
+        );
+        assert_eq!(
+            mode,
+            TouchMode::Hybrid {
+                threshold: DEFAULT_HYBRID_THRESHOLD
+            }
+        );
+        assert!(!skip);
+
+        let (mode, skip) = resolve_touch_mode_and_skip(
+            Some(TouchModeArg::Hybrid(Some(42))),
+            false,
+            false,
+            None,
+            false,
+            false,
+            None,
+        );
+        assert_eq!(mode, TouchMode::Hybrid { threshold: 42 });
+        assert!(!skip);
+    }
+
+    #[test]
+    fn resolve_touch_mode_and_skip_none_sets_skip_true() {
+        let (_, skip) = resolve_touch_mode_and_skip(
+            Some(TouchModeArg::None),
+            false,
+            false,
+            None,
+            false,
+            true,
+            Some(3),
+        );
+        assert!(skip);
+    }
+
+    #[test]
+    fn resolve_touch_mode_and_skip_legacy_flags_unchanged_when_touch_mode_absent() {
+        // Legacy --skip-touch-metrics still works when --touch-mode isn't passed.
+        let (_, skip) = resolve_touch_mode_and_skip(None, false, false, None, true, false, None);
+        assert!(skip);
+
+        // Legacy --no-per-function-touches still works.
+        let (mode, skip) = resolve_touch_mode_and_skip(None, true, false, None, false, true, None);
+        assert_eq!(mode, TouchMode::File);
+        assert!(!skip);
+
+        // Legacy --hybrid-touches still works.
+        let (mode, skip) =
+            resolve_touch_mode_and_skip(None, false, false, Some(7), false, false, None);
+        assert_eq!(mode, TouchMode::Hybrid { threshold: 7 });
+        assert!(!skip);
+    }
 }

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -76,25 +76,32 @@ enum Commands {
         #[arg(long, value_name = "LEVEL")]
         level: Option<OutputLevel>,
 
-        /// Use per-function git log -L for touch metrics (more accurate than file-level
-        /// batching). Results are cached in .hotspots/touch-cache.json.zst — the first
-        /// run on a new commit is slow (~9 ms per uncached function); subsequent runs
-        /// are fast. A warning is printed when 50+ functions need to be fetched.
-        #[arg(long)]
+        /// Touch metrics mode: `auto` (default — config or hybrid:5), `per-function`
+        /// (accurate, O(functions) git calls, cached in .hotspots/touch-cache.json.zst),
+        /// `file` (fast file-level batching), `hybrid[:N]` (file-level first,
+        /// per-function only for files with touch_count_30d >= N, default N=5), or
+        /// `none` (skip touch metrics, directed coupling, and burst_score entirely —
+        /// no git log calls; for benchmarking pure analysis + call graph performance).
+        #[arg(long, value_parser = cmd::analyze::parse_touch_mode_arg, conflicts_with_all = ["per_function_touches", "no_per_function_touches", "skip_touch_metrics", "hybrid_touches"])]
+        touch_mode: Option<cmd::analyze::TouchModeArg>,
+
+        /// Deprecated: use `--touch-mode per-function`. Use per-function git log -L
+        /// for touch metrics (more accurate than file-level batching). Results are
+        /// cached in .hotspots/touch-cache.json.zst — the first run on a new commit
+        /// is slow (~9 ms per uncached function); subsequent runs are fast. A warning
+        /// is printed when 50+ functions need to be fetched.
+        #[arg(long, conflicts_with = "touch_mode")]
         per_function_touches: bool,
 
-        /// Disable per-function touch metrics, use file-level batching instead.
-        /// Overrides config and --per-function-touches. Useful for large repos
-        /// where the cold-start per-function git log -L calls dominate CPU time.
-        #[arg(long, conflicts_with = "per_function_touches")]
+        /// Deprecated: use `--touch-mode file`. Disable per-function touch metrics,
+        /// use file-level batching instead. Overrides config and --per-function-touches.
+        #[arg(long, conflicts_with = "touch_mode")]
         no_per_function_touches: bool,
 
-        /// Skip all touch metrics entirely (no git log calls for churn/recency),
-        /// skip directed coupling (also a git log walk), and skip burst_score
-        /// (also a full-history git log walk).
-        /// Overrides --per-function-touches and --no-per-function-touches.
-        /// Use for benchmarking pure analysis + call graph performance.
-        #[arg(long, conflicts_with = "per_function_touches")]
+        /// Deprecated: use `--touch-mode none`. Skip all touch metrics entirely (no
+        /// git log calls for churn/recency), skip directed coupling (also a git log
+        /// walk), and skip burst_score (also a full-history git log walk).
+        #[arg(long, conflicts_with = "touch_mode")]
         skip_touch_metrics: bool,
 
         /// Output all functions as a flat array (only valid with --mode snapshot --format json).
@@ -131,10 +138,9 @@ enum Commands {
         #[arg(long)]
         skip_gate: bool,
 
-        /// Hybrid touch mode: run file-level touch first, then per-function only for
-        /// files with touch_count_30d >= N. Balances accuracy and performance for
-        /// large repos. Conflicts with --per-function-touches and --no-per-function-touches.
-        #[arg(long, value_name = "N", conflicts_with_all = ["per_function_touches", "no_per_function_touches"])]
+        /// Deprecated: use `--touch-mode hybrid:N`. Hybrid touch mode: run file-level
+        /// touch first, then per-function only for files with touch_count_30d >= N.
+        #[arg(long, value_name = "N", conflicts_with = "touch_mode")]
         hybrid_touches: Option<usize>,
 
         /// Rank using a Gini-gated cold-start strategy (formula / IsolationForest
@@ -349,6 +355,7 @@ fn main() -> anyhow::Result<()> {
             jobs,
             callgraph_skip_above,
             hybrid_touches,
+            touch_mode,
             skip_gate,
             cold_start,
             axes,
@@ -375,6 +382,7 @@ fn main() -> anyhow::Result<()> {
             jobs,
             callgraph_skip_above,
             hybrid_touches,
+            touch_mode,
             skip_gate,
             cold_start,
             axes,


### PR DESCRIPTION
## Summary
Closes #184.

`hotspots analyze` controlled touch-metrics computation via four separate, pairwise-`conflicts_with` flags that grew by accretion (`--per-function-touches`, `--no-per-function-touches`, `--skip-touch-metrics`, `--hybrid-touches`). Replaces them with a single `--touch-mode <auto|per-function|file|hybrid[:N]|none>` flag, matching the internal `TouchMode` enum this already collapsed down to in `resolve_touch_mode()`.

## Changes
- `hotspots-cli/src/cmd/analyze.rs`:
  - New `TouchModeArg` enum + `parse_touch_mode_arg` (custom clap value parser, handles bare `hybrid` and `hybrid:N`).
  - New `resolve_touch_mode_and_skip()`: when `--touch-mode` is given, maps directly to `(TouchMode, skip_touch_metrics)`; when absent, falls back to the existing legacy-flag resolution unchanged (byte-for-byte same behavior as before this PR).
  - New `warn_deprecated_touch_flags()`: prints a one-line stderr warning per legacy flag actually used.
  - Removed the now-redundant `TouchArgs` struct (single-field after `touch_mode`/`skip` split out).
- `hotspots-cli/src/main.rs`: added `--touch-mode`; the four legacy flags now only `conflicts_with = "touch_mode"` (no longer mutually exclusive with each other — they're deprecated, and `resolve_touch_mode`'s existing priority chain already resolves combinations deterministically).
- `docs/REFERENCE.md`: documents `--touch-mode` as primary; legacy flags marked deprecated with their equivalents.

## Behavior
- `--touch-mode auto` (or omitting it) is byte-for-byte identical to today's default resolution, including config fallback (`per_function_touches`/`hybrid_touch_threshold`).
- The four legacy flags still work exactly as before, just with a deprecation warning.
- `--touch-mode` conflicts with all four legacy flags (can't mix old and new).
- No change to what any touch mode actually computes — CLI surface consolidation only, confirmed by the full existing workspace test suite passing unchanged.

## Test plan
- [x] 10 new unit tests covering all 5 `--touch-mode` values, the config-fallback (`auto`) case, and legacy-flag-only behavior when `--touch-mode` is absent
- [x] Manual smoke test: invalid value rejected with a clear error, `--touch-mode` + legacy flag rejected as conflicting, legacy flag alone prints deprecation warning + still works, `--touch-mode hybrid:12` works
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (522 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)