### PR TITLE
feat: add --format csv/xlsx for triage spreadsheets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "argmin"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +352,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +563,7 @@ dependencies = [
  "rayon",
  "regex",
  "rusqlite",
+ "rust_xlsxwriter",
  "serde",
  "serde_json",
  "swc_common",
@@ -1284,6 +1305,15 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_xlsxwriter"
+version = "0.79.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c743cb9f2a4524676020e26ee5f298445a82d882b09956811b1e78ca7e42b440"
+dependencies = [
+ "zip",
 ]
 
 [[package]]
@@ -2241,10 +2271,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +529,7 @@ name = "hotspots-core"
 version = "1.37.0"
 dependencies = [
  "anyhow",
+ "csv",
  "globset",
  "linfa",
  "linfa-ensemble",
@@ -1323,6 +1345,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -12,7 +12,7 @@ hotspots analyze <PATH> [OPTIONS]
 
 | Flag | Default | Description |
 |---|---|---|
-| `--format` | `text` | `text`, `json`, `jsonl`, `html`, `sarif` |
+| `--format` | `text` | `text`, `json`, `jsonl`, `html`, `sarif`, `csv`, `xlsx` |
 | `--mode` | — | `snapshot`, `delta`, `models` |
 | `--top N` | none | Show top N functions by LRS |
 | `--min-lrs F` | `0.0` | Filter functions below this LRS |
@@ -45,6 +45,15 @@ hotspots analyze <PATH> [OPTIONS]
 - `--policy` requires `--mode delta`
 - `--cold-start` is not compatible with `--mode` — it bypasses the trained-ranker/snapshot pipeline entirely
 - `--touch-mode` conflicts with each of the four deprecated flags above; the deprecated flags still work on their own (each prints a one-line warning to stderr) and remain mutually compatible with each other, resolved with the same precedence as before
+- `--format csv`/`--format xlsx` require `--mode snapshot`
+
+#### `--format csv` / `--format xlsx`
+
+A file-level triage/planning view for spreadsheet workflows — a tech lead or EM doing triage, ownership handoff, or sprint planning, not a raw per-function data dump (`--format json --all-functions`) or an in-IDE fix workflow (text/HTML). One row per file, always the full file list (ignores `--top`), with the risk band, quadrant, the file's highest-risk function and its line, ownership `newcomer_rate`, function/critical counts, LOC, and subsystem.
+
+Coupling (`directed_coupling`) is not in the main table — only a minority of files have any coupling relationship, so folding it in would leave most rows reading "n/a" on that column. `--format xlsx` is a real multi-sheet workbook: "Files" (the main table) plus a "Coupling" sheet (files with a real `directed_coupling` value only). `--format csv` is single-file/single-table only — CSV has no notion of multiple tables, so coupling isn't included; use `--format xlsx` for coupling data. `--format xlsx` always writes to a file (`--output`, or `.hotspots/report.xlsx` by default); `--format csv` prints to stdout without `--output`.
+
+Missing axis values (a file excluded from an axis, not a measured zero) are written as the literal string `n/a`, never a blank cell.
 
 #### `--touch-mode`
 

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -138,6 +138,9 @@ pub(crate) fn validate_analyze_flags(args: &AnalyzeArgs) -> anyhow::Result<()> {
     if matches!(format, OutputFormat::Csv) && *mode != Some(OutputMode::Snapshot) {
         anyhow::bail!("--format csv requires --mode snapshot");
     }
+    if matches!(format, OutputFormat::Xlsx) && *mode != Some(OutputMode::Snapshot) {
+        anyhow::bail!("--format xlsx requires --mode snapshot");
+    }
     Ok(())
 }
 
@@ -526,6 +529,7 @@ fn handle_default_output(
         }
         OutputFormat::Sarif => anyhow::bail!("SARIF format requires --mode snapshot"),
         OutputFormat::Csv => anyhow::bail!("--format csv requires --mode snapshot"),
+        OutputFormat::Xlsx => anyhow::bail!("--format xlsx requires --mode snapshot"),
     }
     Ok(())
 }
@@ -672,11 +676,11 @@ fn handle_snapshot_mode(
         snapshot.populate_directed_coupling(repo_root, &partner_scores);
     }
 
-    // `--format csv`'s Ownership column needs `newcomer_rate`, which the
-    // standard snapshot pipeline otherwise never populates (only the
-    // `--cold-start` and `--axes` paths call this today) — gated to CSV so
-    // other formats don't pay for an extra full-history `git log` walk.
-    if !skip_touch_metrics && matches!(format, OutputFormat::Csv) {
+    // `--format csv`/`--format xlsx`'s Ownership column needs `newcomer_rate`,
+    // which the standard snapshot pipeline otherwise never populates (only the
+    // `--cold-start` and `--axes` paths call this today) — gated to these two
+    // formats so others don't pay for an extra full-history `git log` walk.
+    if !skip_touch_metrics && matches!(format, OutputFormat::Csv | OutputFormat::Xlsx) {
         snapshot.populate_history_signals(repo_root);
     }
 
@@ -915,7 +919,11 @@ fn handle_models_mode(
                 hotspots_core::models::render_model_risk_json(&model_map)?
             );
         }
-        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif | OutputFormat::Csv => {
+        OutputFormat::Html
+        | OutputFormat::Jsonl
+        | OutputFormat::Sarif
+        | OutputFormat::Csv
+        | OutputFormat::Xlsx => {
             unreachable!("validated by validate_analyze_flags")
         }
     }
@@ -950,6 +958,7 @@ fn emit_snapshot_output(
         OutputFormat::Html => emit_html_output(snapshot, repo_root, analysis_path, opts),
         OutputFormat::Sarif => emit_sarif_output(snapshot, repo_root, opts),
         OutputFormat::Csv => emit_csv_output(snapshot, repo_root, opts),
+        OutputFormat::Xlsx => emit_xlsx_output(snapshot, repo_root, opts),
     }
 }
 
@@ -1093,10 +1102,9 @@ fn emit_sarif_output(
 /// `--format csv`: one row per file, full inventory (ignores `--top` — a
 /// spreadsheet is for sorting/filtering everything, not a truncated view).
 /// See `hotspots_core::csv_report` for the triage/planning audience and
-/// column rationale. Writes two files — the main table and a `-coupling`
-/// sibling — since coupling has a real value for only a minority of files
-/// on a typical repo and folding it into the main table means most rows
-/// read "n/a" on that column.
+/// column rationale. Single file, single table — coupling data lives only in
+/// `--format xlsx` (a real workbook can hold it as a separate sheet; CSV has
+/// no notion of multiple tables in one file, so it doesn't try to).
 fn emit_csv_output(
     snapshot: &mut Snapshot,
     repo_root: &Path,
@@ -1104,9 +1112,6 @@ fn emit_csv_output(
 ) -> anyhow::Result<()> {
     let csv = hotspots_core::csv_report::render_csv(&snapshot.functions, repo_root)
         .context("failed to render CSV report")?;
-    let coupling_csv =
-        hotspots_core::csv_report::render_coupling_csv(&snapshot.functions, repo_root)
-            .context("failed to render coupling CSV report")?;
     if let Some(output_path) = opts.output {
         if let Some(parent) = output_path.parent() {
             std::fs::create_dir_all(parent)
@@ -1115,39 +1120,34 @@ fn emit_csv_output(
         std::fs::write(&output_path, &csv)
             .with_context(|| format!("failed to write CSV to {}", output_path.display()))?;
         eprintln!("CSV report written to: {}", output_path.display());
-
-        let coupling_path = coupling_sibling_path(&output_path);
-        std::fs::write(&coupling_path, &coupling_csv).with_context(|| {
-            format!(
-                "failed to write coupling CSV to {}",
-                coupling_path.display()
-            )
-        })?;
-        eprintln!(
-            "Coupling CSV report written to: {}",
-            coupling_path.display()
-        );
     } else {
         print!("{csv}");
-        println!();
-        println!("# coupling.csv — files with a directed_coupling relationship");
-        print!("{coupling_csv}");
     }
     Ok(())
 }
 
-/// Derives `<stem>-coupling.<ext>` next to `output_path` (e.g.
-/// `report.csv` -> `report-coupling.csv`).
-fn coupling_sibling_path(output_path: &Path) -> PathBuf {
-    let stem = output_path
-        .file_stem()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| "report".to_string());
-    let file_name = match output_path.extension() {
-        Some(ext) => format!("{stem}-coupling.{}", ext.to_string_lossy()),
-        None => format!("{stem}-coupling"),
-    };
-    output_path.with_file_name(file_name)
+/// `--format xlsx`: a real multi-sheet workbook — "Files" (the main triage
+/// table) and "Coupling" (files with a real `directed_coupling` value only).
+/// Binary format, so it always writes to a file: `--output`, or
+/// `.hotspots/report.xlsx` by default (mirrors HTML's default path).
+fn emit_xlsx_output(
+    snapshot: &mut Snapshot,
+    repo_root: &Path,
+    opts: SnapshotOutputOpts,
+) -> anyhow::Result<()> {
+    let bytes = hotspots_core::xlsx_report::render_xlsx(&snapshot.functions, repo_root)
+        .context("failed to render XLSX report")?;
+    let output_path = opts
+        .output
+        .unwrap_or_else(|| snapshot::hotspots_dir(repo_root).join("report.xlsx"));
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+    }
+    std::fs::write(&output_path, &bytes)
+        .with_context(|| format!("failed to write XLSX to {}", output_path.display()))?;
+    eprintln!("XLSX report written to: {}", output_path.display());
+    Ok(())
 }
 
 fn apply_top_n(
@@ -1159,10 +1159,10 @@ fn apply_top_n(
 ) {
     let is_aggregate_level = level == Some(OutputLevel::File) || level == Some(OutputLevel::Module);
     let is_text = matches!(format, OutputFormat::Text);
-    // CSV always emits the full file inventory — a spreadsheet is for
+    // CSV/XLSX always emit the full file inventory — a spreadsheet is for
     // sorting/filtering everything, not a truncated view (see csv_report.rs).
-    let is_csv = matches!(format, OutputFormat::Csv);
-    if !is_aggregate_level && !is_csv && (top.is_some() || (is_text && explain)) {
+    let is_spreadsheet = matches!(format, OutputFormat::Csv | OutputFormat::Xlsx);
+    if !is_aggregate_level && !is_spreadsheet && (top.is_some() || (is_text && explain)) {
         snapshot.functions.sort_by(|a, b| {
             let a_score = a.activity_risk.unwrap_or(a.lrs);
             let b_score = b.activity_risk.unwrap_or(b.lrs);
@@ -1351,6 +1351,9 @@ fn emit_delta_output(
         }
         OutputFormat::Csv => {
             anyhow::bail!("--format csv is not supported for delta mode (use --mode snapshot)");
+        }
+        OutputFormat::Xlsx => {
+            anyhow::bail!("--format xlsx is not supported for delta mode (use --mode snapshot)");
         }
     }
 

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -949,7 +949,7 @@ fn emit_snapshot_output(
         OutputFormat::Text => emit_text_output(snapshot, repo_root, opts),
         OutputFormat::Html => emit_html_output(snapshot, repo_root, analysis_path, opts),
         OutputFormat::Sarif => emit_sarif_output(snapshot, repo_root, opts),
-        OutputFormat::Csv => emit_csv_output(snapshot, opts),
+        OutputFormat::Csv => emit_csv_output(snapshot, repo_root, opts),
     }
 }
 
@@ -1094,8 +1094,12 @@ fn emit_sarif_output(
 /// spreadsheet is for sorting/filtering everything, not a truncated view).
 /// See `hotspots_core::csv_report` for the triage/planning audience and
 /// column rationale.
-fn emit_csv_output(snapshot: &mut Snapshot, opts: SnapshotOutputOpts) -> anyhow::Result<()> {
-    let csv = hotspots_core::csv_report::render_csv(&snapshot.functions)
+fn emit_csv_output(
+    snapshot: &mut Snapshot,
+    repo_root: &Path,
+    opts: SnapshotOutputOpts,
+) -> anyhow::Result<()> {
+    let csv = hotspots_core::csv_report::render_csv(&snapshot.functions, repo_root)
         .context("failed to render CSV report")?;
     if let Some(output_path) = opts.output {
         if let Some(parent) = output_path.parent() {

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -1093,7 +1093,10 @@ fn emit_sarif_output(
 /// `--format csv`: one row per file, full inventory (ignores `--top` — a
 /// spreadsheet is for sorting/filtering everything, not a truncated view).
 /// See `hotspots_core::csv_report` for the triage/planning audience and
-/// column rationale.
+/// column rationale. Writes two files — the main table and a `-coupling`
+/// sibling — since coupling has a real value for only a minority of files
+/// on a typical repo and folding it into the main table means most rows
+/// read "n/a" on that column.
 fn emit_csv_output(
     snapshot: &mut Snapshot,
     repo_root: &Path,
@@ -1101,6 +1104,9 @@ fn emit_csv_output(
 ) -> anyhow::Result<()> {
     let csv = hotspots_core::csv_report::render_csv(&snapshot.functions, repo_root)
         .context("failed to render CSV report")?;
+    let coupling_csv =
+        hotspots_core::csv_report::render_coupling_csv(&snapshot.functions, repo_root)
+            .context("failed to render coupling CSV report")?;
     if let Some(output_path) = opts.output {
         if let Some(parent) = output_path.parent() {
             std::fs::create_dir_all(parent)
@@ -1109,10 +1115,39 @@ fn emit_csv_output(
         std::fs::write(&output_path, &csv)
             .with_context(|| format!("failed to write CSV to {}", output_path.display()))?;
         eprintln!("CSV report written to: {}", output_path.display());
+
+        let coupling_path = coupling_sibling_path(&output_path);
+        std::fs::write(&coupling_path, &coupling_csv).with_context(|| {
+            format!(
+                "failed to write coupling CSV to {}",
+                coupling_path.display()
+            )
+        })?;
+        eprintln!(
+            "Coupling CSV report written to: {}",
+            coupling_path.display()
+        );
     } else {
         print!("{csv}");
+        println!();
+        println!("# coupling.csv — files with a directed_coupling relationship");
+        print!("{coupling_csv}");
     }
     Ok(())
+}
+
+/// Derives `<stem>-coupling.<ext>` next to `output_path` (e.g.
+/// `report.csv` -> `report-coupling.csv`).
+fn coupling_sibling_path(output_path: &Path) -> PathBuf {
+    let stem = output_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "report".to_string());
+    let file_name = match output_path.extension() {
+        Some(ext) => format!("{stem}-coupling.{}", ext.to_string_lossy()),
+        None => format!("{stem}-coupling"),
+    };
+    output_path.with_file_name(file_name)
 }
 
 fn apply_top_n(

--- a/hotspots-cli/src/cmd/analyze.rs
+++ b/hotspots-cli/src/cmd/analyze.rs
@@ -135,6 +135,9 @@ pub(crate) fn validate_analyze_flags(args: &AnalyzeArgs) -> anyhow::Result<()> {
     if matches!(format, OutputFormat::Sarif) && *mode != Some(OutputMode::Snapshot) {
         anyhow::bail!("--format sarif requires --mode snapshot");
     }
+    if matches!(format, OutputFormat::Csv) && *mode != Some(OutputMode::Snapshot) {
+        anyhow::bail!("--format csv requires --mode snapshot");
+    }
     Ok(())
 }
 
@@ -522,6 +525,7 @@ fn handle_default_output(
             anyhow::bail!("HTML/JSONL format requires --mode snapshot or --mode delta");
         }
         OutputFormat::Sarif => anyhow::bail!("SARIF format requires --mode snapshot"),
+        OutputFormat::Csv => anyhow::bail!("--format csv requires --mode snapshot"),
     }
     Ok(())
 }
@@ -666,6 +670,14 @@ fn handle_snapshot_mode(
             })
             .collect();
         snapshot.populate_directed_coupling(repo_root, &partner_scores);
+    }
+
+    // `--format csv`'s Ownership column needs `newcomer_rate`, which the
+    // standard snapshot pipeline otherwise never populates (only the
+    // `--cold-start` and `--axes` paths call this today) — gated to CSV so
+    // other formats don't pay for an extra full-history `git log` walk.
+    if !skip_touch_metrics && matches!(format, OutputFormat::Csv) {
+        snapshot.populate_history_signals(repo_root);
     }
 
     if !pr_context.is_pr && !no_persist {
@@ -903,7 +915,7 @@ fn handle_models_mode(
                 hotspots_core::models::render_model_risk_json(&model_map)?
             );
         }
-        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif => {
+        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif | OutputFormat::Csv => {
             unreachable!("validated by validate_analyze_flags")
         }
     }
@@ -937,6 +949,7 @@ fn emit_snapshot_output(
         OutputFormat::Text => emit_text_output(snapshot, repo_root, opts),
         OutputFormat::Html => emit_html_output(snapshot, repo_root, analysis_path, opts),
         OutputFormat::Sarif => emit_sarif_output(snapshot, repo_root, opts),
+        OutputFormat::Csv => emit_csv_output(snapshot, opts),
     }
 }
 
@@ -1077,6 +1090,27 @@ fn emit_sarif_output(
     Ok(())
 }
 
+/// `--format csv`: one row per file, full inventory (ignores `--top` — a
+/// spreadsheet is for sorting/filtering everything, not a truncated view).
+/// See `hotspots_core::csv_report` for the triage/planning audience and
+/// column rationale.
+fn emit_csv_output(snapshot: &mut Snapshot, opts: SnapshotOutputOpts) -> anyhow::Result<()> {
+    let csv = hotspots_core::csv_report::render_csv(&snapshot.functions)
+        .context("failed to render CSV report")?;
+    if let Some(output_path) = opts.output {
+        if let Some(parent) = output_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+        }
+        std::fs::write(&output_path, &csv)
+            .with_context(|| format!("failed to write CSV to {}", output_path.display()))?;
+        eprintln!("CSV report written to: {}", output_path.display());
+    } else {
+        print!("{csv}");
+    }
+    Ok(())
+}
+
 fn apply_top_n(
     snapshot: &mut Snapshot,
     format: OutputFormat,
@@ -1086,7 +1120,10 @@ fn apply_top_n(
 ) {
     let is_aggregate_level = level == Some(OutputLevel::File) || level == Some(OutputLevel::Module);
     let is_text = matches!(format, OutputFormat::Text);
-    if !is_aggregate_level && (top.is_some() || (is_text && explain)) {
+    // CSV always emits the full file inventory — a spreadsheet is for
+    // sorting/filtering everything, not a truncated view (see csv_report.rs).
+    let is_csv = matches!(format, OutputFormat::Csv);
+    if !is_aggregate_level && !is_csv && (top.is_some() || (is_text && explain)) {
         snapshot.functions.sort_by(|a, b| {
             let a_score = a.activity_risk.unwrap_or(a.lrs);
             let b_score = b.activity_risk.unwrap_or(b.lrs);
@@ -1272,6 +1309,9 @@ fn emit_delta_output(
         }
         OutputFormat::Sarif => {
             anyhow::bail!("SARIF format is not supported for delta mode (use --mode snapshot)");
+        }
+        OutputFormat::Csv => {
+            anyhow::bail!("--format csv is not supported for delta mode (use --mode snapshot)");
         }
     }
 

--- a/hotspots-cli/src/cmd/diff.rs
+++ b/hotspots-cli/src/cmd/diff.rs
@@ -233,6 +233,11 @@ fn emit_diff_output(
                 "--format csv is not supported for diff (use --format json or --format html)"
             );
         }
+        OutputFormat::Xlsx => {
+            anyhow::bail!(
+                "--format xlsx is not supported for diff (use --format json or --format html)"
+            );
+        }
     }
 
     Ok(has_blocking_failures)

--- a/hotspots-cli/src/cmd/diff.rs
+++ b/hotspots-cli/src/cmd/diff.rs
@@ -228,6 +228,11 @@ fn emit_diff_output(
                 "--format sarif is not supported for diff (use --format json or --format html)"
             );
         }
+        OutputFormat::Csv => {
+            anyhow::bail!(
+                "--format csv is not supported for diff (use --format json or --format html)"
+            );
+        }
     }
 
     Ok(has_blocking_failures)

--- a/hotspots-cli/src/cmd/trends.rs
+++ b/hotspots-cli/src/cmd/trends.rs
@@ -36,8 +36,12 @@ pub(crate) fn handle_trends(
         OutputFormat::Text => {
             print_trends_text_output(&trends)?;
         }
-        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif | OutputFormat::Csv => {
-            anyhow::bail!("HTML/JSONL/SARIF/CSV format is not supported for trends analysis");
+        OutputFormat::Html
+        | OutputFormat::Jsonl
+        | OutputFormat::Sarif
+        | OutputFormat::Csv
+        | OutputFormat::Xlsx => {
+            anyhow::bail!("HTML/JSONL/SARIF/CSV/XLSX format is not supported for trends analysis");
         }
     }
 

--- a/hotspots-cli/src/cmd/trends.rs
+++ b/hotspots-cli/src/cmd/trends.rs
@@ -36,8 +36,8 @@ pub(crate) fn handle_trends(
         OutputFormat::Text => {
             print_trends_text_output(&trends)?;
         }
-        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif => {
-            anyhow::bail!("HTML/JSONL/SARIF format is not supported for trends analysis");
+        OutputFormat::Html | OutputFormat::Jsonl | OutputFormat::Sarif | OutputFormat::Csv => {
+            anyhow::bail!("HTML/JSONL/SARIF/CSV format is not supported for trends analysis");
         }
     }
 

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -331,6 +331,7 @@ pub(crate) enum OutputFormat {
     Jsonl,
     Sarif,
     Csv,
+    Xlsx,
 }
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]

--- a/hotspots-cli/src/main.rs
+++ b/hotspots-cli/src/main.rs
@@ -330,6 +330,7 @@ pub(crate) enum OutputFormat {
     Html,
     Jsonl,
     Sarif,
+    Csv,
 }
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]

--- a/hotspots-core/Cargo.toml
+++ b/hotspots-core/Cargo.toml
@@ -46,6 +46,7 @@ linfa-linear = "0.8.1"
 rand = { version = "0.8", features = ["small_rng"] }
 ndarray = "0.16"
 tree-sitter-c = "0.24.2"
+csv = "1.3"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/hotspots-core/Cargo.toml
+++ b/hotspots-core/Cargo.toml
@@ -47,6 +47,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 ndarray = "0.16"
 tree-sitter-c = "0.24.2"
 csv = "1.3"
+rust_xlsxwriter = "0.79"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/hotspots-core/src/csv_report.rs
+++ b/hotspots-core/src/csv_report.rs
@@ -1,0 +1,248 @@
+//! CSV (spreadsheet) report — file-level triage/planning view.
+//!
+//! Audience: a tech lead or EM doing triage, ownership handoff, or sprint
+//! planning in a spreadsheet — not a raw per-function data dump (that's
+//! `--format json --all-functions`) and not an in-IDE fix workflow (that's
+//! the text/HTML outputs). Rows are one per file, with the three F05 axes
+//! (Risk/Coupling/Ownership) as sortable/filterable columns side by side,
+//! plus enough context (band, quadrant, function/critical counts, subsystem)
+//! to triage without opening the tool again. Always the full file list,
+//! ignoring `--top` — a spreadsheet is for sorting/filtering everything,
+//! not a truncated view.
+
+use crate::risk::RiskBand;
+use crate::snapshot::FunctionSnapshot;
+use serde::Serialize;
+
+/// One row per file. Column order here is the CSV column order.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct FileCsvRow {
+    pub file: String,
+    /// Risk axis: max `activity_risk.unwrap_or(lrs)` across the file's functions.
+    pub risk_score: f64,
+    /// Band of the file's highest-risk function.
+    pub band: String,
+    /// Quadrant of the file's highest-risk function (fire/debt/watch/ok), empty if unset.
+    pub quadrant: String,
+    /// Coupling axis: `directed_coupling`, empty if absent or zero (see `ranking::HotspotAxis`).
+    pub coupling: Option<f64>,
+    /// Ownership axis: `newcomer_rate`, empty if the file has no commits in the 90-day window.
+    pub ownership_newcomer_rate: Option<f64>,
+    pub function_count: usize,
+    pub critical_count: usize,
+    pub loc: u32,
+    /// Nearest manifest-root ancestor (e.g. "packages/next"), empty for repo root or unset.
+    pub subsystem: String,
+}
+
+/// Aggregate `functions` into one row per file, sorted by `risk_score` descending
+/// (ties broken by file path for determinism). Mirrors the file-level dedup logic
+/// in `ranking::rank_by_axis` (max risk score per file; `directed_coupling` and
+/// `newcomer_rate` are already file-level so any function's value represents the file).
+pub fn compute_file_csv_rows(functions: &[FunctionSnapshot]) -> Vec<FileCsvRow> {
+    use std::collections::HashMap;
+
+    struct Acc<'a> {
+        best_risk: f64,
+        best_band: &'a RiskBand,
+        best_quadrant: &'a Option<String>,
+        coupling: Option<f64>,
+        ownership_newcomer_rate: Option<f64>,
+        function_count: usize,
+        critical_count: usize,
+        loc: u32,
+        subsystem: &'a Option<String>,
+    }
+
+    let mut by_file: HashMap<&str, Acc> = HashMap::new();
+    for f in functions {
+        let risk = f.activity_risk.unwrap_or(f.lrs);
+        let entry = by_file.entry(f.file.as_str()).or_insert(Acc {
+            best_risk: f64::MIN,
+            best_band: &f.band,
+            best_quadrant: &f.quadrant,
+            coupling: f.directed_coupling.filter(|&dc| dc != 0.0),
+            ownership_newcomer_rate: f.newcomer_rate,
+            function_count: 0,
+            critical_count: 0,
+            loc: 0,
+            subsystem: &f.subsystem,
+        });
+        if risk > entry.best_risk {
+            entry.best_risk = risk;
+            entry.best_band = &f.band;
+            entry.best_quadrant = &f.quadrant;
+        }
+        entry.function_count += 1;
+        if matches!(f.band, RiskBand::Critical) {
+            entry.critical_count += 1;
+        }
+        entry.loc += f.metrics.loc;
+    }
+
+    let mut rows: Vec<FileCsvRow> = by_file
+        .into_iter()
+        .map(|(file, acc)| FileCsvRow {
+            file: file.to_string(),
+            risk_score: acc.best_risk,
+            band: acc.best_band.as_str().to_string(),
+            quadrant: acc.best_quadrant.clone().unwrap_or_default(),
+            coupling: acc.coupling,
+            ownership_newcomer_rate: acc.ownership_newcomer_rate,
+            function_count: acc.function_count,
+            critical_count: acc.critical_count,
+            loc: acc.loc,
+            subsystem: acc.subsystem.clone().unwrap_or_default(),
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        b.risk_score
+            .total_cmp(&a.risk_score)
+            .then_with(|| a.file.cmp(&b.file))
+    });
+    rows
+}
+
+/// Render `functions` as a CSV string, one row per file (see `compute_file_csv_rows`).
+pub fn render_csv(functions: &[FunctionSnapshot]) -> anyhow::Result<String> {
+    let rows = compute_file_csv_rows(functions);
+    let mut writer = csv::Writer::from_writer(vec![]);
+    for row in &rows {
+        writer.serialize(row)?;
+    }
+    let bytes = writer.into_inner()?;
+    Ok(String::from_utf8(bytes)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::Language;
+    use crate::report::MetricsReport;
+
+    fn fixture(file: &str, loc: u32, band: RiskBand) -> FunctionSnapshot {
+        FunctionSnapshot {
+            function_id: format!("{file}::f"),
+            file: file.to_string(),
+            line: 1,
+            language: Language::Rust,
+            metrics: MetricsReport {
+                cc: 1,
+                nd: 1,
+                fo: 1,
+                ns: 1,
+                loc,
+            },
+            lrs: 0.0,
+            band,
+            suppression_reason: None,
+            churn: None,
+            touch_count_30d: None,
+            days_since_last_change: None,
+            callgraph: None,
+            activity_risk: None,
+            risk_factors: None,
+            percentile: None,
+            driver: None,
+            driver_detail: None,
+            quadrant: None,
+            patterns: vec![],
+            pattern_details: None,
+            subsystem: None,
+            authors_90d: None,
+            directed_coupling: None,
+            jaccard_label_stability: None,
+            convention_bug_fix_count: None,
+            burst_score: None,
+            commit_count: None,
+            author_count: None,
+            author_entropy: None,
+            isolation_rate: None,
+            age_days: None,
+            last_touch_days: None,
+            newcomer_rate: None,
+            explanation: None,
+        }
+    }
+
+    #[test]
+    fn one_row_per_file_not_per_function() {
+        let functions = vec![
+            fixture("a.rs", 10, RiskBand::Low),
+            fixture("a.rs", 20, RiskBand::Low),
+            fixture("b.rs", 5, RiskBand::Low),
+        ];
+        let rows = compute_file_csv_rows(&functions);
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn risk_score_is_max_across_file_functions() {
+        let mut functions = vec![
+            fixture("a.rs", 10, RiskBand::Low),
+            fixture("a.rs", 10, RiskBand::Low),
+        ];
+        functions[0].activity_risk = Some(3.0);
+        functions[1].activity_risk = Some(7.0);
+        let rows = compute_file_csv_rows(&functions);
+        assert_eq!(rows[0].risk_score, 7.0);
+    }
+
+    #[test]
+    fn loc_and_function_count_sum_across_file() {
+        let functions = vec![
+            fixture("a.rs", 10, RiskBand::Low),
+            fixture("a.rs", 20, RiskBand::Low),
+        ];
+        let rows = compute_file_csv_rows(&functions);
+        assert_eq!(rows[0].function_count, 2);
+        assert_eq!(rows[0].loc, 30);
+    }
+
+    #[test]
+    fn critical_count_matches_band() {
+        let functions = vec![
+            fixture("a.rs", 10, RiskBand::Critical),
+            fixture("a.rs", 10, RiskBand::Low),
+            fixture("a.rs", 10, RiskBand::Critical),
+        ];
+        let rows = compute_file_csv_rows(&functions);
+        assert_eq!(rows[0].critical_count, 2);
+    }
+
+    #[test]
+    fn coupling_excludes_zero() {
+        let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
+        functions[0].directed_coupling = Some(0.0);
+        let rows = compute_file_csv_rows(&functions);
+        assert_eq!(rows[0].coupling, None);
+    }
+
+    #[test]
+    fn rows_sorted_by_risk_descending() {
+        let mut functions = vec![
+            fixture("a.rs", 10, RiskBand::Low),
+            fixture("b.rs", 10, RiskBand::Low),
+            fixture("c.rs", 10, RiskBand::Low),
+        ];
+        functions[0].activity_risk = Some(1.0);
+        functions[1].activity_risk = Some(5.0);
+        functions[2].activity_risk = Some(3.0);
+        let rows = compute_file_csv_rows(&functions);
+        let files: Vec<&str> = rows.iter().map(|r| r.file.as_str()).collect();
+        assert_eq!(files, vec!["b.rs", "c.rs", "a.rs"]);
+    }
+
+    #[test]
+    fn render_csv_produces_header_and_rows() {
+        let functions = vec![fixture("a.rs", 10, RiskBand::Low)];
+        let csv_str = render_csv(&functions).unwrap();
+        let mut lines = csv_str.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "file,risk_score,band,quadrant,coupling,ownership_newcomer_rate,function_count,critical_count,loc,subsystem"
+        );
+        assert!(lines.next().unwrap().starts_with("a.rs,"));
+    }
+}

--- a/hotspots-core/src/csv_report.rs
+++ b/hotspots-core/src/csv_report.rs
@@ -13,10 +13,19 @@
 use crate::risk::RiskBand;
 use crate::snapshot::FunctionSnapshot;
 use serde::Serialize;
+use std::path::Path;
+
+/// Sentinel written for `coupling`/`ownership_newcomer_rate` when a file has no
+/// defined value (excluded per `ranking::HotspotAxis`, not a measured zero) —
+/// an explicit label reads as "no data for this file" in a spreadsheet, where a
+/// truly blank cell reads as "something's broken."
+const NO_AXIS_DATA: &str = "n/a";
 
 /// One row per file. Column order here is the CSV column order.
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct FileCsvRow {
+    /// Repo-relative path (e.g. "hotspots-core/src/snapshot.rs"), not absolute —
+    /// an absolute path is machine-specific noise in a shared spreadsheet.
     pub file: String,
     /// Risk axis: max `activity_risk.unwrap_or(lrs)` across the file's functions.
     pub risk_score: f64,
@@ -24,10 +33,13 @@ pub struct FileCsvRow {
     pub band: String,
     /// Quadrant of the file's highest-risk function (fire/debt/watch/ok), empty if unset.
     pub quadrant: String,
-    /// Coupling axis: `directed_coupling`, empty if absent or zero (see `ranking::HotspotAxis`).
-    pub coupling: Option<f64>,
-    /// Ownership axis: `newcomer_rate`, empty if the file has no commits in the 90-day window.
-    pub ownership_newcomer_rate: Option<f64>,
+    /// Coupling axis: `directed_coupling` rounded to 2dp, or `"n/a"` if absent/zero
+    /// (see `ranking::HotspotAxis`) — never a blank cell.
+    pub coupling: String,
+    /// Ownership axis: `newcomer_rate` rounded to 2dp, or `"n/a"` if the file has no
+    /// commits in the 90-day window — never a blank cell, and never confused with a
+    /// real `0.00` (a file with window commits and zero newcomers).
+    pub ownership_newcomer_rate: String,
     pub function_count: usize,
     pub critical_count: usize,
     pub loc: u32,
@@ -35,11 +47,27 @@ pub struct FileCsvRow {
     pub subsystem: String,
 }
 
+fn fmt_axis_value(v: Option<f64>) -> String {
+    match v {
+        Some(x) => format!("{x:.2}"),
+        None => NO_AXIS_DATA.to_string(),
+    }
+}
+
+/// Repo-relative path with `/` separators, falling back to the original string
+/// (also `/`-normalized) if it isn't under `repo_root`.
+fn relativize(file: &str, repo_root: &Path) -> String {
+    Path::new(file)
+        .strip_prefix(repo_root)
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|_| file.replace('\\', "/"))
+}
+
 /// Aggregate `functions` into one row per file, sorted by `risk_score` descending
 /// (ties broken by file path for determinism). Mirrors the file-level dedup logic
 /// in `ranking::rank_by_axis` (max risk score per file; `directed_coupling` and
 /// `newcomer_rate` are already file-level so any function's value represents the file).
-pub fn compute_file_csv_rows(functions: &[FunctionSnapshot]) -> Vec<FileCsvRow> {
+pub fn compute_file_csv_rows(functions: &[FunctionSnapshot], repo_root: &Path) -> Vec<FileCsvRow> {
     use std::collections::HashMap;
 
     struct Acc<'a> {
@@ -83,12 +111,12 @@ pub fn compute_file_csv_rows(functions: &[FunctionSnapshot]) -> Vec<FileCsvRow> 
     let mut rows: Vec<FileCsvRow> = by_file
         .into_iter()
         .map(|(file, acc)| FileCsvRow {
-            file: file.to_string(),
+            file: relativize(file, repo_root),
             risk_score: acc.best_risk,
             band: acc.best_band.as_str().to_string(),
             quadrant: acc.best_quadrant.clone().unwrap_or_default(),
-            coupling: acc.coupling,
-            ownership_newcomer_rate: acc.ownership_newcomer_rate,
+            coupling: fmt_axis_value(acc.coupling),
+            ownership_newcomer_rate: fmt_axis_value(acc.ownership_newcomer_rate),
             function_count: acc.function_count,
             critical_count: acc.critical_count,
             loc: acc.loc,
@@ -105,8 +133,8 @@ pub fn compute_file_csv_rows(functions: &[FunctionSnapshot]) -> Vec<FileCsvRow> 
 }
 
 /// Render `functions` as a CSV string, one row per file (see `compute_file_csv_rows`).
-pub fn render_csv(functions: &[FunctionSnapshot]) -> anyhow::Result<String> {
-    let rows = compute_file_csv_rows(functions);
+pub fn render_csv(functions: &[FunctionSnapshot], repo_root: &Path) -> anyhow::Result<String> {
+    let rows = compute_file_csv_rows(functions, repo_root);
     let mut writer = csv::Writer::from_writer(vec![]);
     for row in &rows {
         writer.serialize(row)?;
@@ -166,6 +194,10 @@ mod tests {
         }
     }
 
+    fn root() -> std::path::PathBuf {
+        std::path::PathBuf::from("/repo")
+    }
+
     #[test]
     fn one_row_per_file_not_per_function() {
         let functions = vec![
@@ -173,7 +205,7 @@ mod tests {
             fixture("a.rs", 20, RiskBand::Low),
             fixture("b.rs", 5, RiskBand::Low),
         ];
-        let rows = compute_file_csv_rows(&functions);
+        let rows = compute_file_csv_rows(&functions, &root());
         assert_eq!(rows.len(), 2);
     }
 
@@ -185,7 +217,7 @@ mod tests {
         ];
         functions[0].activity_risk = Some(3.0);
         functions[1].activity_risk = Some(7.0);
-        let rows = compute_file_csv_rows(&functions);
+        let rows = compute_file_csv_rows(&functions, &root());
         assert_eq!(rows[0].risk_score, 7.0);
     }
 
@@ -195,7 +227,7 @@ mod tests {
             fixture("a.rs", 10, RiskBand::Low),
             fixture("a.rs", 20, RiskBand::Low),
         ];
-        let rows = compute_file_csv_rows(&functions);
+        let rows = compute_file_csv_rows(&functions, &root());
         assert_eq!(rows[0].function_count, 2);
         assert_eq!(rows[0].loc, 30);
     }
@@ -207,7 +239,7 @@ mod tests {
             fixture("a.rs", 10, RiskBand::Low),
             fixture("a.rs", 10, RiskBand::Critical),
         ];
-        let rows = compute_file_csv_rows(&functions);
+        let rows = compute_file_csv_rows(&functions, &root());
         assert_eq!(rows[0].critical_count, 2);
     }
 
@@ -215,8 +247,46 @@ mod tests {
     fn coupling_excludes_zero() {
         let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
         functions[0].directed_coupling = Some(0.0);
-        let rows = compute_file_csv_rows(&functions);
-        assert_eq!(rows[0].coupling, None);
+        let rows = compute_file_csv_rows(&functions, &root());
+        assert_eq!(rows[0].coupling, "n/a");
+    }
+
+    #[test]
+    fn coupling_present_is_rounded_not_blank() {
+        let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
+        functions[0].directed_coupling = Some(12.3456);
+        let rows = compute_file_csv_rows(&functions, &root());
+        assert_eq!(rows[0].coupling, "12.35");
+    }
+
+    #[test]
+    fn ownership_none_is_labeled_not_blank_and_not_zero() {
+        let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
+        functions[0].newcomer_rate = None;
+        let rows = compute_file_csv_rows(&functions, &root());
+        assert_eq!(rows[0].ownership_newcomer_rate, "n/a");
+    }
+
+    #[test]
+    fn ownership_real_zero_is_distinct_from_no_data() {
+        let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
+        functions[0].newcomer_rate = Some(0.0);
+        let rows = compute_file_csv_rows(&functions, &root());
+        assert_eq!(rows[0].ownership_newcomer_rate, "0.00");
+    }
+
+    #[test]
+    fn file_path_is_relativized_to_repo_root() {
+        let functions = vec![fixture("/repo/src/a.rs", 10, RiskBand::Low)];
+        let rows = compute_file_csv_rows(&functions, &root());
+        assert_eq!(rows[0].file, "src/a.rs");
+    }
+
+    #[test]
+    fn file_path_outside_repo_root_falls_back_unchanged() {
+        let functions = vec![fixture("/other/a.rs", 10, RiskBand::Low)];
+        let rows = compute_file_csv_rows(&functions, &root());
+        assert_eq!(rows[0].file, "/other/a.rs");
     }
 
     #[test]
@@ -229,7 +299,7 @@ mod tests {
         functions[0].activity_risk = Some(1.0);
         functions[1].activity_risk = Some(5.0);
         functions[2].activity_risk = Some(3.0);
-        let rows = compute_file_csv_rows(&functions);
+        let rows = compute_file_csv_rows(&functions, &root());
         let files: Vec<&str> = rows.iter().map(|r| r.file.as_str()).collect();
         assert_eq!(files, vec!["b.rs", "c.rs", "a.rs"]);
     }
@@ -237,7 +307,7 @@ mod tests {
     #[test]
     fn render_csv_produces_header_and_rows() {
         let functions = vec![fixture("a.rs", 10, RiskBand::Low)];
-        let csv_str = render_csv(&functions).unwrap();
+        let csv_str = render_csv(&functions, &root()).unwrap();
         let mut lines = csv_str.lines();
         assert_eq!(
             lines.next().unwrap(),

--- a/hotspots-core/src/csv_report.rs
+++ b/hotspots-core/src/csv_report.rs
@@ -3,12 +3,19 @@
 //! Audience: a tech lead or EM doing triage, ownership handoff, or sprint
 //! planning in a spreadsheet — not a raw per-function data dump (that's
 //! `--format json --all-functions`) and not an in-IDE fix workflow (that's
-//! the text/HTML outputs). Rows are one per file, with the three F05 axes
-//! (Risk/Coupling/Ownership) as sortable/filterable columns side by side,
-//! plus enough context (band, quadrant, function/critical counts, subsystem)
-//! to triage without opening the tool again. Always the full file list,
-//! ignoring `--top` — a spreadsheet is for sorting/filtering everything,
-//! not a truncated view.
+//! the text/HTML outputs). Rows are one per file, plus enough context (band,
+//! quadrant, function/critical counts, subsystem) to triage without opening
+//! the tool again. Always the full file list, ignoring `--top` — a
+//! spreadsheet is for sorting/filtering everything, not a truncated view.
+//!
+//! Coupling lives in a **separate** output (`render_coupling_csv`), not the
+//! main table: on a real repo only ~20% of files have any `directed_coupling`
+//! relationship at all (most files never co-change with another file above
+//! the minimum count threshold), so folding it into the main table means most
+//! rows read "n/a" on that column — a dedicated sheet where every row has a
+//! real value is more useful than diluting the main table with mostly-empty
+//! cells. Ownership (`newcomer_rate`) stays in the main table since it's
+//! populated for a majority of files, not a small minority.
 
 use crate::risk::RiskBand;
 use crate::snapshot::FunctionSnapshot;
@@ -33,9 +40,14 @@ pub struct FileCsvRow {
     pub band: String,
     /// Quadrant of the file's highest-risk function (fire/debt/watch/ok), empty if unset.
     pub quadrant: String,
-    /// Coupling axis: `directed_coupling` rounded to 2dp, or `"n/a"` if absent/zero
-    /// (see `ranking::HotspotAxis`) — never a blank cell.
-    pub coupling: String,
+    /// Symbol name of the function that earned `risk_score` (the file's max, not an
+    /// average) — per hotspots-research F110/F111/F112, file-level rollup can hide or
+    /// invert the real signal, which lives at function granularity. Carrying the
+    /// function forward means a row is still actionable without re-deriving which
+    /// function the tool already identified as the actual driver.
+    pub top_function: String,
+    /// Line number of `top_function`, for jumping straight to it.
+    pub top_function_line: u32,
     /// Ownership axis: `newcomer_rate` rounded to 2dp, or `"n/a"` if the file has no
     /// commits in the 90-day window — never a blank cell, and never confused with a
     /// real `0.00` (a file with window commits and zero newcomers).
@@ -54,6 +66,14 @@ fn fmt_axis_value(v: Option<f64>) -> String {
     }
 }
 
+/// Extract the symbol name from a `function_id` of the form `<file>::<symbol>`.
+/// Falls back to the full `function_id` if the separator isn't found.
+fn function_symbol(function_id: &str) -> &str {
+    function_id
+        .rsplit_once("::")
+        .map_or(function_id, |(_, s)| s)
+}
+
 /// Repo-relative path with `/` separators, falling back to the original string
 /// (also `/`-normalized) if it isn't under `repo_root`.
 fn relativize(file: &str, repo_root: &Path) -> String {
@@ -65,8 +85,8 @@ fn relativize(file: &str, repo_root: &Path) -> String {
 
 /// Aggregate `functions` into one row per file, sorted by `risk_score` descending
 /// (ties broken by file path for determinism). Mirrors the file-level dedup logic
-/// in `ranking::rank_by_axis` (max risk score per file; `directed_coupling` and
-/// `newcomer_rate` are already file-level so any function's value represents the file).
+/// in `ranking::rank_by_axis` (max risk score per file; `newcomer_rate` is already
+/// file-level so any function's value represents the file).
 pub fn compute_file_csv_rows(functions: &[FunctionSnapshot], repo_root: &Path) -> Vec<FileCsvRow> {
     use std::collections::HashMap;
 
@@ -74,7 +94,8 @@ pub fn compute_file_csv_rows(functions: &[FunctionSnapshot], repo_root: &Path) -
         best_risk: f64,
         best_band: &'a RiskBand,
         best_quadrant: &'a Option<String>,
-        coupling: Option<f64>,
+        best_function_id: &'a str,
+        best_line: u32,
         ownership_newcomer_rate: Option<f64>,
         function_count: usize,
         critical_count: usize,
@@ -89,7 +110,8 @@ pub fn compute_file_csv_rows(functions: &[FunctionSnapshot], repo_root: &Path) -
             best_risk: f64::MIN,
             best_band: &f.band,
             best_quadrant: &f.quadrant,
-            coupling: f.directed_coupling.filter(|&dc| dc != 0.0),
+            best_function_id: f.function_id.as_str(),
+            best_line: f.line,
             ownership_newcomer_rate: f.newcomer_rate,
             function_count: 0,
             critical_count: 0,
@@ -100,6 +122,8 @@ pub fn compute_file_csv_rows(functions: &[FunctionSnapshot], repo_root: &Path) -
             entry.best_risk = risk;
             entry.best_band = &f.band;
             entry.best_quadrant = &f.quadrant;
+            entry.best_function_id = f.function_id.as_str();
+            entry.best_line = f.line;
         }
         entry.function_count += 1;
         if matches!(f.band, RiskBand::Critical) {
@@ -115,7 +139,8 @@ pub fn compute_file_csv_rows(functions: &[FunctionSnapshot], repo_root: &Path) -
             risk_score: acc.best_risk,
             band: acc.best_band.as_str().to_string(),
             quadrant: acc.best_quadrant.clone().unwrap_or_default(),
-            coupling: fmt_axis_value(acc.coupling),
+            top_function: function_symbol(acc.best_function_id).to_string(),
+            top_function_line: acc.best_line,
             ownership_newcomer_rate: fmt_axis_value(acc.ownership_newcomer_rate),
             function_count: acc.function_count,
             critical_count: acc.critical_count,
@@ -135,6 +160,62 @@ pub fn compute_file_csv_rows(functions: &[FunctionSnapshot], repo_root: &Path) -
 /// Render `functions` as a CSV string, one row per file (see `compute_file_csv_rows`).
 pub fn render_csv(functions: &[FunctionSnapshot], repo_root: &Path) -> anyhow::Result<String> {
     let rows = compute_file_csv_rows(functions, repo_root);
+    let mut writer = csv::Writer::from_writer(vec![]);
+    for row in &rows {
+        writer.serialize(row)?;
+    }
+    let bytes = writer.into_inner()?;
+    Ok(String::from_utf8(bytes)?)
+}
+
+/// One row per file with a coupling relationship. Column order is the CSV column order.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct CouplingCsvRow {
+    pub file: String,
+    /// `directed_coupling`, rounded to 2dp. Every row here has a real value —
+    /// files with none are excluded entirely, not represented as `"n/a"" rows
+    /// (see module docs for why coupling gets its own output).
+    pub coupling: f64,
+}
+
+/// Files with a defined (non-zero) `directed_coupling`, sorted descending.
+/// Excludes files with none at all — this output's whole purpose is to be a
+/// place where every row is real, unlike a "n/a"-heavy column in the main table.
+pub fn compute_coupling_csv_rows(
+    functions: &[FunctionSnapshot],
+    repo_root: &Path,
+) -> Vec<CouplingCsvRow> {
+    use std::collections::HashMap;
+
+    let mut by_file: HashMap<&str, f64> = HashMap::new();
+    for f in functions {
+        if let Some(dc) = f.directed_coupling.filter(|&dc| dc != 0.0) {
+            by_file.entry(f.file.as_str()).or_insert(dc);
+        }
+    }
+
+    let mut rows: Vec<CouplingCsvRow> = by_file
+        .into_iter()
+        .map(|(file, coupling)| CouplingCsvRow {
+            file: relativize(file, repo_root),
+            coupling: (coupling * 100.0).round() / 100.0,
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        b.coupling
+            .total_cmp(&a.coupling)
+            .then_with(|| a.file.cmp(&b.file))
+    });
+    rows
+}
+
+/// Render the coupling-only CSV (see `compute_coupling_csv_rows`).
+pub fn render_coupling_csv(
+    functions: &[FunctionSnapshot],
+    repo_root: &Path,
+) -> anyhow::Result<String> {
+    let rows = compute_coupling_csv_rows(functions, repo_root);
     let mut writer = csv::Writer::from_writer(vec![]);
     for row in &rows {
         writer.serialize(row)?;
@@ -244,19 +325,59 @@ mod tests {
     }
 
     #[test]
-    fn coupling_excludes_zero() {
-        let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
-        functions[0].directed_coupling = Some(0.0);
+    fn top_function_is_the_symbol_from_the_highest_risk_function() {
+        let mut functions = vec![
+            fixture("a.rs", 10, RiskBand::Low),
+            fixture("a.rs", 10, RiskBand::Low),
+        ];
+        functions[0].function_id = "a.rs::low_risk_fn".to_string();
+        functions[0].activity_risk = Some(1.0);
+        functions[0].line = 5;
+        functions[1].function_id = "a.rs::high_risk_fn".to_string();
+        functions[1].activity_risk = Some(9.0);
+        functions[1].line = 42;
         let rows = compute_file_csv_rows(&functions, &root());
-        assert_eq!(rows[0].coupling, "n/a");
+        assert_eq!(rows[0].top_function, "high_risk_fn");
+        assert_eq!(rows[0].top_function_line, 42);
     }
 
     #[test]
-    fn coupling_present_is_rounded_not_blank() {
+    fn coupling_excludes_zero_from_coupling_csv() {
+        let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
+        functions[0].directed_coupling = Some(0.0);
+        let rows = compute_coupling_csv_rows(&functions, &root());
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn coupling_present_is_rounded_in_coupling_csv() {
         let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
         functions[0].directed_coupling = Some(12.3456);
-        let rows = compute_file_csv_rows(&functions, &root());
-        assert_eq!(rows[0].coupling, "12.35");
+        let rows = compute_coupling_csv_rows(&functions, &root());
+        assert_eq!(rows[0].coupling, 12.35);
+    }
+
+    #[test]
+    fn coupling_csv_sorted_descending() {
+        let mut functions = vec![
+            fixture("a.rs", 10, RiskBand::Low),
+            fixture("b.rs", 10, RiskBand::Low),
+        ];
+        functions[0].directed_coupling = Some(5.0);
+        functions[1].directed_coupling = Some(10.0);
+        let rows = compute_coupling_csv_rows(&functions, &root());
+        let files: Vec<&str> = rows.iter().map(|r| r.file.as_str()).collect();
+        assert_eq!(files, vec!["b.rs", "a.rs"]);
+    }
+
+    #[test]
+    fn render_coupling_csv_produces_header_and_rows() {
+        let mut functions = vec![fixture("a.rs", 10, RiskBand::Low)];
+        functions[0].directed_coupling = Some(3.5);
+        let csv_str = render_coupling_csv(&functions, &root()).unwrap();
+        let mut lines = csv_str.lines();
+        assert_eq!(lines.next().unwrap(), "file,coupling");
+        assert_eq!(lines.next().unwrap(), "a.rs,3.5");
     }
 
     #[test]
@@ -311,7 +432,7 @@ mod tests {
         let mut lines = csv_str.lines();
         assert_eq!(
             lines.next().unwrap(),
-            "file,risk_score,band,quadrant,coupling,ownership_newcomer_rate,function_count,critical_count,loc,subsystem"
+            "file,risk_score,band,quadrant,top_function,top_function_line,ownership_newcomer_rate,function_count,critical_count,loc,subsystem"
         );
         assert!(lines.next().unwrap().starts_with("a.rs,"));
     }

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod cfg;
 pub mod compact;
 pub mod config;
 pub mod coupling;
+pub mod csv_report;
 pub mod db;
 pub mod delta;
 pub mod discover;

--- a/hotspots-core/src/lib.rs
+++ b/hotspots-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod suppression;
 pub mod touch_cache;
 pub mod trainer;
 pub mod trends;
+pub mod xlsx_report;
 
 pub use callgraph::CallGraph;
 pub use config::ResolvedConfig;

--- a/hotspots-core/src/xlsx_report.rs
+++ b/hotspots-core/src/xlsx_report.rs
@@ -1,0 +1,202 @@
+//! XLSX (spreadsheet) report — a real multi-sheet workbook for triage/planning.
+//!
+//! Reuses `csv_report`'s row computation (`compute_file_csv_rows`,
+//! `compute_coupling_csv_rows`) — only the writer differs. Exists because CSV
+//! has no notion of multiple tables in one file: coupling has a real value for
+//! only a minority of files on a typical repo (see `csv_report` module docs),
+//! so it needs a home that isn't the main table and isn't a second loose file
+//! next to it. A real workbook is the only format that gives one physical
+//! file with the tables kept separate, plus room for formatting (frozen
+//! header, autofilter, a color scale on risk) that a plain CSV can't carry.
+
+use crate::csv_report::{compute_coupling_csv_rows, compute_file_csv_rows};
+use crate::snapshot::FunctionSnapshot;
+use rust_xlsxwriter::{Color, ConditionalFormat3ColorScale, Format, Workbook};
+use std::path::Path;
+
+const FILES_SHEET: &str = "Files";
+const COUPLING_SHEET: &str = "Coupling";
+
+/// Render `functions` as an XLSX workbook with two sheets — "Files" (the main
+/// triage table) and "Coupling" (files with a real `directed_coupling` value
+/// only) — returning the file's raw bytes for the caller to write to disk.
+pub fn render_xlsx(functions: &[FunctionSnapshot], repo_root: &Path) -> anyhow::Result<Vec<u8>> {
+    let mut workbook = Workbook::new();
+    let header_format = Format::new().set_bold();
+
+    write_files_sheet(&mut workbook, functions, repo_root, &header_format)?;
+    write_coupling_sheet(&mut workbook, functions, repo_root, &header_format)?;
+
+    Ok(workbook.save_to_buffer()?)
+}
+
+fn write_files_sheet(
+    workbook: &mut Workbook,
+    functions: &[FunctionSnapshot],
+    repo_root: &Path,
+    header_format: &Format,
+) -> anyhow::Result<()> {
+    let rows = compute_file_csv_rows(functions, repo_root);
+    let sheet = workbook.add_worksheet();
+    sheet.set_name(FILES_SHEET)?;
+
+    let headers = [
+        "file",
+        "risk_score",
+        "band",
+        "quadrant",
+        "top_function",
+        "top_function_line",
+        "ownership_newcomer_rate",
+        "function_count",
+        "critical_count",
+        "loc",
+        "subsystem",
+    ];
+    for (col, name) in headers.iter().enumerate() {
+        sheet.write_with_format(0, col as u16, *name, header_format)?;
+    }
+
+    for (i, row) in rows.iter().enumerate() {
+        let r = (i + 1) as u32;
+        sheet.write(r, 0, row.file.as_str())?;
+        sheet.write(r, 1, row.risk_score)?;
+        sheet.write(r, 2, row.band.as_str())?;
+        sheet.write(r, 3, row.quadrant.as_str())?;
+        sheet.write(r, 4, row.top_function.as_str())?;
+        sheet.write(r, 5, row.top_function_line)?;
+        sheet.write(r, 6, row.ownership_newcomer_rate.as_str())?;
+        sheet.write(r, 7, row.function_count as u32)?;
+        sheet.write(r, 8, row.critical_count as u32)?;
+        sheet.write(r, 9, row.loc)?;
+        sheet.write(r, 10, row.subsystem.as_str())?;
+    }
+
+    let last_row = rows.len() as u32;
+    let last_col = (headers.len() - 1) as u16;
+    if last_row > 0 {
+        sheet.autofilter(0, 0, last_row, last_col)?;
+
+        // Risk axis color scale: low = green (safe), high = red (bad) — the
+        // library's default 3-color scale runs the other way, so min/max are
+        // swapped here.
+        let risk_scale = ConditionalFormat3ColorScale::new()
+            .set_minimum_color(Color::RGB(0x63BE7B))
+            .set_midpoint_color(Color::RGB(0xFFEB84))
+            .set_maximum_color(Color::RGB(0xF8696B));
+        sheet.add_conditional_format(1, 1, last_row, 1, &risk_scale)?;
+    }
+    sheet.set_freeze_panes(1, 0)?;
+
+    sheet.set_column_width(0, 45)?;
+    sheet.set_column_width(4, 28)?;
+    sheet.set_column_width(10, 18)?;
+
+    Ok(())
+}
+
+fn write_coupling_sheet(
+    workbook: &mut Workbook,
+    functions: &[FunctionSnapshot],
+    repo_root: &Path,
+    header_format: &Format,
+) -> anyhow::Result<()> {
+    let rows = compute_coupling_csv_rows(functions, repo_root);
+    let sheet = workbook.add_worksheet();
+    sheet.set_name(COUPLING_SHEET)?;
+
+    sheet.write_with_format(0, 0, "file", header_format)?;
+    sheet.write_with_format(0, 1, "coupling", header_format)?;
+
+    for (i, row) in rows.iter().enumerate() {
+        let r = (i + 1) as u32;
+        sheet.write(r, 0, row.file.as_str())?;
+        sheet.write(r, 1, row.coupling)?;
+    }
+
+    let last_row = rows.len() as u32;
+    if last_row > 0 {
+        sheet.autofilter(0, 0, last_row, 1)?;
+    }
+    sheet.set_freeze_panes(1, 0)?;
+    sheet.set_column_width(0, 45)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::Language;
+    use crate::report::MetricsReport;
+    use crate::risk::RiskBand;
+
+    fn fixture(file: &str) -> FunctionSnapshot {
+        FunctionSnapshot {
+            function_id: format!("{file}::f"),
+            file: file.to_string(),
+            line: 1,
+            language: Language::Rust,
+            metrics: MetricsReport {
+                cc: 1,
+                nd: 1,
+                fo: 1,
+                ns: 1,
+                loc: 10,
+            },
+            lrs: 0.0,
+            band: RiskBand::Low,
+            suppression_reason: None,
+            churn: None,
+            touch_count_30d: None,
+            days_since_last_change: None,
+            callgraph: None,
+            activity_risk: None,
+            risk_factors: None,
+            percentile: None,
+            driver: None,
+            driver_detail: None,
+            quadrant: None,
+            patterns: vec![],
+            pattern_details: None,
+            subsystem: None,
+            authors_90d: None,
+            directed_coupling: None,
+            jaccard_label_stability: None,
+            convention_bug_fix_count: None,
+            burst_score: None,
+            commit_count: None,
+            author_count: None,
+            author_entropy: None,
+            isolation_rate: None,
+            age_days: None,
+            last_touch_days: None,
+            newcomer_rate: None,
+            explanation: None,
+        }
+    }
+
+    #[test]
+    fn render_xlsx_produces_nonempty_valid_zip() {
+        let functions = vec![fixture("a.rs")];
+        let bytes = render_xlsx(&functions, Path::new("/repo")).unwrap();
+        // XLSX is a zip archive; verify the local file header magic bytes.
+        assert!(bytes.len() > 100);
+        assert_eq!(&bytes[0..2], b"PK");
+    }
+
+    #[test]
+    fn render_xlsx_handles_empty_input() {
+        let bytes = render_xlsx(&[], Path::new("/repo")).unwrap();
+        assert_eq!(&bytes[0..2], b"PK");
+    }
+
+    #[test]
+    fn render_xlsx_includes_coupling_data() {
+        let mut functions = vec![fixture("a.rs"), fixture("b.rs")];
+        functions[0].directed_coupling = Some(5.5);
+        // Just verify it doesn't error with coupling data present.
+        let bytes = render_xlsx(&functions, Path::new("/repo")).unwrap();
+        assert_eq!(&bytes[0..2], b"PK");
+    }
+}


### PR DESCRIPTION
## Summary
Rescues real, complete work found sitting unmerged on `origin/feat/csv-output` (4 commits, dated 2026-09-04/05, pushed but never had a PR opened) — rebased onto current `main` (was 46 commits behind), verified, and documented.

Adds `hotspots analyze --mode snapshot --format csv` and `--format xlsx`: a file-level triage/planning view for spreadsheet workflows (tech lead/EM doing triage, ownership handoff, sprint planning) — distinct from the raw per-function dump (`--format json --all-functions`) and the in-IDE text/HTML outputs.

## What it does
- One row per file: risk band, quadrant, the file's highest-risk function + line (file-level rollup can hide/invert the real signal per hotspots-research F110/F111/F112, so the driving function is carried forward explicitly), ownership `newcomer_rate`, function/critical counts, LOC, subsystem.
- Always the full file list — ignores `--top`, since a spreadsheet is for sorting/filtering everything.
- `--format xlsx` is a real multi-sheet workbook: "Files" (main table) + "Coupling" (files with a real `directed_coupling` value only — most files have none, so it's a separate sheet rather than a mostly-empty column). `--format csv` is single-file/single-table (CSV has no notion of multiple tables), so coupling isn't included there — use xlsx for that.
- Missing axis values (excluded, not a measured zero) are written as the literal `n/a`, never a blank cell.

## Verification (this session)
- Rebased cleanly onto current `main` (v1.37.0), no conflicts.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` both clean.
- `cargo test --workspace`: 540 passed (18 new tests in `csv_report.rs`/`xlsx_report.rs`).
- Manual smoke test: both `--format csv` and `--format xlsx` produce correct, valid output against this repo itself (`file /tmp/hs-snap.xlsx` confirms a real `Microsoft Excel 2007+` file).
- Added `docs/REFERENCE.md` documentation, which was missing (new commit in this PR, everything else is the original 4 commits unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)